### PR TITLE
Fix promote to team leader and kick from team

### DIFF
--- a/src/ControlServer/TcpSession/TcpSession.cpp
+++ b/src/ControlServer/TcpSession/TcpSession.cpp
@@ -1743,6 +1743,26 @@ void TcpSession::handle_packet(const uint8_t* data, size_t length) {
 			if (!session_guid_.empty())
 				TeamService::HandleLeave(session_guid_);
 			break;
+		case GA_U::TEAM_KICK: {
+			// C→S: team leader removes a member from the team.
+			// Payload: CHARACTER_ID of the member to kick.
+			Logger::Log("tcp", "[%s] Received: TEAM_KICK [0x%04X]\n", Logger::GetTime(), packet_type);
+			PacketView pkt(data + 6, length - 6);
+			int64_t target_char_id = (int64_t)pkt.Read4B(GA_T::CHARACTER_ID).value_or(0);
+			if (!session_guid_.empty() && target_char_id != 0)
+				TeamService::KickMember(session_guid_, target_char_id);
+			break;
+		}
+		case GA_U::GROUP_SET_LEADER: {
+			// C→S: current leader promotes a team member to leader.
+			// Payload: CHARACTER_ID of the member to promote.
+			Logger::Log("tcp", "[%s] Received: GROUP_SET_LEADER [0x%04X]\n", Logger::GetTime(), packet_type);
+			PacketView pkt(data + 6, length - 6);
+			int64_t target_char_id = (int64_t)pkt.Read4B(GA_T::CHARACTER_ID).value_or(0);
+			if (!session_guid_.empty() && target_char_id != 0)
+				TeamService::PromoteLeader(session_guid_, target_char_id);
+			break;
+		}
 		case GA_U::SEND_PLAYER_SKILLS: {
 			// CGameClient::SendSkillsToServer @ 0x1141fd00 sends this when the player
 			// hits Save on the skill tree. Payload carries a DATA_SET_CHARACTER_SKILLS

--- a/src/ControlServer/TeamService/TeamService.cpp
+++ b/src/ControlServer/TeamService/TeamService.cpp
@@ -356,6 +356,56 @@ void TeamService::HandleLeave(const std::string& session_guid) {
         TcpSession::DeliverTeamSystemMessage(session_guid, MSG_NOT_IN_A_TEAM, "");
 }
 
+void TeamService::PromoteLeader(const std::string& requester_guid, int64_t target_character_id) {
+    if (target_character_id == 0) return;
+
+    uint64_t team_id = 0;
+    std::string new_leader_name;
+    std::vector<std::string> member_guids;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        Team* team = FindTeamByMemberLocked(requester_guid);
+        if (!team || team->leader_guid != requester_guid) return;
+
+        auto it = std::find_if(team->members.begin(), team->members.end(),
+            [&](const TeamMember& m) { return m.character_id == target_character_id; });
+        if (it == team->members.end()) return;
+        if (it->session_guid == requester_guid) return;  // already leader
+
+        team->leader_guid = it->session_guid;
+        new_leader_name   = it->player_name;
+        team_id = team->id;
+        for (const auto& m : team->members) member_guids.push_back(m.session_guid);
+    }
+
+    Logger::Log("team", "[team] leader promoted to %s in team #%llu\n",
+        new_leader_name.c_str(), (unsigned long long)team_id);
+
+    for (const auto& guid : member_guids)
+        TcpSession::DeliverTeamSystemMessage(guid, MSG_NEW_LEADER, new_leader_name);
+    BroadcastRoster(team_id);
+}
+
+void TeamService::KickMember(const std::string& requester_guid, int64_t target_character_id) {
+    if (target_character_id == 0) return;
+
+    std::string target_guid;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        Team* team = FindTeamByMemberLocked(requester_guid);
+        if (!team || team->leader_guid != requester_guid) return;
+
+        auto it = std::find_if(team->members.begin(), team->members.end(),
+            [&](const TeamMember& m) { return m.character_id == target_character_id; });
+        if (it == team->members.end()) return;
+        if (it->session_guid == requester_guid) return;  // can't kick yourself
+
+        target_guid = it->session_guid;
+    }
+
+    LeaveCurrentTeam(target_guid);
+}
+
 bool TeamService::LeaveCurrentTeam(const std::string& session_guid) {
     // Composition change: dequeue the whole team (if queued) before mutating.
     DequeueForCompositionChange(session_guid);

--- a/src/ControlServer/TeamService/TeamService.hpp
+++ b/src/ControlServer/TeamService/TeamService.hpp
@@ -83,6 +83,14 @@ public:
     // leave the current team (promote/disband as needed).
     static void HandleLeave(const std::string& session_guid);
 
+    // GROUP_SET_LEADER (0x0054): promote target_character_id to team leader.
+    // Caller must be the current leader; no-ops if conditions aren't met.
+    static void PromoteLeader(const std::string& requester_guid, int64_t target_character_id);
+
+    // TEAM_KICK (0x004E): remove target_character_id from the team.
+    // Caller must be the current leader; no-ops if conditions aren't met.
+    static void KickMember(const std::string& requester_guid, int64_t target_character_id);
+
     static bool IsTeamed(const std::string& session_guid);
     static bool IsLeader(const std::string& session_guid);
 


### PR DESCRIPTION
Bug: Two team management actions — "Promote to Team Leader" and "Remove" — did nothing when clicked. Both UI buttons triggered native client functions that sent TCP packets the server had no handler for, so they were silently dropped.

Root cause (found via Ghidra):
- "Promote to Team Leader" → client sends GROUP_SET_LEADER (0x0054) with CHARACTER_ID of the target (FUN_1092ac20 in client binary)
- "Remove" → client sends TEAM_KICK (0x004E) with CHARACTER_ID of the target (FUN_1092aaf0)

Neither code had a case in TcpSession.cpp.

Fixes:
- Added case GA_U::GROUP_SET_LEADER and case GA_U::TEAM_KICK handlers in TcpSession.cpp
- Added TeamService::PromoteLeader — validates caller is leader, swaps leader_guid, broadcasts MSG_NEW_LEADER + updated roster to all members
- Added TeamService::KickMember — validates caller is leader, resolves target's session, delegates to existing LeaveCurrentTeam (handles empty-roster to kication, disband if needed, rosterrebroadcast)

Related to: https://discord.com/channels/994691794627461211/1521266430496997506