### PR TITLE
Fix: Force Target debuff properly taunt enemy (nearby) mechs

### DIFF
--- a/src/GameServer/TgGame/TgPawn/InitializeDefaultProps/TgPawn__InitializeDefaultProps.cpp
+++ b/src/GameServer/TgGame/TgPawn/InitializeDefaultProps/TgPawn__InitializeDefaultProps.cpp
@@ -325,6 +325,11 @@ void __fastcall TgPawn__InitializeDefaultProps::Call(ATgPawn* Pawn, void* edx) {
 	Pawn->AddProperty( GA_PROPERTY::TGPID_PROTECTION_RANGED,       0, 0, 0, 1000.0f);
 	Pawn->AddProperty( GA_PROPERTY::TGPID_PROTECTION_AOE,          0, 0, 0, 1000.0f);
 
+	// TGPID_TAUNT (305): Force Target device effect calls ApplyToProperty(305, value),
+	// which resolves via GetTargetProperty — no-ops silently if the slot is absent.
+	// Seed at 0; the effect's ADD calc writes a positive value in, Remove subtracts it back.
+	Pawn->AddProperty( GA_PROPERTY::TGPID_TAUNT,                   0, 0, 0, 100.0f);
+
 	// Vision arc — APawn::PeripheralVision (offset 0x0228) is the cosine of
 	// the half-arc the AI uses for SeePlayer / target acquisition. UC default
 	// from TgPawn.uc:10535 is 0.5 (= 120° total arc) which is too narrow for


### PR DESCRIPTION
… pawns

The Force Target fix seeds TGPID_TAUNT (property 305) at value 0 on every pawn's s_Properties during InitializeDefaultProps.

Why it was needed: The Force Target device works by calling ApplyToProperty(305, value) on the target pawn. The engine's GetTargetProperty looks up property 305 in the pawn's s_Properties array — if the slot doesn't exist, the call silently no-ops and the taunt effect never lands.

What the fix does: One line in TgPawn__InitializeDefaultProps::Call adds the property slot at 0 so it's always present. The effect's ADD calc then writes a positive value in on apply, and Remove subtracts it back out — the existing effect system handles the rest correctly with no other changes needed.

Explanation: The Force target debuff applied but did not taunt the surrounding mechs as it should.

Related to: https://discord.com/channels/994691794627461211/1519305943727214592