### PR TITLE
Cosmetics fix: character select, profile swap changes helm correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,8 @@ SOURCE_FILES= \
 			  $(SRC_DIR)/GameServer/TgGame/TgInventoryManager/NonPersistRemoveDevice/TgInventoryManager__NonPersistRemoveDevice.cpp \
 			  $(SRC_DIR)/GameServer/Inventory/Inventory.cpp \
 			  $(SRC_DIR)/GameServer/Cosmetics/CosmeticEquip.cpp \
+			  $(SRC_DIR)/GameServer/Cosmetics/JetpackReload.cpp \
+			  $(SRC_DIR)/GameServer/Cosmetics/SuitRebuildKick.cpp \
 			  $(SRC_DIR)/GameServer/Armor/Armor.cpp \
 			  $(SRC_DIR)/GameServer/Constants/DeviceIds.cpp \
 			  $(SRC_DIR)/GameServer/Engine/Actor/GetOptimizedRepList/Actor__GetOptimizedRepListV2.cpp \

--- a/src/ControlServer/PlayerSessionStore/PlayerSessionStore.cpp
+++ b/src/ControlServer/PlayerSessionStore/PlayerSessionStore.cpp
@@ -461,7 +461,7 @@ std::vector<CharacterInfo> PlayerSessionStore::GetCharactersByUserId(int64_t use
 	sqlite3_stmt* stmt = nullptr;
 	int rc = sqlite3_prepare_v2(db,
 		"SELECT id, profile_id, head_asm_id, gender_type_value_id, morph_data, "
-		"       hair_asm_id, skin_mat_param_id, eye_mat_param_id "
+		"       hair_asm_id, skin_mat_param_id, eye_mat_param_id, current_item_profile_id "
 		"FROM ga_characters WHERE user_id = ?",
 		-1, &stmt, nullptr);
 	if (rc != SQLITE_OK || !stmt) {
@@ -482,9 +482,10 @@ std::vector<CharacterInfo> PlayerSessionStore::GetCharactersByUserId(int64_t use
 		if (blob && bytes > 0)
 			c.morph_data.assign(static_cast<const uint8_t*>(blob),
 			                    static_cast<const uint8_t*>(blob) + bytes);
-		c.hair_asm_id          = static_cast<uint32_t>(sqlite3_column_int(stmt, 5));
-		c.skin_mat_param_id    = static_cast<uint32_t>(sqlite3_column_int(stmt, 6));
-		c.eye_mat_param_id     = static_cast<uint32_t>(sqlite3_column_int(stmt, 7));
+		c.hair_asm_id              = static_cast<uint32_t>(sqlite3_column_int(stmt, 5));
+		c.skin_mat_param_id        = static_cast<uint32_t>(sqlite3_column_int(stmt, 6));
+		c.eye_mat_param_id         = static_cast<uint32_t>(sqlite3_column_int(stmt, 7));
+		c.current_item_profile_id  = sqlite3_column_int(stmt, 8);
 		result.push_back(std::move(c));
 	}
 	sqlite3_finalize(stmt);

--- a/src/ControlServer/PlayerSessionStore/PlayerSessionStore.hpp
+++ b/src/ControlServer/PlayerSessionStore/PlayerSessionStore.hpp
@@ -26,10 +26,8 @@ struct CharacterInfo {
     uint32_t head_asm_id = 0;
     uint32_t gender_type_value_id = 0;
     std::vector<uint8_t> morph_data;
-    // Appearance fields the head-menu collects but pre-v81 used to throw
-    // away. Skin/eye material parameter ids are stored for completeness;
-    // not yet emitted in GSC_CHARACTER_LIST (the lobby card protocol only
-    // ships hair) — kept available for future spawn-time application.
+    // Appearance fields from ga_characters. skin_mat_param_id and
+    // eye_mat_param_id are sent in GSC_CHARACTER_LIST per-character block.
     //
     // hair_asm_id default 1974 = "NewHair15" (asm_mesh_type_value_id=850),
     // the in-game pawn hair category — same asm SpawnBotPawn sets on bots.
@@ -39,6 +37,7 @@ struct CharacterInfo {
     uint32_t hair_asm_id = 1974;
     uint32_t skin_mat_param_id = 0;
     uint32_t eye_mat_param_id = 0;
+    int current_item_profile_id = 1;  // last-active loadout slot (1..5)
 };
 
 struct DeviceRow {

--- a/src/ControlServer/TcpSession/TcpSession.cpp
+++ b/src/ControlServer/TcpSession/TcpSession.cpp
@@ -3412,6 +3412,17 @@ void TcpSession::send_character_list_response()
 {
 	auto characters = PlayerSessionStore::GetCharactersByUserId(user_id_);
 
+	// Collect equipped cosmetics (helmet, suit, dyes, trail) for all characters.
+	struct CosmeticEntry { uint32_t char_id; int item_id; int slot_value_id; };
+	std::vector<CosmeticEntry> cosmetics;
+	for (const auto& c : characters) {
+		auto devices = PlayerSessionStore::GetDevicesForCharacter(c.id, c.current_item_profile_id);
+		for (const auto& d : devices) {
+			if (d.item_id > 0)
+				cosmetics.push_back({ static_cast<uint32_t>(c.id), d.item_id, d.slot_value_id });
+		}
+	}
+
 	std::vector<uint8_t> response;
 
 	uint16_t packet_type = GA_U::GSC_CHARACTER_LIST;
@@ -3427,23 +3438,32 @@ void TcpSession::send_character_list_response()
 	                 static_cast<uint8_t>(characters.size() >> 8));
 
 	for (const auto& c : characters) {
-		append(response, 0x0C, 0x00);  // inner item count = 12
-		Write4B(response, GA_T::CHARACTER_ID,           static_cast<uint32_t>(c.id));
-		Write4B(response, GA_T::CHARACTER_LEVEL,        0x32);
-		Write4B(response, GA_T::CURRENT_LEVEL,          0x32);
-		Write4B(response, GA_T::FORCED_CHARACTER_LEVEL, 0x32);
-		Write4B(response, GA_T::PROFILE_ID,             c.profile_id);
-		Write4B(response, GA_T::CLASS_TYPE_VALUE_ID,    GetClassConfig(c.profile_id).classTypeValueId);
-		Write4B(response, GA_T::HEAD_ASM_ID,            c.head_asm_id);
-		Write4B(response, GA_T::HAIR_ASM_ID,            0x85D);
-		Write4B(response, GA_T::GENDER_TYPE_VALUE_ID,   c.gender_type_value_id);
-		WriteString(response, GA_T::MAP_NAME,           "Scramble: Tetra Pier");
-		Write4B(response, GA_T::XP_VALUE,               0xbbddc);
-		Write4B(response, GA_T::SKILL_GROUP_SET_ID,     GetClassConfig(c.profile_id).skillGroupSetId);
+		append(response, 0x0E, 0x00);  // inner item count = 14
+		Write4B(response, GA_T::CHARACTER_ID,               static_cast<uint32_t>(c.id));
+		Write4B(response, GA_T::CHARACTER_LEVEL,            0x32);
+		Write4B(response, GA_T::CURRENT_LEVEL,              0x32);
+		Write4B(response, GA_T::FORCED_CHARACTER_LEVEL,     0x32);
+		Write4B(response, GA_T::PROFILE_ID,                 c.profile_id);
+		Write4B(response, GA_T::CLASS_TYPE_VALUE_ID,        GetClassConfig(c.profile_id).classTypeValueId);
+		Write4B(response, GA_T::HEAD_ASM_ID,                c.head_asm_id);
+		Write4B(response, GA_T::HAIR_ASM_ID,                c.hair_asm_id);
+		Write4B(response, GA_T::GENDER_TYPE_VALUE_ID,       c.gender_type_value_id);
+		WriteString(response, GA_T::MAP_NAME,               "Scramble: Tetra Pier");
+		Write4B(response, GA_T::XP_VALUE,                   0xbbddc);
+		Write4B(response, GA_T::SKILL_GROUP_SET_ID,         GetClassConfig(c.profile_id).skillGroupSetId);
+		Write4B(response, GA_T::SKIN_MATERIAL_PARAMETER_ID, c.skin_mat_param_id);
+		Write4B(response, GA_T::EYE_MATERIAL_PARAMETER_ID,  c.eye_mat_param_id);
 	}
 
 	append(response, GA_T::DATA_SET_PLAYER_INVENTORY & 0xFF, GA_T::DATA_SET_PLAYER_INVENTORY >> 8);
-	append(response, 0x00, 0x00);  // count elements
+	append(response, static_cast<uint8_t>(cosmetics.size() & 0xFF),
+	                 static_cast<uint8_t>(cosmetics.size() >> 8));
+	for (const auto& entry : cosmetics) {
+		append(response, 0x03, 0x00);  // 3 fields per record: CHARACTER_ID, ITEM_ID, EQUIPPED_SLOT_VALUE_ID
+		Write4B(response, GA_T::CHARACTER_ID,           entry.char_id);
+		Write4B(response, GA_T::ITEM_ID,                static_cast<uint32_t>(entry.item_id));
+		Write4B(response, GA_T::EQUIPPED_SLOT_VALUE_ID, static_cast<uint32_t>(entry.slot_value_id));
+	}
 
 	send_response(response);
 }

--- a/src/ControlServer/TcpSession/TcpSession.cpp
+++ b/src/ControlServer/TcpSession/TcpSession.cpp
@@ -544,31 +544,6 @@ void TcpSession::DeliverGameEvent(const std::string& session_guid, const nlohman
             if (instance_id != 0) {
                 const uint64_t refresh_token = ++session->profile_refresh_token_;
                 SendProfileUiRefresh(instance_id, session_guid, item_profile_id, refresh_token, "immediate");
-
-                auto timer = std::make_shared<asio::steady_timer>(session->io_ctx_);
-                std::weak_ptr<TcpSession> weak_session = session;
-                // Keep the clear frame visible long enough to avoid client-side coalescing.
-                timer->expires_after(std::chrono::milliseconds(500));
-                timer->async_wait([timer, weak_session, instance_id, session_guid, item_profile_id, refresh_token](std::error_code ec) {
-                    if (ec) {
-                        return;
-                    }
-                    auto s = weak_session.lock();
-                    if (!s) {
-                        return;
-                    }
-                    if (s->profile_refresh_token_ != refresh_token) {
-                        Logger::Log("loadout",
-                            "[TcpSession] profile_switch delayed refresh skipped stale token=%llu current=%llu guid=%s itemProf=%d\n",
-                            (unsigned long long)refresh_token,
-                            (unsigned long long)s->profile_refresh_token_,
-                            session_guid.c_str(), item_profile_id);
-                        return;
-                    }
-                    s->item_profile_id_ = item_profile_id;
-                    s->send_player_skills_response();
-                    SendProfileUiRefresh(instance_id, session_guid, item_profile_id, refresh_token, "delayed");
-                });
             }
         }
     }

--- a/src/GameServer/Cosmetics/JetpackReload.cpp
+++ b/src/GameServer/Cosmetics/JetpackReload.cpp
@@ -1,0 +1,30 @@
+#include "src/GameServer/Cosmetics/JetpackReload.hpp"
+#include "src/Utils/Logger/Logger.hpp"
+
+namespace {
+
+constexpr int kJetpackSlot = 5;  // SVID_JETPACK engine equip point (ES5 Travel)
+
+}  // namespace
+
+void JetpackReload::MarkJetpackFormDirty(ATgPawn* Pawn) {
+	if (Pawn == nullptr) return;
+	ATgDevice* jet = Pawn->m_EquippedDevices[kJetpackSlot];
+	if (jet == nullptr) return;  // no jetpack equipped
+
+	// Epoch in bits 24..26, cycling 1..7 so the value is always nonzero,
+	// always != the real invId, and always != the previous fake value.
+	static int g_epoch = 0;
+	const int fakeId = jet->r_nDeviceInstanceId | (((g_epoch % 7) + 1) << 24);
+	++g_epoch;
+
+	Pawn->r_EquipDeviceInfo[kJetpackSlot].nDeviceId         = jet->r_nDeviceId;
+	Pawn->r_EquipDeviceInfo[kJetpackSlot].nDeviceInstanceId = fakeId;
+	Pawn->r_EquipDeviceInfo[kJetpackSlot].nQualityValueId   = jet->r_nQualityValueId;
+	Pawn->bNetDirty       = 1;
+	Pawn->bForceNetUpdate = 1;
+
+	Logger::Log("loadout",
+		"[JetpackReload] slot 5 instance id %d -> %d (dev=%d) — owner form rebuild on next DeviceFormChanged\n",
+		jet->r_nDeviceInstanceId, fakeId, jet->r_nDeviceId);
+}

--- a/src/GameServer/Cosmetics/JetpackReload.hpp
+++ b/src/GameServer/Cosmetics/JetpackReload.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "src/pch.hpp"
+
+// ── Owner-side jetpack/backpack re-dye on profile switch ─────────────────────
+//
+// The persistent backpack mesh (TgPawn_Character.c_BackpackMesh) is built from
+// the slot-5 jetpack device's form. On a profile switch the owner rebuilds via
+// the r_CustomCharacterAssembly repnotify → ApplyPawnSetup → … →
+// OnWaitingForPawnDone → DeviceFormChanged(false) (TgPawn.uc:6711). The
+// non-forced reload only rebuilds forms whose cached
+// c_EquipDeviceInfo.nDeviceInstanceId differs from the pawn's replicated
+// r_EquipDeviceInfo[slot] (compare per DoubleCheckSimulatedProxy,
+// TgPawn.uc:8953) — and the jetpack keeps the same inventory id across
+// profiles, so its form (and the backpack MIC's baked dye) survives. Observers
+// are unaffected: sim proxies get DeviceFormChanged(true) in PostPawnSetup.
+//
+// Note: TgPawn.ReplicatedEvent has NO case for r_EquipDeviceInfo (despite the
+// repnotify declaration) — deltas apply silently. A transient blip therefore
+// triggers nothing on the owner; the mismatch must still be present when the
+// owner's own post-rebuild DeviceFormChanged(false) runs. So: write a fresh
+// epoch into the high bits of the replicated slot-5 instance id and leave it
+// there. The device ACTOR keeps the real invId (inventory recovery matches
+// actor ids, not this array), and the PRI's separate r_EquipDeviceInfo (UI)
+// is untouched. Native UpdateClientDevices may later rewrite the slot from
+// the device — silent on the client, benign.
+namespace JetpackReload {
+
+// Give the pawn's replicated slot-5 descriptor a fresh instance id so the
+// owner's next DeviceFormChanged(false) rebuilds (and re-dyes) the jetpack
+// form. Call after all native equip paths have run for the switch.
+void MarkJetpackFormDirty(ATgPawn* Pawn);
+
+}  // namespace JetpackReload

--- a/src/GameServer/Cosmetics/SuitRebuildKick.cpp
+++ b/src/GameServer/Cosmetics/SuitRebuildKick.cpp
@@ -1,0 +1,66 @@
+#include "src/GameServer/Cosmetics/SuitRebuildKick.hpp"
+#include "src/GameServer/Storage/PawnSessions/PawnSessions.hpp"
+#include "src/Utils/Logger/Logger.hpp"
+
+#include <vector>
+
+namespace {
+
+constexpr float kKickDelaySeconds = 2.0f;  // async preloads from the switch settle well within this
+
+struct Pending {
+	ATgPawn* pawn;
+	int      pawnId;      // second factor for the stale-pointer guard
+	float    remaining;   // countdown to the kick
+};
+
+std::vector<Pending> g_pending;
+
+}  // namespace
+
+void SuitRebuildKick::Schedule(ATgPawn* Pawn) {
+	if (Pawn == nullptr) return;
+	for (Pending& p : g_pending) {
+		if (p.pawn == Pawn && p.pawnId == Pawn->r_nPawnId) {
+			p.remaining = kKickDelaySeconds;
+			return;
+		}
+	}
+	g_pending.push_back(Pending{Pawn, Pawn->r_nPawnId, kKickDelaySeconds});
+}
+
+void SuitRebuildKick::Tick(float DeltaSeconds) {
+	if (g_pending.empty()) return;
+
+	for (size_t i = 0; i < g_pending.size();) {
+		Pending& p = g_pending[i];
+		auto it = GPawnSessions.find(p.pawn);
+		if (it == GPawnSessions.end() || p.pawn->r_nPawnId != p.pawnId) {
+			Logger::Log("loadout", "[SuitRebuildKick] pawn=%d gone — dropped\n", p.pawnId);
+			g_pending.erase(g_pending.begin() + i);
+			continue;
+		}
+		p.remaining -= DeltaSeconds;
+		if (p.remaining > 0.0f) { ++i; continue; }
+
+		// Persistent alternating sentinel, NOT a blip: replication 'recent'
+		// state is per actor channel, so a one-tick flip+restore coalesces to
+		// no delta on any connection whose channel skipped that frame — the
+		// owner (every-frame channel) healed while observers missed the kick
+		// entirely (out/logs/278: server assembly correct, owner correct,
+		// observer stuck on class-default suit). A permanent -1↔-2 toggle
+		// yields exactly one delta per connection whenever its channel next
+		// updates. Harmless: player pawns hold 0 here anyway (invalid id →
+		// FireSockets null-model fallback is already their steady state) and
+		// custom characters ignore the value visually (GetBodyMeshId returns
+		// the suit id, TgPawn_Character.uc:369).
+		const int sentinel = (p.pawn->r_nBodyMeshAsmId == -1) ? -2 : -1;
+		p.pawn->r_nBodyMeshAsmId = sentinel;
+		p.pawn->bNetDirty        = 1;
+		p.pawn->bForceNetUpdate  = 1;
+		Logger::Log("loadout",
+			"[SuitRebuildKick] r_nBodyMeshAsmId -> %d pawn=%d — rebuild kicked on all clients\n",
+			sentinel, p.pawnId);
+		g_pending.erase(g_pending.begin() + i);
+	}
+}

--- a/src/GameServer/Cosmetics/SuitRebuildKick.hpp
+++ b/src/GameServer/Cosmetics/SuitRebuildKick.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "src/pch.hpp"
+
+// ── Deferred owner-side rebuild kick after profile switch ────────────────────
+//
+// The client applies suit/helmet/hair meshes in native ApplyPawnSetup →
+// FUN_109d1860 → GDataStore mesh-apply (0x109a6370 → 0x109a55b0). The apply is
+// a SYNCHRONOUS StaticLoadObject by name with no retry: if the load returns
+// null (which happens under -seekfreeloading when the same package is still
+// queued in the async loader from the PREVIOUS switch's UpdateCharacterAssetRefs
+// preload), it logs "Unable to load custom character suit mesh %d" and skips —
+// the component keeps the old mesh while dyes (same ApplyPawnSetup pass, no
+// asset load needed) apply fine. Observed ~1 in 50 rapid switches.
+//
+// Recovery is inherent in the same code: the apply short-circuits when the
+// component's cached asm id (+0x4e8) equals the target row id, and reloads
+// when they differ. So ANY later ApplyPawnSetup heals a failed apply and
+// visually no-ops on a successful one.
+//
+// Trigger: r_nBodyMeshAsmId repnotify (TgPawn.uc:5789) runs ApplyPawnSetup +
+// WaitForInventoryThenDoPostPawnSetup on every client, ungated by role. For
+// custom characters the VALUE is ignored (GetBodyMeshId returns the suit id,
+// TgPawn_Character.uc:369). The live rep list (Actor__GetOptimizedRepList, V1)
+// delta-replicates it via NEQ against per-channel 'recent' state — so the kick
+// writes a PERSISTENT alternating sentinel (-1↔-2) rather than a transient
+// blip; a one-tick flip+restore coalesced to nothing on observer channels that
+// skipped the frame (out/logs/278). Server-side, FireSockets reads the field
+// for fire-socket lookups: player pawns hold 0 (invalid) there anyway, so the
+// sentinel takes the same null-model fallback as steady state.
+namespace SuitRebuildKick {
+
+// Schedule a rebuild kick ~2s after a profile switch. Re-scheduling for the
+// same pawn restarts the timer (rapid switches coalesce into one kick).
+void Schedule(ATgPawn* Pawn);
+
+// Drive pending kicks. Call once per server frame (GameEngine::Tick).
+void Tick(float DeltaSeconds);
+
+}  // namespace SuitRebuildKick

--- a/src/GameServer/Engine/GameEngine/Tick/GameEngine__Tick.cpp
+++ b/src/GameServer/Engine/GameEngine/Tick/GameEngine__Tick.cpp
@@ -6,6 +6,7 @@
 #include "src/GameServer/Stats/MatchStats.hpp"
 #include "src/GameServer/Engine/KismetWebDump/KismetWebDump.hpp"
 #include "src/GameServer/TgGame/MissionVODirector/MissionVODirector.hpp"
+#include "src/GameServer/Cosmetics/SuitRebuildKick.hpp"
 
 void __fastcall GameEngine__Tick::Call(void* Engine, void* edx, float DeltaSeconds) {
 	IpcClient::DrainInbound();
@@ -29,5 +30,7 @@ void __fastcall GameEngine__Tick::Call(void* Engine, void* edx, float DeltaSecon
 	// (Bancroft_HalfwayPoint/_30sRemaining/_10sRemaining) off the round timer.
 	// Self-gates on map name + Defense round state; no-op elsewhere.
 	MissionVODirector::Tick(DeltaSeconds);
+	// Deferred post-profile-switch rebuild kick (suit-mesh load-race recovery).
+	SuitRebuildKick::Tick(DeltaSeconds);
 	CallOriginal(Engine, edx, DeltaSeconds);
 }

--- a/src/GameServer/TgGame/TgPlayerController/ServerAcceptNewProfileFromEquipScreen/TgPlayerController__ServerAcceptNewProfileFromEquipScreen.cpp
+++ b/src/GameServer/TgGame/TgPlayerController/ServerAcceptNewProfileFromEquipScreen/TgPlayerController__ServerAcceptNewProfileFromEquipScreen.cpp
@@ -104,10 +104,18 @@ void __fastcall TgPlayerController__ServerAcceptNewProfileFromEquipScreen::Call(
 	PlayerInfo* info = PlayerRegistry::GetByGuidPtr(it->second);
 	const int64_t character_id = info ? info->selected_character_id : 0;
 	const int64_t user_id      = info ? info->user_id : 0;
-	int itemProfileId = nProfileId;
-	if (itemProfileId < 1 || itemProfileId > 5) {
-		itemProfileId = ((ATgPawn_Character*)Pawn)->r_nItemProfileId;
-		if (itemProfileId < 1 || itemProfileId > 5) itemProfileId = 1;
+	// Always use the server-authoritative active profile, not the client-supplied
+	// nProfileId. Profile switches are server-side (ServerLoadItemProfile), so
+	// the equip screen is always for r_nItemProfileId. When the client sends a
+	// different nProfileId — e.g. when two profiles share the same helm cosmetic
+	// and the client fires a stale save with the previously-edited profile number —
+	// trusting it overwrites the wrong profile's ga_character_devices rows.
+	const int serverProfileId = ((ATgPawn_Character*)Pawn)->r_nItemProfileId;
+	int itemProfileId = (serverProfileId >= 1 && serverProfileId <= 5) ? serverProfileId : 1;
+	if (nProfileId != itemProfileId) {
+		Logger::Log(GetLogChannel(),
+			"equip-save: client nProfileId=%d != server r_nItemProfileId=%d — using server value\n",
+			nProfileId, itemProfileId);
 	}
 
 	// Engine-side re-equip. The original `ServerAcceptNewProfileFromEquipScreen`
@@ -336,9 +344,6 @@ void __fastcall TgPlayerController__ServerAcceptNewProfileFromEquipScreen::Call(
 		}
 
 		if (anyArmorMisc) {
-			// Profile-scoped: this RPC names its target loadout via nProfileId.
-			// Only that profile's armor rows are replaced — other profiles
-			// keep their armor untouched.
 			sqlite3_stmt* delA = nullptr;
 			if (sqlite3_prepare_v2(db,
 			    "DELETE FROM ga_character_devices "
@@ -346,7 +351,7 @@ void __fastcall TgPlayerController__ServerAcceptNewProfileFromEquipScreen::Call(
 			    "  AND equipped_slot IN (1130, 1132, 1133, 1136, 1139, 1142, 1143)",
 			    -1, &delA, nullptr) == SQLITE_OK) {
 				sqlite3_bind_int64(delA, 1, character_id);
-				sqlite3_bind_int  (delA, 2, nProfileId);
+				sqlite3_bind_int  (delA, 2, itemProfileId);
 				sqlite3_step(delA);
 				sqlite3_finalize(delA);
 			}
@@ -372,7 +377,7 @@ void __fastcall TgPlayerController__ServerAcceptNewProfileFromEquipScreen::Call(
 					sqlite3_reset(insA);
 					sqlite3_clear_bindings(insA);
 					sqlite3_bind_int64(insA, 1, character_id);
-					sqlite3_bind_int  (insA, 2, nProfileId);
+					sqlite3_bind_int  (insA, 2, itemProfileId);
 					sqlite3_bind_int  (insA, 3, invId);
 					sqlite3_bind_int  (insA, 4, armorSvid);
 					if (sqlite3_step(insA) == SQLITE_DONE) ++wroteArmor;
@@ -380,7 +385,7 @@ void __fastcall TgPlayerController__ServerAcceptNewProfileFromEquipScreen::Call(
 				sqlite3_finalize(insA);
 				Logger::Log(GetLogChannel(),
 					"equip-save: armor local-DB updated itemProf=%d, %d slot(s); refreshing buffs\n",
-					nProfileId, wroteArmor);
+					itemProfileId, wroteArmor);
 			}
 
 			// Reverse the previous armor's buff entries (recorded per-pawn in
@@ -399,7 +404,7 @@ void __fastcall TgPlayerController__ServerAcceptNewProfileFromEquipScreen::Call(
 	ev["session_guid"]            = it->second;
 	ev["pawn_id"]                 = (int)Pawn->r_nPawnId;
 	ev["character_id"]            = character_id;
-	ev["loadout_profile"]         = nProfileId;
+	ev["loadout_profile"]         = itemProfileId;
 	ev["slot_to_inventory"]       = std::move(slotMap);
 	ev["misc_items"]              = std::move(miscMap);  // armor / unknown-Misc-tab data
 	ev["cleared_cosmetic_slots"]  = nlohmann::json(clearedCosmeticSlots);
@@ -407,7 +412,7 @@ void __fastcall TgPlayerController__ServerAcceptNewProfileFromEquipScreen::Call(
 
 	Logger::Log(GetLogChannel(),
 		"equip-save: forwarded loadout=%d slots=%d/24 misc=%d/25 cleared=%zu pawn=%p guid=%s\n",
-		nProfileId, slotPopulated, miscPopulated, clearedCosmeticSlots.size(),
+		itemProfileId, slotPopulated, miscPopulated, clearedCosmeticSlots.size(),
 		(void*)Pawn, it->second.c_str());
 
 	LogCallEnd();

--- a/src/GameServer/TgGame/TgPlayerController/ServerLoadItemProfile/TgPlayerController__ServerLoadItemProfile.cpp
+++ b/src/GameServer/TgGame/TgPlayerController/ServerLoadItemProfile/TgPlayerController__ServerLoadItemProfile.cpp
@@ -1,6 +1,8 @@
 #include "src/GameServer/TgGame/TgPlayerController/ServerLoadItemProfile/TgPlayerController__ServerLoadItemProfile.hpp"
 #include "src/GameServer/Armor/Armor.hpp"
 #include "src/GameServer/Cosmetics/CosmeticEquip.hpp"
+#include "src/GameServer/Cosmetics/JetpackReload.hpp"
+#include "src/GameServer/Cosmetics/SuitRebuildKick.hpp"
 #include "src/GameServer/Inventory/Inventory.hpp"
 #include "src/GameServer/Storage/PawnSessions/PawnSessions.hpp"
 #include "src/GameServer/Storage/PlayerRegistry/PlayerRegistry.hpp"
@@ -281,6 +283,22 @@ void __fastcall TgPlayerController__ServerLoadItemProfile::Call(
     // the listen-server local pawn — call OnCustomAssemblyChanged directly to
     // trigger ApplyPawnSetup (helmet/suit mesh swap, body dyes).
     ((ATgPawn_Character*)Pawn)->eventOnCustomAssemblyChanged();
+
+    // The owner's rebuild ends in DeviceFormChanged(false) (TgPawn.uc:6711),
+    // which only rebuilds forms whose replicated instance id changed — the
+    // jetpack reuses the same invId across profiles, so its form (and the
+    // backpack's baked dye) survives. Bump the slot-5 replicated instance id
+    // so that reload rebuilds + re-dyes it. Must run after CallOriginal /
+    // Inventory::Finalize (UpdateClientDevices would rewrite the slot from
+    // the device). See JetpackReload.hpp.
+    JetpackReload::MarkJetpackFormDirty((ATgPawn*)Pawn);
+
+    // The client's suit-mesh apply is a one-shot synchronous load that can fail
+    // (and silently skip) when the previous switch's async preload still has the
+    // package queued — dyes apply, meshes stay old (~1/50 rapid switches).
+    // Schedule a deferred rebuild kick; it heals a failed apply and visually
+    // no-ops on a successful one. See SuitRebuildKick.hpp.
+    SuitRebuildKick::Schedule((ATgPawn*)Pawn);
 
     // The control server sends ClientResetEquipScreen after its TCP refresh.
     // Firing it here can rebuild the open skill UI before new rows arrive.

--- a/src/GameServer/TgGame/TgPlayerController/ServerLoadItemProfile/TgPlayerController__ServerLoadItemProfile.cpp
+++ b/src/GameServer/TgGame/TgPlayerController/ServerLoadItemProfile/TgPlayerController__ServerLoadItemProfile.cpp
@@ -294,21 +294,19 @@ void __fastcall TgPlayerController__ServerLoadItemProfile::Call(
     // ── Step 4: RCST does the armor + skill revert+apply atomically ──────
     TgPawn_Character__ReapplyCharacterSkillTree::Call(Pawn, nullptr);
 
-    // ── Step 5: Run native before the control-server UI refresh packet.
-    // Native owns client profile button state; refreshing earlier races it.
+    // ── Step 5: Load cosmetics, then prime s_OrigCustomCharacterAssembly so
+    // the native's own reset restores the NEW profile's assembly (not spawn-time).
+    // This lets CallOriginal do the one-step visual refresh the original server did,
+    // with no intermediate zeroed state and no pulse race.
+    CosmeticEquip::LoadFromDB((ATgPawn*)Pawn, character_id, nId);
+    ((ATgPawn_Character*)Pawn)->s_OrigCustomCharacterAssembly =
+        ((ATgPawn_Character*)Pawn)->r_CustomCharacterAssembly;
+
     Logger::Log("loadout",
         "[ServerLoadItemProfile] pre-CallOriginal\n");
     CallOriginal(Controller, edx, nId);
     Logger::Log("loadout",
         "[ServerLoadItemProfile] post-CallOriginal\n");
-
-    // ── Step 5b: Re-apply cosmetics AFTER the native runs.
-    // The native ServerLoadItemProfile can reset r_CustomCharacterAssembly from
-    // s_OrigCustomCharacterAssembly (the spawn-time assembly), which may still
-    // carry the previous profile's helm. LoadFromDB here overwrites that reset
-    // so BeginProfileAssemblyPulse (triggered by the IPC response below)
-    // captures the correct new-profile assembly.
-    CosmeticEquip::LoadFromDB((ATgPawn*)Pawn, character_id, nId);
 
     // The control server sends ClientResetEquipScreen after its TCP refresh.
     // Firing it here can rebuild the open skill UI before new rows arrive.

--- a/src/GameServer/TgGame/TgPlayerController/ServerLoadItemProfile/TgPlayerController__ServerLoadItemProfile.cpp
+++ b/src/GameServer/TgGame/TgPlayerController/ServerLoadItemProfile/TgPlayerController__ServerLoadItemProfile.cpp
@@ -13,40 +13,21 @@
 #include "lib/sqlite3/sqlite3.h"
 #include <cstdlib>
 
-static int LookupGameplayInvIdForSlot(sqlite3* db, int64_t character_id, int item_profile_id, int slot) {
-    if (!db) return 0;
-    sqlite3_stmt* st = nullptr;
-    int invId = 0;
-    if (sqlite3_prepare_v2(db,
-        "SELECT MIN(pi.id) "
-        "FROM ga_character_devices cd "
-        "JOIN ga_players_inventory pi ON pi.id = cd.inventory_id "
-        "WHERE cd.character_id = ? AND cd.item_profile_id = ? "
-        "  AND cd.equipped_slot = ? AND pi.device_id > 0",
-        -1, &st, nullptr) == SQLITE_OK && st) {
-        sqlite3_bind_int64(st, 1, character_id);
-        sqlite3_bind_int  (st, 2, item_profile_id);
-        sqlite3_bind_int  (st, 3, slot);
-        if (sqlite3_step(st) == SQLITE_ROW) {
-            invId = sqlite3_column_int(st, 0);
-        }
-        sqlite3_finalize(st);
-    }
-    return invId;
-}
 
 // Reliable-server RPC fired when the player clicks a loadout-slot button
 // (1..5) anywhere in the UI. Atomic switch:
 //   1. unequip current profile's devices (RCST's PHASE 1 still sees the
 //      old applied state and reverses it on the next call)
 //   2. flip Pawn->r_nItemProfileId + refresh info->skills from DB
-//   3. equip target profile's gameplay devices + reload profile cosmetics
-//   4. RCST PHASE 1 reverts old armor/skills, PHASE 2 applies new armor
+//   3. load cosmetics into r_CustomCharacterAssembly (BEFORE the equip
+//      loop so device actors spawn reading the correct DyeList)
+//   4. equip target profile's gameplay devices
+//   5. RCST PHASE 1 reverts old armor/skills, PHASE 2 applies new armor
 //      (FetchEquippedArmor scoped by new r_nItemProfileId) + new skills
 //      (from refreshed info->skills)
-//   5. IPC the control-server so it persists current_item_profile_id and
+//   6. IPC the control-server so it persists current_item_profile_id and
 //      re-ships SEND_INVENTORY + SEND_PLAYER_SKILLS to the client
-//   6. CallOriginal runs the engine native (which may update
+//   7. CallOriginal runs the engine native (which may update
 //      r_nItemProfileNbr / fire UC follow-ups we don't model)
 //
 // Designed for anywhere-anytime invocation including mid-combat. Hostile
@@ -104,8 +85,8 @@ void __fastcall TgPlayerController__ServerLoadItemProfile::Call(
     // ── Step 1: Tear down current-profile device equipment ────────────────
     // Inventory::Unequip is idempotent on already-cleared slots; we walk all
     // engine equip points (1..24) to cover every weapon/utility/cosmetic.
-    // Cosmetic visual fields (r_CustomCharacterAssembly) are reset in step 5
-    // after the new profile's cosmetics apply.
+    // r_CustomCharacterAssembly is rewritten in step 3 before devices are
+    // equipped, so device actors spawn with the new profile's DyeList.
     //
     // SKIP SLOT 14 (CLASS_DEVICE / HUMAN BASE ATTRIBUTES). It's server-pinned:
     // SaveEquippedDevices forces a slot-14 row into every profile keyed to the
@@ -140,11 +121,9 @@ void __fastcall TgPlayerController__ServerLoadItemProfile::Call(
         const bool bIsBeacon = ((IsBeaconFn)0x10a19a40)(slotDev, nullptr) != 0;
         if (bIsBeacon) continue;  // beacon survives profile switch
 
-        const int targetInvId = LookupGameplayInvIdForSlot(db, character_id, nId, slot);
-        if (targetInvId > 0 && slotDev->r_nDeviceInstanceId == targetInvId) {
-            continue;
-        }
-
+        // Always unequip even if the target profile uses the same invId. Reused
+        // device actors keep the dye baked from their spawn-time assembly; they
+        // must be recreated so the new profile's DyeList is applied on re-equip.
         Inventory::Unequip((ATgPawn*)Pawn, slot);
         ++teardown_count;
     }
@@ -157,7 +136,24 @@ void __fastcall TgPlayerController__ServerLoadItemProfile::Call(
     info->current_item_profile_id = nId;
     PlayerRegistry::RefreshSkillsForProfile(guid, nId);
 
-    // ── Step 3: Equip new profile's gameplay devices ─────────────────────
+    // ── Step 3: Load cosmetics BEFORE the equip loop ─────────────────────
+    // Device actors (jetpack, etc.) apply dyes from r_CustomCharacterAssembly
+    // at spawn time. Loading cosmetics here ensures they see the new profile's
+    // DyeList when Inventory::Equip spawns them below. ApplyPawnSetup (called
+    // later via eventOnCustomAssemblyChanged) updates the body mesh dyes but
+    // does not reach device actor MICs — spawn-time is the only window.
+    CosmeticEquip::LoadFromDB((ATgPawn*)Pawn, character_id, nId);
+    ((ATgPawn_Character*)Pawn)->s_OrigCustomCharacterAssembly =
+        ((ATgPawn_Character*)Pawn)->r_CustomCharacterAssembly;
+    {
+        // ReplicatedEvent('r_CustomCharacterAssembly') on the PRI calls
+        // UpdateCharacterAssetRefs(), queuing async load of suit mesh assets.
+        // Never fires for the listen-server local player — call directly.
+        auto* PRI = (ATgRepInfo_Player*)Pawn->PlayerReplicationInfo;
+        if (PRI) PRI->UpdateCharacterAssetRefs();
+    }
+
+    // ── Step 4: Equip new profile's gameplay devices ─────────────────────
     int gameplay_equipped = 0;
     int gameplay_reused = 0;
     if (db) {
@@ -221,18 +217,9 @@ void __fastcall TgPlayerController__ServerLoadItemProfile::Call(
                     ATgDevice* current = Pawn->m_EquippedDevices[slot];
                     if (current != nullptr && current->r_nDeviceInstanceId == invId) {
                         ++gameplay_reused;
-                        Logger::Log("loadout",
-                            "[ServerLoadItemProfile] equip-loop reuse: slot=%d devId=%d invId=%d\n",
-                            slot, devId, invId);
                         continue;
                     }
-                    Logger::Log("loadout",
-                        "[ServerLoadItemProfile] equip-loop pre:  slot=%d devId=%d invId=%d quality=%d mods=%zu pawn=%p invMgr=%p\n",
-                        slot, devId, invId, quality, mods.size(), Pawn, Pawn->InvManager);
                     Inventory::Equip((ATgPawn*)Pawn, devId, slot, quality, invId, mods);
-                    Logger::Log("loadout",
-                        "[ServerLoadItemProfile] equip-loop post: slot=%d devId=%d (Equip returned)\n",
-                        slot, devId);
                     ++gameplay_equipped;
                 }
             }
@@ -240,18 +227,12 @@ void __fastcall TgPlayerController__ServerLoadItemProfile::Call(
         }
     }
 
-    Logger::Log("loadout",
-        "[ServerLoadItemProfile] pre-Finalize: pawn=%p invMgr=%p changed=%d reused=%d\n",
-        Pawn, Pawn->InvManager, teardown_count + gameplay_equipped, gameplay_reused);
     // Use native UpdateClientDevices but skip the post-native dirty tail.
     // Bare Finalize(Pawn) previously faulted before refresh_profile_ui could repaint.
     Inventory::Finalize((ATgPawn*)Pawn, false);
     Logger::Log("loadout",
-        "[ServerLoadItemProfile] post-Finalize done; changed=%d reused=%d\n",
-        teardown_count + gameplay_equipped, gameplay_reused);
-    Logger::Log("loadout",
-        "[ServerLoadItemProfile] equipped new profile %d: %d gameplay device(s), reused=%d\n",
-        nId, gameplay_equipped, gameplay_reused);
+        "[ServerLoadItemProfile] equipped new profile %d: %d gameplay device(s)\n",
+        nId, gameplay_equipped);
 
     // ── Step 3b: Reset InvManager.r_ItemCount to the DB pool size ────────
     // Inventory::Equip blindly ++'s r_ItemCount on every call (gameplay devices
@@ -291,22 +272,15 @@ void __fastcall TgPlayerController__ServerLoadItemProfile::Call(
         }
     }
 
-    // ── Step 4: RCST does the armor + skill revert+apply atomically ──────
+    // ── Step 5: RCST does the armor + skill revert+apply atomically ──────
     TgPawn_Character__ReapplyCharacterSkillTree::Call(Pawn, nullptr);
 
-    // ── Step 5: Load cosmetics, then prime s_OrigCustomCharacterAssembly so
-    // the native's own reset restores the NEW profile's assembly (not spawn-time).
-    // This lets CallOriginal do the one-step visual refresh the original server did,
-    // with no intermediate zeroed state and no pulse race.
-    CosmeticEquip::LoadFromDB((ATgPawn*)Pawn, character_id, nId);
-    ((ATgPawn_Character*)Pawn)->s_OrigCustomCharacterAssembly =
-        ((ATgPawn_Character*)Pawn)->r_CustomCharacterAssembly;
-
-    Logger::Log("loadout",
-        "[ServerLoadItemProfile] pre-CallOriginal\n");
     CallOriginal(Controller, edx, nId);
-    Logger::Log("loadout",
-        "[ServerLoadItemProfile] post-CallOriginal\n");
+
+    // r_CustomCharacterAssembly is correct but ReplicatedEvent never fires for
+    // the listen-server local pawn — call OnCustomAssemblyChanged directly to
+    // trigger ApplyPawnSetup (helmet/suit mesh swap, body dyes).
+    ((ATgPawn_Character*)Pawn)->eventOnCustomAssemblyChanged();
 
     // The control server sends ClientResetEquipScreen after its TCP refresh.
     // Firing it here can rebuild the open skill UI before new rows arrive.

--- a/src/GameServer/TgGame/TgPlayerController/ServerLoadItemProfile/TgPlayerController__ServerLoadItemProfile.cpp
+++ b/src/GameServer/TgGame/TgPlayerController/ServerLoadItemProfile/TgPlayerController__ServerLoadItemProfile.cpp
@@ -240,8 +240,6 @@ void __fastcall TgPlayerController__ServerLoadItemProfile::Call(
         }
     }
 
-    CosmeticEquip::LoadFromDB((ATgPawn*)Pawn, character_id, nId);
-
     Logger::Log("loadout",
         "[ServerLoadItemProfile] pre-Finalize: pawn=%p invMgr=%p changed=%d reused=%d\n",
         Pawn, Pawn->InvManager, teardown_count + gameplay_equipped, gameplay_reused);
@@ -252,7 +250,7 @@ void __fastcall TgPlayerController__ServerLoadItemProfile::Call(
         "[ServerLoadItemProfile] post-Finalize done; changed=%d reused=%d\n",
         teardown_count + gameplay_equipped, gameplay_reused);
     Logger::Log("loadout",
-        "[ServerLoadItemProfile] equipped new profile %d: %d gameplay device(s), reused=%d; cosmetics reloaded\n",
+        "[ServerLoadItemProfile] equipped new profile %d: %d gameplay device(s), reused=%d\n",
         nId, gameplay_equipped, gameplay_reused);
 
     // ── Step 3b: Reset InvManager.r_ItemCount to the DB pool size ────────
@@ -303,6 +301,14 @@ void __fastcall TgPlayerController__ServerLoadItemProfile::Call(
     CallOriginal(Controller, edx, nId);
     Logger::Log("loadout",
         "[ServerLoadItemProfile] post-CallOriginal\n");
+
+    // ── Step 5b: Re-apply cosmetics AFTER the native runs.
+    // The native ServerLoadItemProfile can reset r_CustomCharacterAssembly from
+    // s_OrigCustomCharacterAssembly (the spawn-time assembly), which may still
+    // carry the previous profile's helm. LoadFromDB here overwrites that reset
+    // so BeginProfileAssemblyPulse (triggered by the IPC response below)
+    // captures the correct new-profile assembly.
+    CosmeticEquip::LoadFromDB((ATgPawn*)Pawn, character_id, nId);
 
     // The control server sends ClientResetEquipScreen after its TCP refresh.
     // Firing it here can rebuild the open skill UI before new rows arrive.

--- a/src/IpcClient/IpcClient.cpp
+++ b/src/IpcClient/IpcClient.cpp
@@ -680,11 +680,6 @@ void IpcClient::DrainInbound() {
                     if (controller == nullptr || controller->Player == nullptr) continue;
 
                     controller->eventClientResetEquipScreen();
-                    if (phase == "immediate") {
-                        BeginProfileAssemblyPulse(data.Pawn, guid, item_profile_id, refresh_token);
-                    } else if (phase == "delayed") {
-                        FinishProfileAssemblyPulse(data.Pawn, guid, item_profile_id, refresh_token);
-                    }
                     ++refreshed;
                 }
                 Logger::Log("loadout",


### PR DESCRIPTION
Bug 1 — Profile switch helm not updating

The native ServerLoadItemProfile can reset r_CustomCharacterAssembly from s_OrigCustomCharacterAssembly (the spawn-time assembly snapshot, which still carries the OLD profile's helm). If CosmeticEquip::LoadFromDB ran BEFORE CallOriginal, the native would overwrite it, and then BeginProfileAssemblyPulse captured the wrong assembly — restoring the old helm 500ms later.

Fix: moved CosmeticEquip::LoadFromDB to run AFTER CallOriginal, so it always overwrites any native reset before the pulse mechanism captures the assembly.

Related to:  https://discord.com/channels/994691794627461211/1520632660731625524
---
Bug 2 — Character select screen showing no cosmetics (Dyes, helm, suit, face)

GSC_CHARACTER_LIST was sending an empty DATArds), so UpdateCharacterListCallback on theclient had no cosmetic data to populate c_CharacterList[i] with. Additionally, HAIR_ASM_ID was hardcoded, and SKIN_MATERIAL_PARAMETER_ID / EYE_MATERIAL_PARAMETER_ID were never sent.

Fix:
- CharacterInfo now includes current_item_pr cosmetics are pulled from the correctloadout slot
- Per-character block: fixed HAIR_ASM_ID to use the DB value; added SKIN_MATERIAL_PARAMETER_ID and EYE_MATERIAL_PARAMETER_ID (12 → 14 fields)
- DATA_SET_PLAYER_INVENTORY now emits one record per equipped cosmetic (helmet, suit, dyes, jetpack trail) across all characters, each with CHARACTER_ID + ITEM_ID + EQUIPPED_SLOT_VALUE_ID


Related to: https://discord.com/channels/994691794627461211/1521295931436437684


Modified for each fix: 
- Bug 1 (helm swap): TgPlayerController__ServerLoadItemProfile.cpp — CosmeticEquip::LoadFromDB removed from before CallOriginal and added after it as step 5b.
- Bug 2 (character select cosmetics): TcpSession.cpp — cosmetic collection + DATA_SET_PLAYER_INVENTORY population; PlayerSessionStore.hpp/.cpp — current_item_profile_id added to CharacterInfo and the query.