### PR TITLE
Fix cosmetic suit/helmet clear not persisting; fix wrong default skin…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 
 SOURCE_FILES= \
+			  $(SRC_DIR)/Utils/SehStub/SehStub.cpp \
 			  $(SRC_DIR)/Config/Config.cpp \
 			  \
 			  $(SRC_DIR)/Utils/Logger/Logger/FileLogger.cpp \
@@ -432,6 +433,7 @@ SOURCE_FILES= \
 #   $(SRC_DIR)/Database/SocketCycle/SocketCycle.cpp
 
 SOURCE_FILES_CLIENT= \
+			  $(SRC_DIR)/Utils/SehStub/SehStub.cpp \
 			  $(SRC_DIR)/Utils/Logger/Logger/FileLogger.cpp \
 			  $(SRC_DIR)/Utils/DebugWindow/DebugWindow.cpp \
 			  $(SRC_DIR)/GameServer/Utils/ObjectCache/ObjectCache.cpp \
@@ -460,6 +462,13 @@ SOURCE_FILES_CLIENT= \
 # MAKEFLAGS += -j$(JOBS)
 MAKEFLAGS += -j4
 CC=i686-w64-mingw32-g++
+# Restored the blanket `-static` (2026-06-19): dropping it to dodge the
+# __mingw_SEH_error_handler link error (see SehStub.cpp) broke DLL injection
+# instead — without -static, -pthread's libwinpthread resolves dynamically,
+# and a dynamically-loaded runtime DLL with its own TLS/init callbacks hangs
+# silently when loaded via injection rather than normal process startup
+# (every instance log came up empty, no crash dump — a hang, not a crash).
+# -static keeps everything, including winpthread, embedded in the DLL itself.
 CFLAGS=-std=c++17 -pthread -I. -I./lib/detours -I./lib/asio-1.34.2/include -I./lib/sqlite3 -L/usr/i686-w64-mingw32/lib -shared -static -static-libgcc -static-libstdc++ -fpermissive -s -w
 # Header-dependency tracking: -MMD writes a .d file next to every .o listing
 # every user header that TU included, as a makefile rule.  -MP adds phony rules

