### PR TITLE
Allow unequipping all item slots

### DIFF
--- a/src/ControlServer/Loadouts/ArmorLoadouts.hpp
+++ b/src/ControlServer/Loadouts/ArmorLoadouts.hpp
@@ -61,7 +61,7 @@ constexpr int kSlotCount    = 7;
 
 // stock_n in the inventory row equals the variant's index here.
 // kDefaultVariantIndex picks which variant is auto-equipped per slot.
-constexpr int kDefaultVariantIndex = 0;  // [rrrrrr]
+constexpr int kDefaultVariantIndex = kVariantCount;  // "No Armor" sentinel (Common, no buffs)
 
 // EPIC-tier kit egids:
 //   ArmorBallistics::EPIC = 24165  (prop 218 Protection-Ranged   'r')

--- a/src/ControlServer/PlayerSessionStore/PlayerSessionStore.cpp
+++ b/src/ControlServer/PlayerSessionStore/PlayerSessionStore.cpp
@@ -450,6 +450,7 @@ int64_t PlayerSessionStore::InsertCharacter(int64_t user_id, uint32_t profile_id
 	// load in. Without this, fresh characters hit the resubmit loop on the
 	// REST device until disconnect+reconnect.
 	PinClassDeviceSlot14(newId);
+	SeedCharacterArmorDefaults(newId);
 	return newId;
 }
 
