### PR TITLE
Fix stacking Dome Boosts stopping turrets/drones from shooting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,6 +337,7 @@ SOURCE_FILES= \
 			  $(SRC_DIR)/GameServer/TgGame/TgMissionObjective/RegisterSelf/TgMissionObjective__RegisterSelf.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/TgDynamicSMActor/ForceNetRelevant/TgDynamicSMActor__ForceNetRelevant.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/TgAIController/TargetInLOS/TgAIController__TargetInLOS.cpp \
+			  $(SRC_DIR)/GameServer/TgGame/TgAIController/LOSTrace/TgAIController__LOSTrace.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/TgAIController/CanBeRepaired/TgAIController__CanBeRepaired.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/TgAIController/SpawnPets/TgAIController__SpawnPets.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/TgAIController/RadioAlarm/TgAIController__RadioAlarm.cpp \

--- a/src/GameServer/TgGame/TgAIController/LOSTrace/TgAIController__LOSTrace.cpp
+++ b/src/GameServer/TgGame/TgAIController/LOSTrace/TgAIController__LOSTrace.cpp
@@ -1,17 +1,22 @@
-#include "src/GameServer/TgGame/TgAIController/TargetInLOS/TgAIController__TargetInLOS.hpp"
+#include "src/GameServer/TgGame/TgAIController/LOSTrace/TgAIController__LOSTrace.hpp"
 #include "src/GameServer/TgGame/TgProj_Deployable/SpawnDeployable/TgProj_Deployable__SpawnDeployable.hpp"
 
-// bCollideActors is bit 0x08000000 at AActor+0xB0.
-// bDeleteMe   is bit 0x00000008 at AActor+0xAC.
 static const uint32_t kCollide  = 0x08000000;
 static const uint32_t kDeleteMe = 0x00000008;
 
