### PR TITLE
Fix: turret detection cone tilted by camera pitch at deploy time

### DIFF
--- a/src/GameServer/TgGame/TgDeviceFire/SpawnPet/TgDeviceFire__SpawnPet.cpp
+++ b/src/GameServer/TgGame/TgDeviceFire/SpawnPet/TgDeviceFire__SpawnPet.cpp
@@ -422,15 +422,15 @@ void __fastcall TgDeviceFire__SpawnPet::Call(UTgDeviceFire* pThis, void* edx, BO
 				// (with pin removed, AI defaults m_rFixedDirection to (0,0,0)
 				// world-X — same fixed-pin behavior, just to a wrong direction).
 				// Idle scanning is anim-tree-driven, not AI-driven.
-				PetPawn->Rotation         = spawnRot;
-				PetPawn->DesiredRotation  = spawnRot;
+				PetPawn->Rotation         = rot;
+				PetPawn->DesiredRotation  = rot;
 				if (PetPawn->Controller) {
 					ATgAIController* aic = (ATgAIController*)PetPawn->Controller;
-					aic->Rotation           = spawnRot;
+					aic->Rotation           = rot;
 					// aic->Focus              = nullptr;
-					aic->DesiredRotation    = spawnRot;
-					aic->m_rFixedDirection  = spawnRot;
-					aic->m_rSpawnDirection  = spawnRot;
+					aic->DesiredRotation    = rot;
+					aic->m_rFixedDirection  = rot;
+					aic->m_rSpawnDirection  = rot;
 					aic->m_vSpawnLocation   = PetPawn->Location;
 					// aic->bReplicateMovement = 1;
 				}
@@ -439,8 +439,9 @@ void __fastcall TgDeviceFire__SpawnPet::Call(UTgDeviceFire* pThis, void* edx, BO
 				// PetPawn->bNetDirty       = 1;
 				// PetPawn->bForceNetUpdate = 1;
 				Logger::Log("pet_spawn",
-					"TgDeviceFire::SpawnPet: rotation locked to (%d,%d,%d) "
-					"(pawn + AI m_rFixedDirection/m_rSpawnDirection)\n",
+					"TgDeviceFire::SpawnPet: rotation locked to (%d,%d,%d) pitch-zeroed "
+					"(pawn + AI m_rFixedDirection/m_rSpawnDirection); spawnRot was (%d,%d,%d)\n",
+					rot.Pitch, rot.Yaw, rot.Roll,
 					spawnRot.Pitch, spawnRot.Yaw, spawnRot.Roll);
 
 				Logger::Log("pet_spawn",


### PR DESCRIPTION
Fix: Turret detection cone was tilted by player camera pitch at deploy time

SpawnPet computed a zeroed-pitch rotation (rot, Pitch=0, Yaw from controller, Roll=0) specifically to use for turret direction fields, but then assigned spawnRot (raw controller rotation with whatever pitch the camera had) everywhere instead. The dead variable was never applied.

Effect: The AI detection cone and m_rFixedDirection were centered on the player's look direction at deploy time, not horizontal. Deploying while looking up tilted the cone upward, creating a blind spot for ground-level targets close to the turret. Deploying while looking down had the opposite effect for airborne targets.

Fix: Use the zeroed-pitch rot for all six direction assignments — PetPawn->Rotation, PetPawn->DesiredRotation, aic->Rotation, aic->DesiredRotation, aic->m_rFixedDirection, aic->m_rSpawnDirection.

The change is inside TgDeviceFire__SpawnPet::Call() — that hook only fires when a player deploys a turret through their device (fire mode). Map-placed PvE turrets are spawned at level load via TgGame::SpawnBotById directly (not through SpawnPet), so they never hit this code path and are completely unaffected.

Related to https://discord.com/channels/994691794627461211/1520449778012524735