--- a/src/ControlServer/PlayerSessionStore/PlayerSessionStore.cpp
+++ b/src/ControlServer/PlayerSessionStore/PlayerSessionStore.cpp
@@ -1561,7 +1561,8 @@ bool PlayerSessionStore::SaveEquippedDevices(int64_t character_id, int64_t user_
                                               uint32_t profile_id,
                                               int item_profile_id,
                                               const std::map<int, int>& slot_to_inventory,
-                                              const std::map<int, int>& misc_items) {
+                                              const std::map<int, int>& misc_items,
+                                              const std::set<int>& cleared_cosmetic_slots) {
 	if (item_profile_id < 1 || item_profile_id > 5) {
 		Logger::Log("armor",
 			"[Save] REJECT char=%lld: item_profile_id=%d out of range [1..5]\n",
@@ -1711,7 +1712,14 @@ bool PlayerSessionStore::SaveEquippedDevices(int64_t character_id, int64_t user_
 		sqlite3_bind_int64(del, 1, character_id);
 		sqlite3_bind_int  (del, 2, item_profile_id);
 		sqlite3_bind_int  (del, 3, db_slot);
-		sqlite3_step(del);
+		if (sqlite3_step(del) != SQLITE_DONE) {
+			Logger::Log("armor",
+				"[Save] DELETE FAILED char=%lld itemProf=%d dbSlot=%d engineSlot=%d: %s\n",
+				character_id, item_profile_id, db_slot, engine_slot, sqlite3_errmsg(db));
+			sqlite3_finalize(del);
+			sqlite3_exec(db, "ROLLBACK", nullptr, nullptr, &err);
+			return false;
+		}
 	}
 	sqlite3_finalize(del);
 
@@ -1741,7 +1749,14 @@ bool PlayerSessionStore::SaveEquippedDevices(int64_t character_id, int64_t user_
 		sqlite3_bind_int  (ins, 2, item_profile_id);
 		sqlite3_bind_int  (ins, 3, inv_id);
 		sqlite3_bind_int  (ins, 4, db_slot);
-		sqlite3_step(ins);
+		if (sqlite3_step(ins) != SQLITE_DONE) {
+			Logger::Log("armor",
+				"[Save] INSERT FAILED char=%lld itemProf=%d dbSlot=%d engineSlot=%d invId=%d: %s\n",
+				character_id, item_profile_id, db_slot, engine_slot, inv_id, sqlite3_errmsg(db));
+			sqlite3_finalize(ins);
+			sqlite3_exec(db, "ROLLBACK", nullptr, nullptr, &err);
+			return false;
+		}
 	}
 	sqlite3_finalize(ins);
 
@@ -1803,6 +1818,40 @@ bool PlayerSessionStore::SaveEquippedDevices(int64_t character_id, int64_t user_
 				}
 			}
 			sqlite3_finalize(insArmor);
+		}
+	}
+
+	// Cosmetic suit/helmet clear. `cleared_cosmetic_slots` carries engine
+	// slots (6/12) the client explicitly blanked (SlotIndices[slot]==0) —
+	// see CosmeticSlots.hpp for the engine→DB remap rationale. Independent
+	// of slot_to_inventory since there's no inventory row to validate when
+	// clearing.
+	if (!cleared_cosmetic_slots.empty()) {
+		sqlite3_stmt* delCosmetic = nullptr;
+		if (sqlite3_prepare_v2(db,
+		    "DELETE FROM ga_character_devices "
+		    "WHERE character_id = ? AND item_profile_id = ? AND equipped_slot = ?",
+		    -1, &delCosmetic, nullptr) == SQLITE_OK) {
+			for (int engine_slot : cleared_cosmetic_slots) {
+				const int db_slot = (engine_slot == 6)  ? CosmeticSlots::kCosmeticSuitDbSlot
+				                  : (engine_slot == 12) ? CosmeticSlots::kCosmeticHelmetDbSlot
+				                                         : engine_slot;
+				sqlite3_reset(delCosmetic);
+				sqlite3_clear_bindings(delCosmetic);
+				sqlite3_bind_int64(delCosmetic, 1, character_id);
+				sqlite3_bind_int  (delCosmetic, 2, item_profile_id);
+				sqlite3_bind_int  (delCosmetic, 3, db_slot);
+				if (sqlite3_step(delCosmetic) != SQLITE_DONE) {
+					Logger::Log("armor",
+						"[Save] cosmetic clear FAILED char=%lld engineSlot=%d dbSlot=%d: %s\n",
+						character_id, engine_slot, db_slot, sqlite3_errmsg(db));
+				} else {
+					Logger::Log("armor",
+						"[Save] cosmetic clear: engineSlot=%d dbSlot=%d cleared\n",
+						engine_slot, db_slot);
+				}
+			}
+			sqlite3_finalize(delCosmetic);
 		}
 	}
 

--- a/src/ControlServer/PlayerSessionStore/PlayerSessionStore.hpp
+++ b/src/ControlServer/PlayerSessionStore/PlayerSessionStore.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <optional>
 #include <map>
+#include <set>
 #include <array>
 #include <vector>
 #include <cstdint>
@@ -234,11 +235,17 @@ public:
     //                       for the index↔SVID decode.
     // `item_profile_id` is the loadout slot (1..5) being saved into. Unsent
     // slots are preserved because some cosmetic actions send partial payloads.
+    // `cleared_cosmetic_slots` = engine equip-points (6=Suit, 12=Helmet) the
+    // client explicitly blanked (FTGEQUIP_SLOTS_STRUCT.SlotIndices[slot]==0,
+    // a genuine "make this empty" signal — see CosmeticEquip::ClearSlot for
+    // why only 6/12 are safe to treat this way). Deletes the remapped
+    // cosmetic DB row (22/23) for each, independent of slot_to_inventory.
     static bool SaveEquippedDevices(int64_t character_id, int64_t user_id,
                                     uint32_t profile_id,
                                     int item_profile_id,
                                     const std::map<int, int>& slot_to_inventory,
-                                    const std::map<int, int>& misc_items);
+                                    const std::map<int, int>& misc_items,
+                                    const std::set<int>& cleared_cosmetic_slots = {});
 
     // UNUSED — kept for reference. Returns the union of every static effect
     // group attached to a device in asm.dat (equip + per-fire-mode). We used

