### PR TITLE
Fix: heal score credited on Adrenaline  overheal created by the gun's own max-HP …

### DIFF
--- a/src/GameServer/TgGame/TgEffect/TrackStats/TgEffect__TrackStats.cpp
+++ b/src/GameServer/TgGame/TgEffect/TrackStats/TgEffect__TrackStats.cpp
@@ -1,4 +1,5 @@
 #include "src/GameServer/TgGame/TgEffect/TrackStats/TgEffect__TrackStats.hpp"
+#include "src/GameServer/TgGame/_effect_core/HealCreditGate.hpp"
 #include "src/GameServer/Combat/SendKillAlert/SendKillAlert.hpp"
 #include "src/GameServer/Combat/SendCombatMessage/SendCombatMessage.hpp"
 #include "src/GameServer/Combat/MissionAlerts/SendAlert.hpp"
@@ -625,6 +626,18 @@ void __fastcall TgEffect__TrackStats::Call(UTgEffect* /*Effect*/, void* /*edx*/,
 		// the only thing that keeps the field fresh.
 		if (targetPawn != nullptr) {
 			targetPawn->m_LastHealer = Instigator;
+		}
+
+		// Target was already at its OLD max HP when a device-fire max-HP buff
+		// (Adrenaline Gun's +400) raised the ceiling moments ago in this same
+		// combo — see TgPawn__ApplyBuff.cpp. The instant heal that follows is
+		// only filling headroom the device itself created, not real healing
+		// performed by the player, so zero out fMissingHealth: the existing
+		// overheal clamps in TrackHealing/TrackBotHealing and
+		// MoraleCredit::Award already turn that into zero credit.
+		if (targetPawn != nullptr &&
+		    HealCreditGate::ConsumeFullBeforeMaxBuff(targetPawn)) {
+			fMissingHealth = 0.0f;
 		}
 
 		// STYPE_HEALING credit — credit Instigator (or owner if pet) for

--- a/src/GameServer/TgGame/TgPawn/ApplyBuff/TgPawn__ApplyBuff.cpp
+++ b/src/GameServer/TgGame/TgPawn/ApplyBuff/TgPawn__ApplyBuff.cpp
@@ -1,4 +1,5 @@
 #include "src/GameServer/TgGame/TgPawn/ApplyBuff/TgPawn__ApplyBuff.hpp"
+#include "src/GameServer/TgGame/_effect_core/HealCreditGate.hpp"
 #include "src/Utils/Logger/Logger.hpp"
 
 // Direct native call to TgPawn::GetBuffIndex (vtable[0x560], FUN_109cd890).
@@ -328,10 +329,20 @@ void __fastcall TgPawn__ApplyBuff::Call(ATgPawn* Pawn, void* /*edx*/, FBuffHeade
 	    BuffFilter.nPropId == 390 /* HEALTH_MOD (blueprint maxHP rolls) */) {
 		const bool deviceFire = (buffSourceType >= 3);  // SELF (3) or OTHER (4)
 		const int hpBefore = deviceFire ? *(int*)((char*)Pawn + 0x2c4) : 0;
+		// r_nHealthMaximum BEFORE this recompute — the ceiling the pawn was
+		// actually capped at a moment ago. If hpBefore already sat at (or
+		// above) it, the pawn was truly full pre-buff; any heal that follows
+		// in this same combo is only filling the headroom this buff just
+		// created, not real player healing (see HealCreditGate.hpp).
+		const int oldMaxBefore = deviceFire ? *(int*)((char*)Pawn + 0x43c) : 0;
 
 		RecomputeEagerBaseProp(Pawn, 304 /* HEALTH_MAX */);
 
 		if (deviceFire) {
+			if (hpBefore >= oldMaxBefore && oldMaxBefore > 0) {
+				HealCreditGate::MarkFullBeforeMaxBuff(Pawn);
+			}
+
 			const int hpAfter = *(int*)((char*)Pawn + 0x2c4);
 			if (hpAfter > hpBefore) {
 				SetPropertyNative(Pawn, /*edx=*/nullptr, 51 /* HEALTH */, (float)hpBefore);

--- a/src/GameServer/TgGame/_effect_core/HealCreditGate.hpp
+++ b/src/GameServer/TgGame/_effect_core/HealCreditGate.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "src/pch.hpp"
+#include <unordered_set>
+
+// One-shot suppression for heal score/morale credit when a max-HP buff
+// (TgPawn__ApplyBuff, prop 412/390, device-fire source) tops a pawn off from
+// a freshly-raised ceiling rather than the player's own healing.
+//
+// Concrete case: Adrenaline Gun fires HoT + instant heal + +400 max-HP buff,
+// reordered (see TgDeviceFire__GetEffectGroup.cpp) so the max-HP buff lands
+// BEFORE the instant heal — otherwise the heal clamps against the OLD max
+// and is lost (db5d99e). But if the target was already at the OLD max
+// (truly full) when the buff raises the ceiling, the instant heal that
+// follows is just filling headroom the device itself created — not real
+// healing performed by the player — so it shouldn't earn STYPE_HEALING or
+// morale credit. TgEffect__TrackStats consumes the flag and zeroes
+// fMissingHealth, which the existing TrackHealing / MoraleCredit::Award
+// overheal clamps already turn into zero credit.
+//
+// Keyed by pawn pointer only (no per-device correlation): the buff and its
+// follow-up heal fire back-to-back in the same device-fire callstack, so an
+// unrelated heal landing in that same instant is not a realistic case.
+namespace HealCreditGate {
+
+inline std::unordered_set<ATgPawn*> g_fullBeforeMaxBuff;
+
+inline void MarkFullBeforeMaxBuff(ATgPawn* Pawn) {
+	if (Pawn) g_fullBeforeMaxBuff.insert(Pawn);
+}
+
+// Consume (clear) the flag; returns true if it was set.
+inline bool ConsumeFullBeforeMaxBuff(ATgPawn* Pawn) {
+	if (!Pawn) return false;
+	return g_fullBeforeMaxBuff.erase(Pawn) > 0;
+}
+
+}  // namespace HealCreditGate


### PR DESCRIPTION
…buff

Fix: heal score credited on overheal created by the gun's own max-HP buff

The prior fix (db5d99e) reordered the Adrenaline Gun's effect group so its +400 max-HP buff applies before its instant heal, preventing the heal from clamping against the old (lower) max HP. Side effect: if the target was already at full HP before the buff landed, the heal would still register as "real" healing against the new, artificially raised ceiling — crediting STYPE_HEALING and morale points for topping off headroom the device itself just created, not health the player was actually missing.
genuinely full beforehand.

Verified in-game: healing a damaged target with the Adrenaline Gun still credits the boost/heal score normally; healing a full-HP target with the same gun no longer ticks up the boost/heal score.

Investigated (no fix needed): Adrenaline Gun / Nanite Enhancement System / Boost Beam family don't grant scoreboard "buff" credit

Raised separately during testing: shouldn't applying a beneficial buff (Adrenaline Gun's max-HP buff, Nanite Enhancement's +5% damage buff) also credit the scoreboard buff-value stat, the way Frenzy Wave/Protection do?

Traced via the call-tree visualizer + out/server.db:
- TgPawn::TrackBuff (STYPE_BUFFVALUE) is an intact native, invoked generically by the engine on every device fire (visible firing right inside DeviceFiring.BeginState), passing the firing effect group's DB-authored buff_value field straight through.
- Frenzy Wave's buff effect group has buff_value=240 (category_value_id=935).
- Every effect group on Adrenaline Gun, Nanite Enhancement System, Boost Beam (Mk I–IV), and Multi-Boost Beam — including their own category_value_id=935 entries — has buff_value=0.

The credit pipeline is working correctly end-to-end; these devices simply have no buff_value authored. Confirmed this is consistent across the entire device family sharing that equip slot (not an isolated gap on one item), so treating as working-as-captured — no code or data change made.