-int __fastcall TgAIController__TargetInLOS::Call(ATgAIController* aic, void* edx) {
-	// ForceField domes are transparent to friendly fire (CheckTeamPassThrough),
-	// so the LOS trace should also see through them. Disable their collision
-	// for the duration of the check so the recursive trace (FUN_10a806e0)
-	// never hits them in the first place.
+// Depth counter — prevents re-disabling/re-enabling on recursive self-calls.
+static int s_depth = 0;
+
+int __fastcall TgAIController__LOSTrace::Call(int* param_1, void* edx,
+	int p2, int p3, int p4, int p5, int p6, int p7, int p8, int p9, int p10)
+{
+	if (s_depth > 0)
+		return CallOriginal(param_1, edx, p2, p3, p4, p5, p6, p7, p8, p9, p10);
+
 	auto& ffs = TgProj_Deployable__SpawnDeployable::GetForceFieldSet();
+	if (ffs.empty())
+		return CallOriginal(param_1, edx, p2, p3, p4, p5, p6, p7, p8, p9, p10);
+
 	std::vector<ATgDeployable*> disabled;
 	std::vector<ATgDeployable*> toRemove;
 
@@ -26,7 +31,9 @@ int __fastcall TgAIController__TargetInLOS::Call(ATgAIController* aic, void* edx
 	for (ATgDeployable* d : toRemove)
 		ffs.erase(d);
 
-	int result = CallOriginal(aic, edx);
+	s_depth++;
+	int result = CallOriginal(param_1, edx, p2, p3, p4, p5, p6, p7, p8, p9, p10);
+	s_depth--;
 
 	for (ATgDeployable* d : disabled)
 		*(uint32_t*)((char*)d + 0xB0) |= kCollide;

--- a/src/GameServer/TgGame/TgAIController/LOSTrace/TgAIController__LOSTrace.hpp
+++ b/src/GameServer/TgGame/TgAIController/LOSTrace/TgAIController__LOSTrace.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "src/pch.hpp"
+#include "src/Utils/HookBase.hpp"
+
+// Hook on the recursive LOS trace (FUN_10a806e0, __thiscall).
+// Called from every AI LOS path: TargetInLOS (fire maintenance),
+// FindBestEnemy (target acquisition), LineOfSightTo UC native, etc.
+// ForceField domes are disabled at the top-level entry so the trace sees
+// through all of them. Depth tracking prevents re-disabling on recursive
+// self-calls (which all pass through this hook too).
+class TgAIController__LOSTrace : public HookBase<
+	int(__fastcall*)(int*, void*, int, int, int, int, int, int, int, int, int),
+	0x10a806e0,
+	TgAIController__LOSTrace> {
+public:
+	static int __fastcall Call(int* param_1, void* edx,
+		int p2, int p3, int p4, int p5, int p6, int p7, int p8, int p9, int p10);
+	static inline int __fastcall CallOriginal(int* param_1, void* edx,
+		int p2, int p3, int p4, int p5, int p6, int p7, int p8, int p9, int p10) {
+		return m_original(param_1, edx, p2, p3, p4, p5, p6, p7, p8, p9, p10);
+	}
+};

--- a/src/GameServer/TgGame/TgAIController/TargetInLOS/TgAIController__TargetInLOS.hpp
+++ b/src/GameServer/TgGame/TgAIController/TargetInLOS/TgAIController__TargetInLOS.hpp
@@ -3,14 +3,14 @@
 #include "src/pch.hpp"
 #include "src/Utils/HookBase.hpp"
 
-// Hook on `TgAIController::TargetInLOS` (0x10a86100). Diagnostic-only — used
-// to investigate the "owner blocks turret LOS" gameplay regression. The AI
-// runs this every fire-tick during continuous fire; if it returns 1 the AI
-// keeps firing through whatever's in between. Original game dropped the
-// lock-on when the deploying player walked into the LOS path.
+// Hook on `TgAIController::TargetInLOS` (FUN_10a85c60).
+// Fixes the multi-dome turret bug: ForceField domes are transparent to friendly
+// fire (CheckTeamPassThrough), so they should also be transparent to LOS checks.
+// We disable bCollideActors on all live domes before the trace runs so the
+// recursive tracer (FUN_10a806e0) never hits them at all, then restore.
 class TgAIController__TargetInLOS : public HookBase<
 	int(__fastcall*)(ATgAIController*, void*),
-	0x10a86100,
+	0x10a85c60,
 	TgAIController__TargetInLOS> {
 public:
 	static int __fastcall Call(ATgAIController* aic, void* edx);

--- a/src/GameServer/TgGame/TgDeviceFire/Deploy/TgDeviceFire__Deploy.cpp
+++ b/src/GameServer/TgGame/TgDeviceFire/Deploy/TgDeviceFire__Deploy.cpp
@@ -61,6 +61,7 @@ void __fastcall TgDeviceFire__Deploy::Call(UTgDeviceFire* pThis, void* edx) {
 		// point) is meaningless for self-spawning deployables — it could be
 		// a wall 30m away, the floor in front, or mid-air.
 		bool bSelfSpawn = DeployableClassify::DeploysOnSelf(deployableId);
+		bool bIsForceFieldByClass = TgProj_Deployable__SpawnDeployable::IsForceFieldDeployableId(deployableId);
 		AWorldInfo* WorldInfo = World__GetWorldInfo::CallOriginal((UWorld*)Globals::Get().GWorld, nullptr, 0);
 
 		FVector spawnLocation = bSelfSpawn
@@ -137,6 +138,11 @@ void __fastcall TgDeviceFire__Deploy::Call(UTgDeviceFire* pThis, void* edx) {
 			Logger::Log("inventory", "[deploy] Spawn returned null for %s (deployableId=%d), aborting\n", clsName, deployableId);
 			return;
 		}
+
+		// Register immediately after Spawn so LOSTrace can disable this dome's
+		// collision before any LOS check fires.
+		if (bIsForceFieldByClass)
+			TgProj_Deployable__SpawnDeployable::GetForceFieldSet().insert(Deployable);
 
 		// cylHalfHeight is now the SCALED half-extent (UE3 convention), so it
 		// goes straight into SetCollisionSize. The previous `* 2` was a vestige

--- a/src/GameServer/TgGame/TgProj_Deployable/SpawnDeployable/TgProj_Deployable__SpawnDeployable.cpp
+++ b/src/GameServer/TgGame/TgProj_Deployable/SpawnDeployable/TgProj_Deployable__SpawnDeployable.cpp
@@ -198,6 +198,11 @@ void TgProj_Deployable__SpawnDeployable::GetDeployableSpawnZLift(
 		: 5.0f;  // TgDeployable.CollisionCylinder CDO halfHeight * 0.5
 }
 
+std::unordered_set<ATgDeployable*>& TgProj_Deployable__SpawnDeployable::GetForceFieldSet() {
+	static std::unordered_set<ATgDeployable*> s_set;
+	return s_set;
+}
+
 bool TgProj_Deployable__SpawnDeployable::IsForceFieldDeployableId(int nDeployableId) {
 	const char* clsName = GetDeployableClassName(nDeployableId);
 	if (!clsName) return false;
@@ -972,6 +977,9 @@ ATgDeployable* TgProj_Deployable__SpawnDeployable::SpawnDeployableActor(
 	// this list to enumerate live deployables. The native that originally
 	// populated it is stripped — see RegisterDeployableInGRI.
 	RegisterDeployableInGRI(Deployable);
+
+	if (IsForceFieldDeployableId(deployableId))
+		GetForceFieldSet().insert(Deployable);
 
 	// Team-ownership fix (long-standing bug: deployables rendered as enemy
 	// to their own team, repair arm refused to target them).

--- a/src/GameServer/TgGame/TgProj_Deployable/SpawnDeployable/TgProj_Deployable__SpawnDeployable.hpp
+++ b/src/GameServer/TgGame/TgProj_Deployable/SpawnDeployable/TgProj_Deployable__SpawnDeployable.hpp
@@ -159,6 +159,10 @@ public:
 	// fire mode has no prop-154 row or the pawn has no PRI.
 	static void EnforceDeployableLimit(ATgPawn* pawn, ATgDeployable* newDep, UTgDeviceFire* sourceFireMode);
 
+	// Set of currently live ATgDeploy_ForceField actors. Populated at spawn;
+	// stale entries (bDeleteMe) pruned lazily in TargetInLOS.
+	static std::unordered_set<ATgDeployable*>& GetForceFieldSet();
+
 	// Append `dep` to the global `GRI.m_Deployables` list (TgRepInfo_Game's
 	// world-wide deployable registry, replicated to every client). UC's
 	// TgBeaconFactory.uc:58 iterates this list, and the HUD's device-bar

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -253,6 +253,7 @@
 #include "src/GameServer/TgGame/TgMissionObjective/RegisterSelf/TgMissionObjective__RegisterSelf.hpp"
 #include "src/GameServer/TgGame/TgDynamicSMActor/ForceNetRelevant/TgDynamicSMActor__ForceNetRelevant.hpp"
 #include "src/GameServer/TgGame/TgAIController/TargetInLOS/TgAIController__TargetInLOS.hpp"
+#include "src/GameServer/TgGame/TgAIController/LOSTrace/TgAIController__LOSTrace.hpp"
 #include "src/GameServer/TgGame/TgAIController/CanBeRepaired/TgAIController__CanBeRepaired.hpp"
 #include "src/GameServer/TgGame/TgAIController/SpawnPets/TgAIController__SpawnPets.hpp"
 #include "src/GameServer/TgGame/TgAIController/RadioAlarm/TgAIController__RadioAlarm.hpp"
@@ -613,7 +614,8 @@ DWORD WINAPI ModuleThread(LPVOID) {
 	TgPawn__ApplyJetpackTrail::Install();
 	TgPawn__BeginStats::Install();
 	TgPawn__CanMove::Install();
-	// TgAIController__TargetInLOS::Install();
+	// TgAIController__TargetInLOS::Install();   // superseded by LOSTrace
+	TgAIController__LOSTrace::Install();
 	// TgAIController__CanBeRepaired::Install();
 	TgAIController__SpawnPets::Install();
 	TgAIController__RadioAlarm::Install();


### PR DESCRIPTION
Bug: when two robos use dome boost on top of each other, turrets(or drones) inside them stop shooting enemies (and new spawned turrets/drones inside them dont lock onto targets even if in range)

(This is not a new bug, it used to happen on the original game, but seems like it was unintended by Hi-Rez)

Part 1: Turrets lose target when domes spawn around them (fire maintenance)

Hook: TgAIController__TargetInLOS at FUN_10a85510/10a85570

When a turret is already tracking and shooting a target, the engine calls TargetInLOS on every tick to decide whether to keep firing. Internally it runs a recursive LOS trace (FUN_10a806e0) that respects actor collision. ForceField domes have bCollideActors set, so the trace bounces between overlapping domes repeatedly; with 2 domes it ping-pongs until it exceeds the recursion budget and returns "no LOS" — causing the turret to stop firing even though the target is visible.

Fix: Before calling the original TargetInLOS, temporarily clear bCollideActors (bit 0x08000000 at AActor+0xB0) on every live ForceField dome in the set. The trace runs straight through them, gets the correct result, then collision is restored. Dead domes (bDeleteMe) are pruned from the set at the same time.

The TargetInLOS path calls FUN_10a806e0 with depth=0, allowing up to 10 recursions — enough to survive typical 2-dome geometry even without disabling, but not reliably. The explicit disable makes it deterministic regardless of geometry.

---
Part 2: Turrets/drones spawned inside 2+ active domes can't acquire any target

Hook: TgAIController__LOSTrace at FUN_10a806e0 + registration in TgDeviceFire__Deploy

Target acquisition (finding an enemy to lock onto) goes through FindBestEnemy (FUN_10a85300), which calls the same recursive LOS trace — but with depth=10 instead of depth=0. The trace's own recursion limit is depth > 10, meaning it fails after a single dome hit; with 2 overlapping domes it never reaches the target and returns "not visible." This is why newly spawned units inside active domes couldn't acquire any target at all, even though the target was clearly in range.

Fix: Two parts working together:

- Registration: TgDeviceFire__Deploy (the self-spawn path ForceField domes use) inserts each freshly spawned dome into a shared unordered_set<ATgDeployable*> immediately after SpawnActor.
- Hook: TgAIController__LOSTrace hooks FUN_10a806e0 itself — the single recursive trace that all LOS paths share. At top-level entry (s_depth == 0), it disables collision on all registered domes, calls the original trace (which now sees through them), then re-enables collision. A s_depth counter prevents the hook from re-disabling on its own recursive self-calls. Dead domes are pruned from the set during each pass.

Because the hook sits at FUN_10a806e0 — the lowest common point used by both TargetInLOS and FindBestEnemy — it covers all AI LOS paths with a single interception point. FindBestEnemy's depth=10 limit is now irrelevant because the domes are invisible to the trace entirely.

Related to https://discord.com/channels/994691794627461211/1519879389586653244
