### PR TITLE
Fix: Recon stims (VV, VS, Range Stim) are now mutually exclusive

### DIFF
--- a/src/GameServer/TgGame/TgDeviceFire/GetEffectGroup/TgDeviceFire__GetEffectGroup.cpp
+++ b/src/GameServer/TgGame/TgDeviceFire/GetEffectGroup/TgDeviceFire__GetEffectGroup.cpp
@@ -12,6 +12,11 @@
 typedef void*(__cdecl* ConstructEffectGroupFn)(void*, int, int, int, unsigned, unsigned, int, int, int*);
 static ConstructEffectGroupFn ConstructEffectGroup = (ConstructEffectGroupFn)0x109a90b0;
 
+// Recon stim pairing: cat-936 buff EG id → paired cat-773 sensor EG id.
+// Populated per device on first GetEffectGroup call; consumed by
+// TgEffectGroup__RemoveEffects to clear scanner slots when the buff is evicted.
+std::unordered_map<int, int> g_sensorEgForBuffEg;
+
 // -------------------------------------------------------------------------
 // Visual-noise blacklist: type-263 (DeviceFiring) effect groups whose
 // target_fx_id is the "dome ring" asset 1275. On every refire pulse
@@ -286,6 +291,7 @@ UTgEffectGroup* BuildEffectGroup(int egId, int egType) {
 	}
 
 	// --- Build UTgEffect children ---