@@ -1222,7 +1223,7 @@ void PlayerSessionStore::SeedArmor(int64_t user_id) {
 	//                       class wears the same armor pool)
 	//   device_id      — 0 (armor pieces have no backing device; the
 	//                       Inventory marshal's cosmetic-style path applies)
-	//   quality        — 1162 (Q_EPIC; tier color in the client UI)
+	//   quality        — 1162 (Q_EPIC; matches 6-mod variants)
 	//   mod_effect_group_ids — variant CSV from ArmorLoadouts::kVariants
 	//   oc             — 0
 	//   allowed_slots  — the slot's group-126 SVID as a decimal string
@@ -1275,9 +1276,35 @@ void PlayerSessionStore::SeedArmor(int64_t user_id) {
 	}
 	sqlite3_finalize(stmt);
 
+	// "No Armor" sentinel — one row per slot, stock_n = kVariantCount (5).
+	// Empty mod_effect_group_ids → ParseEgidCsv("") = {} → zero buffs when
+	// applied. Appears in the armor picker alongside the 5 stat variants so
+	// the player can select it to clear a slot. ApplyDefaultArmor handles
+	// the empty-CSV row naturally (zero egids, zero ApplyBuff calls).
+	int insertedNone = 0;
+	sqlite3_stmt* noneStmt = nullptr;
+	const char* kNone =
+		"INSERT OR IGNORE INTO ga_players_inventory"
+		"  (user_id, profile_id, device_id, quality, mod_effect_group_ids, oc, allowed_slots, item_id, stock_n) "
+		"VALUES (?, 0, 0, 1165, '', 0, ?, ?, ?)";
+	if (sqlite3_prepare_v2(db, kNone, -1, &noneStmt, nullptr) == SQLITE_OK) {
+		for (int si = 0; si < ArmorLoadouts::kSlotCount; ++si) {
+			const auto& slot = ArmorLoadouts::kSlots[si];
+			const std::string allowed = std::to_string(slot.slot_value_id);
+			sqlite3_reset(noneStmt);
+			sqlite3_clear_bindings(noneStmt);
+			sqlite3_bind_int64(noneStmt, 1, user_id);
+			sqlite3_bind_text (noneStmt, 2, allowed.c_str(), -1, SQLITE_TRANSIENT);
+			sqlite3_bind_int  (noneStmt, 3, slot.base_item_id);
+			sqlite3_bind_int  (noneStmt, 4, ArmorLoadouts::kVariantCount);
+			if (sqlite3_step(noneStmt) == SQLITE_DONE && sqlite3_changes(db) > 0) ++insertedNone;
+		}
+		sqlite3_finalize(noneStmt);
+	}
+
 	Logger::Log("armor-seed",
-		"SeedArmor: user=%lld inserted=%d (of %d possible — rest already present)\n",
-		(long long)user_id, inserted, ArmorLoadouts::kSlotCount * ArmorLoadouts::kVariantCount);
+		"SeedArmor: user=%lld inserted=%d (of %d possible — rest already present) none=%d\n",
+		(long long)user_id, inserted, ArmorLoadouts::kSlotCount * ArmorLoadouts::kVariantCount, insertedNone);
 }
 
 void PlayerSessionStore::SeedCharacterArmorDefaults(int64_t character_id) {

--- a/src/GameServer/Cosmetics/CosmeticEquip.cpp
+++ b/src/GameServer/Cosmetics/CosmeticEquip.cpp
@@ -407,7 +407,7 @@ bool ApplyToPawn(ATgPawn* Pawn, int64_t character_id, int item_profile_id,
 bool ClearSlot(ATgPawn* Pawn, int64_t character_id, int item_profile_id, int slot) {
 	if (!Pawn) return false;
 	item_profile_id = NormalizeItemProfileId(Pawn, item_profile_id);
-	if (slot != 6 && slot != 12 && (slot < 16 || slot > 20)) return false;
+	if (slot != 6 && slot != 12 && slot != 21 && (slot < 16 || slot > 20)) return false;
 
 	auto* charPawn = (ATgPawn_Character*)Pawn;
 	auto* PRI      = (ATgRepInfo_Player*)Pawn->PlayerReplicationInfo;
@@ -431,6 +431,9 @@ bool ClearSlot(ATgPawn* Pawn, int64_t character_id, int item_profile_id, int slo
 			PRI->r_CustomCharacterAssembly.HelmetMeshId = -1;
 		}
 		dbSlot = CosmeticSlots::kCosmeticHelmetDbSlot;
+	} else if (slot == 21) {
+		charPawn->r_CustomCharacterAssembly.JetpackTrailId = kNoCosmeticItemId;
+		if (PRI) PRI->r_CustomCharacterAssembly.JetpackTrailId = kNoCosmeticItemId;
 	} else {
 		charPawn->r_CustomCharacterAssembly.DyeList[slot - 16] = kNoCosmeticItemId;
 		if (PRI) PRI->r_CustomCharacterAssembly.DyeList[slot - 16] = kNoCosmeticItemId;

--- a/src/GameServer/TgGame/TgPlayerController/ServerAcceptNewProfileFromEquipScreen/TgPlayerController__ServerAcceptNewProfileFromEquipScreen.cpp
+++ b/src/GameServer/TgGame/TgPlayerController/ServerAcceptNewProfileFromEquipScreen/TgPlayerController__ServerAcceptNewProfileFromEquipScreen.cpp
@@ -196,6 +196,44 @@ void __fastcall TgPlayerController__ServerAcceptNewProfileFromEquipScreen::Call(
 		CosmeticEquip::ClearSlot(Pawn, character_id, itemProfileId, 12);
 		clearedCosmeticSlots.insert(12);
 	}
+	if (DeviceArray.SlotIndices[21] == 0) {
+		CosmeticEquip::ClearSlot(Pawn, character_id, itemProfileId, 21);
+		clearedCosmeticSlots.insert(21);
+	}
+	for (int slot = 16; slot <= 20; ++slot) {
+		if (DeviceArray.SlotIndices[slot] == 0) {
+			CosmeticEquip::ClearSlot(Pawn, character_id, itemProfileId, slot);
+			clearedCosmeticSlots.insert(slot);
+		}
+	}
+
+	// Explicit device unequip — visible weapon/offhand/etc slots the player
+	// blanked (SlotIndices[slot]==0). Slot 14 (class device, hidden from the
+	// equip screen) always sends 0 and is excluded from this list.
+	if (character_id != 0) {
+		static const int kClearableDeviceSlots[] = {1, 2, 3, 5, 7, 8, 9, 10, 13};
+		sqlite3_stmt* delDev = nullptr;
+		sqlite3_prepare_v2(db,
+			"DELETE FROM ga_character_devices "
+			"WHERE character_id = ? AND item_profile_id = ? AND equipped_slot = ?",
+			-1, &delDev, nullptr);
+		for (int slot : kClearableDeviceSlots) {
+			if (DeviceArray.SlotIndices[slot] != 0) continue;
+			Inventory::Unequip(Pawn, slot);
+			if (delDev) {
+				sqlite3_reset(delDev);
+				sqlite3_clear_bindings(delDev);
+				sqlite3_bind_int64(delDev, 1, character_id);
+				sqlite3_bind_int  (delDev, 2, itemProfileId);
+				sqlite3_bind_int  (delDev, 3, slot);
+				sqlite3_step(delDev);
+				Logger::Log(GetLogChannel(),
+					"equip-save: cleared device slot %d for char=%lld\n",
+					slot, (long long)character_id);
+			}
+		}
+		if (delDev) sqlite3_finalize(delDev);
+	}
 
 	// Pre-pass: Unequip anything that's being SWAPPED for a different invId.
 	// Without this, `Inventory::Equip` would create a second ATgDevice actor


### PR DESCRIPTION
Changes

Removing helm and suit already works, this adds the option to remove the rest of items/dyes/Jetpack trail

src/GameServer/Cosmetics/CosmeticEquip.cpp
- Extended ClearSlot guard to include slot 21 (jetpack trail)
- Added trail case: clears JetpackTrailId on pawn + PRI

src/GameServer/TgGame/TgPlayerController/ServerAcceptNewProfileFromEquipScreen/TgPlayerController__ServerAcceptNewProfileFromEquipScreen.cpp
- Slot 21 (trail): zero-check → ClearSlot
- Slots 16–20 (dyes): zero-check → ClearSlot per slot
- Slots 1,2,3,5,7,8,9,10,13 (weapons, offhands, boost ): zero-check → Inventory::Unequip + DB DELETE
- Armor block: DELETE all 7 armor rows then INSERT non-zero MiscItems entries; calls Armor::Revert + Armor::Apply for immediate runtime effect

src/ControlServer/PlayerSessionStore/PlayerSessionStore.cpp
- SeedArmor: seeds 5 Epic stat variants (quaor" sentinel (stock_n=5, quality 1165, emptymods, no level requirement) per slot for every user on login
- Character creation: added SeedCharacterArmorDefaults(newId) call so new characters spawn with armor equipped

src/ControlServer/Loadouts/ArmorLoadouts.hpp
- kDefaultVariantIndex changed from 0 ([rrrrrr]) to kVariantCount (5) — new characters spawn wearing the Common white sentinel in all 7 armor slots

---
Tested ✓

- Removing weapons, offhands,jetpack, boost (slots 1,2,3,5,7,8,9,10,13)
- Removing jetpack trail (slot 21)
- Removing dyes (slots 16–20)
- White Common armor appears in armor inventory (rest of epic rrr+rrr nnn+nnn armor options stay)
- New characters spawn with Common white armor instead of empty slots
- Changes save when swapping profile
- Changes save when logging out

Related to https://discord.com/channels/994691794627461211/1520633691716583537