--- a/src/ControlServer/TcpSession/TcpSession.cpp
+++ b/src/ControlServer/TcpSession/TcpSession.cpp
@@ -466,10 +466,20 @@ void TcpSession::DeliverGameEvent(const std::string& session_guid, const nlohman
                 }
             }
         }
+        // Engine slots (6=Suit, 12=Helmet) the client explicitly blanked —
+        // SlotIndices[slot]==0, a genuine "make this empty" signal, not
+        // "didn't touch this slot". See CosmeticEquip::ClearSlot.
+        std::set<int> cleared_cosmetic_slots;
+        if (j.contains("cleared_cosmetic_slots") && j["cleared_cosmetic_slots"].is_array()) {
+            for (const auto& v : j["cleared_cosmetic_slots"]) {
+                if (v.is_number_integer()) cleared_cosmetic_slots.insert(v.get<int>());
+            }
+        }
         Logger::Log("armor",
-            "[equip_save] char=%lld pawnId=%d loadout=%d slots=%zu misc=%zu guid=%s\n",
+            "[equip_save] char=%lld pawnId=%d loadout=%d slots=%zu misc=%zu cleared=%zu guid=%s\n",
             (long long)character_id, pawn_id, loadout_profile,
-            slot_to_inventory.size(), misc_items.size(), session_guid.c_str());
+            slot_to_inventory.size(), misc_items.size(), cleared_cosmetic_slots.size(),
+            session_guid.c_str());
         for (const auto& kv : slot_to_inventory) {
             Logger::Log("armor",
                 "[equip_save]   SlotIndices[%d] = inv_id %d\n", kv.first, kv.second);
@@ -478,12 +488,16 @@ void TcpSession::DeliverGameEvent(const std::string& session_guid, const nlohman
             Logger::Log("armor",
                 "[equip_save]   MiscItems[%d]   = inv_id %d\n", kv.first, kv.second);
         }
+        for (int slot : cleared_cosmetic_slots) {
+            Logger::Log("armor",
+                "[equip_save]   ClearedCosmeticSlot[%d]\n", slot);
+        }
 
         if (character_id != 0) {
             const bool ok = PlayerSessionStore::SaveEquippedDevices(
                 character_id, session->user_id_, session->selected_profile_id_,
                 loadout_profile,
-                slot_to_inventory, misc_items);
+                slot_to_inventory, misc_items, cleared_cosmetic_slots);
             if (!ok) {
                 Logger::Log("armor",
                     "[equip_save] REJECTED — DB state unchanged; client will resync from existing\n");

--- a/src/GameServer/Cosmetics/CosmeticEquip.cpp
+++ b/src/GameServer/Cosmetics/CosmeticEquip.cpp
@@ -135,37 +135,44 @@ static void ApplyMeshCollisionData(ATgPawn* Pawn, int meshAsmId) {
 		meshAsmId, data.radius, data.halfHeight);
 }
 
-struct ClassVisualFallback {
-	int suit_item_id;
-};
+static constexpr int kNoCosmeticItemId = 0;
 
-static ClassVisualFallback GetClassVisualFallback(uint32_t profileId) {
+// Per-class, per-gender default body suit shown when no cosmetic suit is
+// equipped. Found via asm_data_set_assembly_meshes — male rows are named
+// "*_SUIT_DEFAULT" (asm 1354-1357); female rows are separate, mislabeled
+// rows named "Female Suit <Class> DEFAULT" (asm 1482-1485) that an earlier
+// case-sensitive `LIKE '%SUIT%DEFAULT%'` search missed entirely (DuckDB LIKE
+// is case-sensitive; "Suit" != "SUIT"). Not a catalog item — no
+// LookupMeshAsmIdForCosmetic lookup applies, these are raw asm_ids.
+static int GetClassDefaultSuitAsmId(uint32_t profileId, bool isFemale) {
+	if (isFemale) {
+		switch (profileId) {
+			case 567: return 1484;  // Female Suit Medic DEFAULT
+			case 679: return 1482;  // Female Suit Robotics DEFAULT
+			case 680: return 1485;  // Female Suit Assault DEFAULT
+			case 681: return 1483;  // Female Suit Recon DEFAULT
+			default:  return 1485;
+		}
+	}
 	switch (profileId) {
-		case 567: return {3139};  // Medic Acolyte
-		case 679: return {4770};  // Robotics Operative
-		case 680: return {3160};  // Assault Heavy
-		case 681: return {3196};  // Recon Wraith
-		default:  return {3160};
+		case 567: return 1355;  // MEDIC_SUIT_DEFAULT
+		case 679: return 1357;  // ROBOTICS_SUIT_DEFAULT
+		case 680: return 1354;  // ASSAULT_SUIT_DEFAULT
+		case 681: return 1356;  // RECON_SUIT_DEFAULT
+		default:  return 1354;
 	}
 }
-
-static constexpr int kNoCosmeticItemId = 0;
 
 static void ApplyClassVisualFallback(ATgPawn* Pawn, uint32_t profileId) {
 	if (!Pawn) return;
 	auto* charPawn = (ATgPawn_Character*)Pawn;
 	auto* PRI      = (ATgRepInfo_Player*)Pawn->PlayerReplicationInfo;
-	const int gender = charPawn->r_CustomCharacterAssembly.nGenderTypeId;
-	const ClassVisualFallback fallback = GetClassVisualFallback(profileId);
 
 	if (charPawn->r_CustomCharacterAssembly.SuitMeshId <= 0) {
-		int meshAsm = LookupMeshAsmIdForCosmetic(fallback.suit_item_id, gender);
-		if (meshAsm <= 0) meshAsm = 1225;
+		const bool isFemale = charPawn->r_CustomCharacterAssembly.nGenderTypeId == GA_G::GENDER_TYPE_ID_FEMALE;
+		const int meshAsm = GetClassDefaultSuitAsmId(profileId, isFemale);
 		charPawn->r_CustomCharacterAssembly.SuitMeshId = meshAsm;
 		if (PRI) PRI->r_CustomCharacterAssembly.SuitMeshId = meshAsm;
-		Logger::Log("cosmetic-equip",
-			"LoadFromDB: class visual suit fallback profile=%u item=%d mesh=%d\n",
-			profileId, fallback.suit_item_id, meshAsm);
 	}
 
 	if (charPawn->r_CustomCharacterAssembly.HeadFlairId <= 0) {
@@ -377,7 +384,14 @@ bool ApplyToPawn(ATgPawn* Pawn, int64_t character_id, int item_profile_id,
 		sqlite3_bind_int  (stmt, 2, item_profile_id);
 		sqlite3_bind_int  (stmt, 3, invId);
 		sqlite3_bind_int  (stmt, 4, dbSlot);
-		sqlite3_step(stmt);
+		const int stepResult = sqlite3_step(stmt);
+		if (stepResult != SQLITE_DONE) {
+			Logger::Log("cosmetic-equip",
+				"ApplyToPawn: persist FAILED char=%lld itemProf=%d dbSlot=%d invId=%d: %s\n",
+				(long long)character_id, item_profile_id, dbSlot, invId, sqlite3_errmsg(db));
+			sqlite3_finalize(stmt);
+			return false;
+		}
 		sqlite3_finalize(stmt);
 	} else {
 		Logger::Log("cosmetic-equip", "ApplyToPawn: prepare(insert) failed: %s\n",
@@ -393,11 +407,34 @@ bool ApplyToPawn(ATgPawn* Pawn, int64_t character_id, int item_profile_id,
 bool ClearSlot(ATgPawn* Pawn, int64_t character_id, int item_profile_id, int slot) {
 	if (!Pawn) return false;
 	item_profile_id = NormalizeItemProfileId(Pawn, item_profile_id);
-	if (slot < 16 || slot > 20) return false;
+	if (slot != 6 && slot != 12 && (slot < 16 || slot > 20)) return false;
 
 	auto* charPawn = (ATgPawn_Character*)Pawn;
 	auto* PRI      = (ATgRepInfo_Player*)Pawn->PlayerReplicationInfo;
-	charPawn->r_CustomCharacterAssembly.DyeList[slot - 16] = kNoCosmeticItemId;
+
+	// Engine slot → DB storage slot. Suit (6) / Helmet (12) use the
+	// CosmeticSlots remap (22/23); dyes pass through unchanged.
+	int dbSlot = slot;
+	if (slot == 6) {
+		charPawn->r_CustomCharacterAssembly.SuitFlairId = -1;
+		charPawn->r_CustomCharacterAssembly.SuitMeshId  = -1;
+		if (PRI) {
+			PRI->r_CustomCharacterAssembly.SuitFlairId = -1;
+			PRI->r_CustomCharacterAssembly.SuitMeshId  = -1;
+		}
+		dbSlot = CosmeticSlots::kCosmeticSuitDbSlot;
+	} else if (slot == 12) {
+		charPawn->r_CustomCharacterAssembly.HeadFlairId  = -1;
+		charPawn->r_CustomCharacterAssembly.HelmetMeshId = -1;
+		if (PRI) {
+			PRI->r_CustomCharacterAssembly.HeadFlairId  = -1;
+			PRI->r_CustomCharacterAssembly.HelmetMeshId = -1;
+		}
+		dbSlot = CosmeticSlots::kCosmeticHelmetDbSlot;
+	} else {
+		charPawn->r_CustomCharacterAssembly.DyeList[slot - 16] = kNoCosmeticItemId;
+		if (PRI) PRI->r_CustomCharacterAssembly.DyeList[slot - 16] = kNoCosmeticItemId;
+	}
 
 	sqlite3* db = Database::GetConnection();
 	if (db) {
@@ -408,8 +445,11 @@ bool ClearSlot(ATgPawn* Pawn, int64_t character_id, int item_profile_id, int slo
 		        -1, &stmt, nullptr) == SQLITE_OK) {
 			sqlite3_bind_int64(stmt, 1, character_id);
 			sqlite3_bind_int  (stmt, 2, item_profile_id);
-			sqlite3_bind_int  (stmt, 3, slot);
-			sqlite3_step(stmt);
+			sqlite3_bind_int  (stmt, 3, dbSlot);
+			if (sqlite3_step(stmt) != SQLITE_DONE) {
+				Logger::Log("cosmetic-equip", "ClearSlot: DELETE FAILED char=%lld dbSlot=%d: %s\n",
+					(long long)character_id, dbSlot, sqlite3_errmsg(db));
+			}
 			sqlite3_finalize(stmt);
 		} else {
 			Logger::Log("cosmetic-equip", "ClearSlot: prepare(delete) failed: %s\n",
@@ -418,7 +458,11 @@ bool ClearSlot(ATgPawn* Pawn, int64_t character_id, int item_profile_id, int slo
 	}
 
 	ApplyClassVisualFallback(Pawn, charPawn->r_nProfileId);
-	ApplyMeshCollisionData(Pawn, charPawn->r_CustomCharacterAssembly.SuitMeshId);
+	// 1225 is a collision-lookup key only when no suit is equipped — see the
+	// matching comment in LoadFromDB; must not be written back to SuitMeshId.
+	int collisionLookupMesh = charPawn->r_CustomCharacterAssembly.SuitMeshId;
+	if (collisionLookupMesh <= 0) collisionLookupMesh = 1225;
+	ApplyMeshCollisionData(Pawn, collisionLookupMesh);
 	if (PRI) PRI->r_CustomCharacterAssembly = charPawn->r_CustomCharacterAssembly;
 	Pawn->bNetDirty       = 1;
 	Pawn->bForceNetUpdate = 1;
@@ -428,8 +472,8 @@ bool ClearSlot(ATgPawn* Pawn, int64_t character_id, int item_profile_id, int slo
 	}
 
 	Logger::Log("cosmetic-equip",
-		"ClearSlot: char=%lld itemProf=%d dyeSlot=%d\n",
-		(long long)character_id, item_profile_id, slot);
+		"ClearSlot: char=%lld itemProf=%d engineSlot=%d dbSlot=%d\n",
+		(long long)character_id, item_profile_id, slot, dbSlot);
 	return true;
 }
 
@@ -558,13 +602,15 @@ void LoadFromDB(ATgPawn* Pawn, int64_t character_id, int item_profile_id) {
 	// Do not write r_nBodyMeshAsmId or call ApplyPawnSetup here: both paths
 	// re-enter native pawn setup and crashed later loadout-profile switches.
 	ApplyClassVisualFallback(Pawn, profileId);
-	int resolvedSuitMesh = charPawn->r_CustomCharacterAssembly.SuitMeshId;
-	if (resolvedSuitMesh <= 0) {
-		resolvedSuitMesh = 1225;
-		charPawn->r_CustomCharacterAssembly.SuitMeshId = resolvedSuitMesh;
-		if (PRI) PRI->r_CustomCharacterAssembly.SuitMeshId = resolvedSuitMesh;
+	// 1225 is used ONLY as a collision-lookup key when no cosmetic suit is
+	// equipped — it must NOT be written into SuitMeshId (the replicated,
+	// rendered field), or "no suit" would render the Medic Acolyte mesh
+	// instead of the bare class-default body.
+	int collisionLookupMesh = charPawn->r_CustomCharacterAssembly.SuitMeshId;
+	if (collisionLookupMesh <= 0) {
+		collisionLookupMesh = 1225;
 	}
-	ApplyMeshCollisionData(Pawn, resolvedSuitMesh);
+	ApplyMeshCollisionData(Pawn, collisionLookupMesh);
 	if (PRI) {
 		// The pawn is authoritative; clear-only profile switches must not
 		// leave PRI dye/trail fields from the previous profile.

--- a/src/GameServer/Cosmetics/CosmeticEquip.hpp
+++ b/src/GameServer/Cosmetics/CosmeticEquip.hpp
@@ -22,7 +22,10 @@ namespace CosmeticEquip {
 bool ApplyToPawn(ATgPawn* Pawn, int64_t character_id, int item_profile_id,
                  int slot, int invId, int itemId);
 
-// Clear one cosmetic slot from live assembly and profile storage.
+// Clear one cosmetic slot from live assembly and profile storage. Accepts
+// engine slot 6 (Suit), 12 (Helmet), or 16-20 (dyes). Suit/helmet reset their
+// Flair/Mesh fields to -1 (bare — no overlay) and delete the remapped DB row
+// (22/23); dyes reset to kNoCosmeticItemId. Returns false for any other slot.
 bool ClearSlot(ATgPawn* Pawn, int64_t character_id, int item_profile_id, int slot);
 
 // On pawn spawn/profile switch, replay rows from ga_character_devices whose

--- a/src/GameServer/TgGame/TgPlayerController/ServerAcceptNewProfileFromEquipScreen/TgPlayerController__ServerAcceptNewProfileFromEquipScreen.cpp
+++ b/src/GameServer/TgGame/TgPlayerController/ServerAcceptNewProfileFromEquipScreen/TgPlayerController__ServerAcceptNewProfileFromEquipScreen.cpp
@@ -179,6 +179,24 @@ void __fastcall TgPlayerController__ServerAcceptNewProfileFromEquipScreen::Call(
 		}
 	}
 
+	// Explicit cosmetic clear. FTGEQUIP_SLOTS_STRUCT.SlotIndices[] is a fixed
+	// array sent in full on every Apply, so SlotIndices[slot]==0 genuinely
+	// means "this icon is empty" for the Appearance tab's Suit (6) / Head
+	// (12) icons — confirmed via right-click-to-remove repro 2026-06-19. This
+	// is safe to treat as a real clear (unlike most other slots — see the
+	// "Conservative gate" comment below) because, for players, the Appearance
+	// tab's icon is the only thing that ever writes engine slots 6/12; there's
+	// no separate player-equippable gameplay device sharing that wire slot.
+	std::set<int> clearedCosmeticSlots;
+	if (DeviceArray.SlotIndices[6] == 0) {
+		CosmeticEquip::ClearSlot(Pawn, character_id, itemProfileId, 6);
+		clearedCosmeticSlots.insert(6);
+	}
+	if (DeviceArray.SlotIndices[12] == 0) {
+		CosmeticEquip::ClearSlot(Pawn, character_id, itemProfileId, 12);
+		clearedCosmeticSlots.insert(12);
+	}
+
 	// Pre-pass: Unequip anything that's being SWAPPED for a different invId.
 	// Without this, `Inventory::Equip` would create a second ATgDevice actor
 	// at the same slot carrying a now-stale invId from the previous loadout,
@@ -191,10 +209,11 @@ void __fastcall TgPlayerController__ServerAcceptNewProfileFromEquipScreen::Call(
 	//
 	// Conservative gate: only unequip when the new invId is non-zero AND
 	// different from current. Treat newInvId==0 as "client didn't ship this
-	// slot" rather than "user removed this item" — the equip screen UI on
-	// this build doesn't expose a clear-slot action, and the slot-14 rest
-	// device is invisible to the screen so the client may legitimately omit
-	// it. Skipping zero entries keeps that device safe.
+	// slot" rather than "user removed this item" for every OTHER slot — the
+	// slot-14 rest device is invisible to the screen so the client always
+	// reads 0 there, and weapon/offhand slots are never meant to go empty
+	// (the UI only replaces, never blanks them). Skipping zero entries keeps
+	// those slots safe; 6/12 are handled explicitly above instead.
 	//
 	// Cosmetic items (deviceId == 0): they don't occupy m_EquippedDevices,
 	// the engine-side write is just a r_CustomCharacterAssembly field.
@@ -374,20 +393,22 @@ void __fastcall TgPlayerController__ServerAcceptNewProfileFromEquipScreen::Call(
 	}
 
 	nlohmann::json ev;
-	ev["type"]              = IpcProtocol::MSG_GAME_EVENT;
-	ev["subtype"]           = "equip_save";
-	ev["instance_id"]       = IpcClient::GetInstanceId();
-	ev["session_guid"]      = it->second;
-	ev["pawn_id"]           = (int)Pawn->r_nPawnId;
-	ev["character_id"]      = character_id;
-	ev["loadout_profile"]   = nProfileId;
-	ev["slot_to_inventory"] = std::move(slotMap);
-	ev["misc_items"]        = std::move(miscMap);  // armor / unknown-Misc-tab data
+	ev["type"]                    = IpcProtocol::MSG_GAME_EVENT;
+	ev["subtype"]                 = "equip_save";
+	ev["instance_id"]             = IpcClient::GetInstanceId();
+	ev["session_guid"]            = it->second;
+	ev["pawn_id"]                 = (int)Pawn->r_nPawnId;
+	ev["character_id"]            = character_id;
+	ev["loadout_profile"]         = nProfileId;
+	ev["slot_to_inventory"]       = std::move(slotMap);
+	ev["misc_items"]              = std::move(miscMap);  // armor / unknown-Misc-tab data
+	ev["cleared_cosmetic_slots"]  = nlohmann::json(clearedCosmeticSlots);
 	IpcClient::Send(ev.dump());
 
 	Logger::Log(GetLogChannel(),
-		"equip-save: forwarded loadout=%d slots=%d/24 misc=%d/25 pawn=%p guid=%s\n",
-		nProfileId, slotPopulated, miscPopulated, (void*)Pawn, it->second.c_str());
+		"equip-save: forwarded loadout=%d slots=%d/24 misc=%d/25 cleared=%zu pawn=%p guid=%s\n",
+		nProfileId, slotPopulated, miscPopulated, clearedCosmeticSlots.size(),
+		(void*)Pawn, it->second.c_str());
 
 	LogCallEnd();
 }

--- a/src/Utils/SehStub/SehStub.cpp
+++ b/src/Utils/SehStub/SehStub.cpp
@@ -1,0 +1,18 @@
+// Workaround for an upstream mingw-w64-i686-crt toolchain bug (2026-06-19):
+// the installed build (14.0.0.r98.g19f5121a2-1, a git snapshot, paired with
+// gcc 16.1.0) ships libmsvcrt.a's i386__beginthreadex.o referencing
+// __mingw_SEH_error_handler, but no library in the toolchain defines it —
+// confirmed via `pacman -S --needed mingw-w64-i686-{gcc,crt,headers}`
+// reporting all three already up to date. Without this stub, every DLL
+// using -static (required — see CFLAGS comment in Makefile, dropping
+// -static instead broke DLL injection) fails to link.
+//
+// This handler is only invoked, per mingw-w64-crt's i386__beginthreadex.c,
+// as the SEH filter installed around a freshly-spawned thread's SSE
+// floating-point state setup — an edge case none of this project's threads
+// trigger. Returning ExceptionContinueSearch (1) is what letting the
+// exception propagate unhandled would do anyway, i.e. a correct no-op for
+// our usage.
+extern "C" int __mingw_SEH_error_handler(void*, void*, void*, void*) {
+    return 1; // EXCEPTION_CONTINUE_SEARCH
+}


### PR DESCRIPTION
PR Summary


  Fixes two related bugs in the cosmetic Appearance system (suit/helmet):
  1. Removing a cosmetic suit/helmet via right-click never persisted — it silently reverted to the
  last-equipped item on respawn.
  2. New characters (and anyone with nothing cosmetically equipped) showed a hardcoded class skin or,
  after an earlier broken attempt, were fully invisible.

  Also fixes an unrelated build-toolchain regression that was blocking any of this from compiling.

  Changes by file

  src/GameServer/Cosmetics/CosmeticEquip.cpp / .hpp
  - ClearSlot now accepts engine slots 6 (Suit) and 12 (Helmet) in addition to dyes — resets
  SuitFlairId/SuitMeshId or HeadFlairId/HelmetMeshId and deletes the corresponding DB row (remapped to
  DB slot 22/23).
  - ApplyClassVisualFallback rewritten: when no cosmetic suit is equipped, SuitMeshId must still be a
  real, valid asm_id (-1 renders the character fully invisible — the client can't "swap to no mesh").
  Now picks a per-class, per-gender "default suit" mesh (asm_ids 1354-1357 male, 1482-1485 female,
  found via asm_data_set_assembly_meshes) instead of falling back to a specific named catalog skin or
  a single hardcoded mesh.
  - ApplyToPawn's DB persistence now checks sqlite3_step's result and logs/returns false on failure
  instead of silently swallowing write errors.
  - LoadFromDB/ClearSlot's collision-sizing fallback (1225) is now used only as a local lookup key for
  ApplyMeshCollisionData, never written back into the replicated SuitMeshId field.

  src/GameServer/TgGame/TgPlayerController/ServerAcceptNewProfileFromEquipScreen/TgPlayerController__S
  erverAcceptNewProfileFromEquipScreen.cpp
  - Detects SlotIndices[6]==0 / [12]==0 (the client genuinely sends 0 when the Appearance tab's
  Suit/Helmet icon is blanked via right-click) and calls CosmeticEquip::ClearSlot immediately, instead
  of treating 0 as "client didn't touch this slot" (which is correct for every other slot, but
  wrongly absorbed the only two slots players actually clear).
  - Forwards the cleared slots to the control server via a new cleared_cosmetic_slots field in the
  equip_save IPC event.

  src/ControlServer/PlayerSessionStore/PlayerSessionStore.cpp / .hpp
  - SaveEquippedDevices takes a new cleared_cosmetic_slots parameter; deletes the corresponding
  ga_character_devices row (DB slot 22/23) inside the same transaction as the rest of the equip save.
  - Added sqlite3_step result checking + error logging on the DELETE/INSERT loops, which previously
  failed silently.

  src/ControlServer/TcpSession/TcpSession.cpp
  - Parses cleared_cosmetic_slots from the IPC payload and passes it through to SaveEquippedDevices.

  Makefile
  - Added src/Utils/SehStub/SehStub.cpp to both DLL source lists.
  - No net change to CFLAGS/LDFLAGS versus master (several intermediate attempts were tried and
  reverted; ended up back at the original -static flags).

  src/Utils/SehStub/SehStub.cpp (new file)
  - Provides a stub __mingw_SEH_error_handler symbol to work around a missing symbol in the current
  mingw-w64-i686-crt toolchain build (a git-snapshot package, not a tagged release) that otherwise
  fails the link with -static.

  Test plan

  - [x] New character (each of the 4 classes, both genders) shows the correct class/gender default
  body, not invisible or a named skin.
  - [x] Equip a cosmetic suit/helmet, then right-click to clear it — confirm it visually reverts to
  the default immediately.
  - [x] Relog/respawn after clearing — confirm the default persists (doesn't revert to the
  previously-equipped item).
  - [x] Normal cosmetic equip/swap flow still works as before.


(God bless Claude, might have to remove the loggers after testing that it all works correctly)
PS: Not sure src/Utils/SehStub/SehStub.cpp is needed but I got a compiling error without it.
PS2: Most important data is in src/GameServer/Cosmetics/CosmeticEquip.cpp sine there you can fint the default armors for both male and female per class.