+	bool hasSensorEffect = false;
 	{
 		sqlite3_stmt* stmt = nullptr;
 		int rc = sqlite3_prepare_v2(db,
@@ -298,6 +304,7 @@ UTgEffectGroup* BuildEffectGroup(int egId, int egType) {
 
 			while (sqlite3_step(stmt) == SQLITE_ROW) {
 				int classResId = sqlite3_column_int(stmt, 0);
+				if (classResId == 244) hasSensorEffect = true;
 				UClass* effectClass = GetEffectClassById(classResId);
 				if (!effectClass) {
 					Logger::Log("effects",
@@ -369,6 +376,15 @@ UTgEffectGroup* BuildEffectGroup(int egId, int egType) {
 			sqlite3_finalize(stmt);
 		}
 	}
+
+	// Sensor stims (TgEffectSensor, class_res_id=244) come from the DB with
+	// application_value_id=155 (stacking), so firing Visual Scanner while
+	// Vulture Vision is active would fill both r_ScannerSettings slots and both
+	// effects persist simultaneously. Promote to 156 (Newest Wins) so
+	// GetNewEffectGroupByApp calls RemoveAllEffectGroups before applying the
+	// clone, evicting the old stim's scanner settings.
+	if (hasSensorEffect && g->m_nApplicationType == 155)
+		g->m_nApplicationType = 156;
 
 	// Stealth-category (621) effect groups in the DB have lifetime=0
 	// (e.g. egId 9315 for Spring Stealth, slot 981 / device 3023). Promote
@@ -586,6 +602,46 @@ UTgEffectGroup* __fastcall TgDeviceFire__GetEffectGroup::Call(UTgDeviceFire* pTh
 				for (size_t k = 0; k < idxs.size(); k++) {
 					pThis->s_EffectGroupList.Data[idxs[k]] = groups[k];
 				}
+			}
+		}
+
+		// Recon stim mutual exclusivity.
+		// VS/VV devices have a cat-773 TgEffectSensor EG (promoted to app=156 in
+		// BuildEffectGroup) paired with a cat-936 damage buff EG. Range Stim
+		// devices have only the cat-936 EG (prop 214, range damage). All three
+		// families must evict each other when a new stim fires, so:
+		//   • Promote each cat-936 buff EG to app=156 (Newest Wins), ensuring
+		//     RemoveAllEffectGroups(cat-936) is called before the clone applies.
+		//   • Record cat-936_egId → cat-773_egId so RemoveEffects can clear the
+		//     scanner slot when the VS/VV buff is evicted by Range Stim firing.
+		{
+			UTgEffectGroup* sensorEG = nullptr;
+			UTgEffectGroup* buffEG   = nullptr;
+			bool buffHasProp214      = false;
+
+			for (int i = 0; i < pThis->s_EffectGroupList.Count; i++) {
+				UTgEffectGroup* g = pThis->s_EffectGroupList.Data[i];
+				if (!g) continue;
+				if (g->m_nCategoryCode == 773 && g->m_nApplicationType == 156) {
+					sensorEG = g;
+				} else if (g->m_nCategoryCode == 936) {
+					for (int j = 0; j < g->m_Effects.Count; j++) {
+						UTgEffect* e = g->m_Effects.Data[j];
+						if (e && (e->m_nPropertyId == 214 || e->m_nPropertyId == 65)) {
+							buffEG = g;
+							if (e->m_nPropertyId == 214) buffHasProp214 = true;
+							break;
+						}
+					}
+				}
+			}
+
+			// VS/VV identified by sensorEG; RS identified by prop-214 range buff
+			if (buffEG && (sensorEG || buffHasProp214)) {
+				if (buffEG->m_nApplicationType != 156)
+					buffEG->m_nApplicationType = 156;
+				if (sensorEG)
+					g_sensorEgForBuffEg[buffEG->m_nEffectGroupId] = sensorEG->m_nEffectGroupId;
 			}
 		}
 	}

--- a/src/GameServer/TgGame/TgEffectGroup/RemoveEffects/TgEffectGroup__RemoveEffects.cpp
+++ b/src/GameServer/TgGame/TgEffectGroup/RemoveEffects/TgEffectGroup__RemoveEffects.cpp
@@ -2,6 +2,10 @@
 #include "src/GameServer/Utils/ObjectClassCache/ObjectClassCache.hpp"
 #include "src/Utils/Logger/Logger.hpp"
 
+// Populated by TgDeviceFire__GetEffectGroup: cat-936 buff EG id → cat-773 sensor EG id.
+// Used below to clear scanner slots when a VS/VV buff EG is evicted by Range Stim or a newer stim.
+extern std::unordered_map<int, int> g_sensorEgForBuffEg;
+
 // TgEffectGroup::RemoveEffects — reimplements stripped stub @ 0x10a6f3d0.
 // Reverse each effect via its OWN-class Remove. The SDK eventRemove wrapper
 // resolves base TgEffect.Remove and ProcessEvent runs it without virtual
@@ -78,6 +82,24 @@ void __fastcall TgEffectGroup__RemoveEffects::Call(UTgEffectGroup* eg, void* /*e
 			Logger::Log("effects",
 				"[REMOVE-EFFECTS]   effect[%d] propId=%d m_fCurrent=%.2f -> Remove dispatched\n",
 				i, effect->m_nPropertyId, beforeCurrent);
+		}
+	}
+
+	// When a VS/VV cat-936 buff EG is evicted (by Range Stim or a newer stim
+	// firing), clear the paired cat-773 sensor EG's scanner slot so the stim's
+	// visual effects (stealth reveal, health-bracket highlight) stop immediately.
+	if (eg->m_nCategoryCode == 936 && Target) {
+		auto it = g_sensorEgForBuffEg.find(eg->m_nEffectGroupId);
+		if (it != g_sensorEgForBuffEg.end() && ObjectClassCache::ClassNameContains(Target, "TgPawn")) {
+			ATgPawn* pawn = (ATgPawn*)Target;
+			const int sensorEgId = it->second;
+			for (int i = 0; i < 2; i++) {
+				if (pawn->r_ScannerSettings[i].EffectGroupId == sensorEgId) {
+					pawn->ClearScannerSettingByIndex(i);
+					pawn->ApplyScannerSettingsToPawn(true);
+					break;
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Recon Stim Mutual Exclusivity

Problem: Recon stims (Vulture Vision, Visual Scanner, Range Stim) were not properly replacing each other.

- Using Visual Scanner while Vulture Vision was active left VV's "enemies below 25% health highlighted" effect running alongside VS's stealth detection for the duration of the previous buff.
- Range Stim firing while VV/VS was active removed the damage buff but left the scanner visual effects (stealth reveal, health-bracket highlight) active.
- VV/VS firing while Range Stim was active didn't replace RS at all — the weaker stim's buff was simply dropped because Strongest Wins (app=157) kept the higher-value RS buff in place.

Root cause: All three stim families shared cbuffs, but used either Stacking (app=155) orStrongest Wins (app=157) as their application type. Neither guarantees mutual exclusivity — Stacking lets multiple coexist, and Strongest Wins silently drops the new stim if the active one has a higher value. VV/VS additionally had their scanner settings (category 773, TgEffearate EG that Range Stim never touched, soeven when RS evicted the damage buff, the scanner visuals persisted.

Fix:

1. Cat-773 sensor EGs promoted to Newest Winll RemoveAllEffectGroups on their sensoring one always evicts the other's scanner settings.
2. Cat-936 damage buff EGs promoted to Newest Wins (app=156): All three stims (VV, VS, RS) now use Newest Wins on their damage buff, so the most recently fired stim always wins regardless of value — replacing Strongest Wins which was silently blocking weaker stims from applying.
3. Scanner slot clearing on buff eviction: When RS fires and evicts VV or VS's cat-936 buff via RemoveAllEffectGroups, a pairing map (buffEgId → sensorEgId) trigge on the pawn's matching r_ScannerSettingsslot, removing the scanner visual immediately even though RS has no sensor EG of its own.

The Sensor Deployable (+15% damage aura, cat) is unaffected — it uses a completelydifferent category and effect class and stacks normally with all three stims.

Related to https://discord.com/channels/994691794627461211/1519845610046623745