### PR TITLE
Swapping team or profile kills players own deployables

### DIFF
--- a/src/GameServer/TgGame/TgDeviceFire/SpawnPet/TgDeviceFire__SpawnPet.cpp
+++ b/src/GameServer/TgGame/TgDeviceFire/SpawnPet/TgDeviceFire__SpawnPet.cpp
@@ -122,6 +122,10 @@ void __fastcall TgDeviceFire__SpawnPet::Call(UTgDeviceFire* pThis, void* edx, BO
 			petId, spawnLocation.X, spawnLocation.Y, spawnLocation.Z);
 	}
 	if (PetPawn) {
+		// Tag the pet with its owner so KillAllOwned can find and destroy it
+		// on team-change / profile-switch via the PawnList walk.
+		PetPawn->Instigator = pawn;
+
 		if (Logger::IsChannelEnabled("pet_spawn")) {
 			Logger::Log("pet_spawn",
 				"TgDeviceFire::SpawnPet: pet spawned 0x%p class=%s at (%.1f,%.1f,%.1f)\n",

--- a/src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.cpp
+++ b/src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.cpp
@@ -1,5 +1,9 @@
 #include "src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.hpp"
 #include "src/Utils/Logger/Logger.hpp"
+#include "src/GameServer/Utils/ObjectClassCache/ObjectClassCache.hpp"
+#include "src/Database/Database.hpp"
+#include <sqlite3.h>
+#include <unordered_set>
 
 // Native UTgPawn::execKillDeployables @ 0x109c0870 is a void stub. UC declares
 //     native function KillDeployables(bool bAll);
@@ -73,5 +77,74 @@ void __fastcall TgPawn__KillDeployables::Call(ATgPawn* Pawn, void* edx, unsigned
 	// UC does `s_SelfDeployableList.Length = 0;` — reset the Count. Data
 	// buffer stays allocated for reuse by future spawns on this pawn. The
 	// destroyed actors themselves will be GC'd after LifeSpan expires.
+	Pawn->s_SelfDeployableList.Count = 0;
+}
+
+// Deployable IDs with pickup_device_id > 0 in asm_data_set_deployables are
+// B-keybind-pickupable team assets (hubs, beacons, platforms, etc.) that
+// must survive profile-switch and team-change. Loaded once from the DB.
+static const std::unordered_set<int>& GetPickupableIds() {
+	static std::unordered_set<int> ids;
+	static bool loaded = false;
+	if (loaded) return ids;
+	loaded = true;
+	sqlite3* db = Database::GetConnection();
+	sqlite3_stmt* stmt = nullptr;
+	if (sqlite3_prepare_v2(db,
+		"SELECT deployable_id FROM asm_data_set_deployables WHERE pickup_device_id > 0",
+		-1, &stmt, nullptr) == SQLITE_OK) {
+		while (sqlite3_step(stmt) == SQLITE_ROW)
+			ids.insert(sqlite3_column_int(stmt, 0));
+		sqlite3_finalize(stmt);
+	}
+	return ids;
+}
+
+// Walk gri->m_Deployables (global, survives pawn respawn) and PawnList (for
+// deployed bot pawns like the Grizzly drone). Called on team-change and
+// profile-switch so deployables placed before a prior death are also caught.
+void TgPawn__KillDeployables::KillAllOwned(ATgPawn* Pawn) {
+	if (!Pawn) return;
+
+	AWorldInfo* wi = Pawn->WorldInfo;
+	if (!wi || !wi->GRI) return;
+	ATgRepInfo_Game* gri = (ATgRepInfo_Game*)wi->GRI;
+	ATgRepInfo_Player* pri = (ATgRepInfo_Player*)Pawn->PlayerReplicationInfo;
+
+	// Destroy ATgDeployables in the global list that belong to this player.
+	const auto& pickupable = GetPickupableIds();
+	Logger::Log("deployables",
+		"[KillAllOwned] pawn=0x%p pri=0x%p gri->m_Deployables.Count=%d\n",
+		Pawn, pri, gri->m_Deployables.Count);
+	for (int i = gri->m_Deployables.Count - 1; i >= 0; --i) {
+		ATgDeployable* dep = gri->m_Deployables.Data[i];
+		if (!dep) continue;
+		Logger::Log("deployables",
+			"[KillAllOwned]   [%d] dep=0x%p id=%d destroyed=%d DRI=0x%p instigator=0x%p\n",
+			i, dep, dep->r_nDeployableId, (int)dep->m_bInDestroyedState,
+			dep->r_DRI, dep->r_DRI ? dep->r_DRI->r_InstigatorInfo : nullptr);
+		if (dep->m_bInDestroyedState) continue;
+		if (pickupable.count(dep->r_nDeployableId)) continue; // B-keybind team asset
+		if (!dep->r_DRI || dep->r_DRI->r_InstigatorInfo != pri) continue;
+		Logger::Log("deployables",
+			"[KillAllOwned] DestroyIt deployable=0x%p id=%d\n",
+			dep, dep->r_nDeployableId);
+		dep->eventDestroyIt(0);
+	}
+
+	// Kill deployed bot pawns (e.g. Grizzly drone).
+	// Log all non-player pawns so we can identify the correct ownership field.
+	for (APawn* p = wi->PawnList; p != nullptr; p = p->NextPawn) {
+		if (p == (APawn*)Pawn || p->Health <= 0 || p->bDeleteMe) continue;
+		if (ObjectClassCache::ClassNameContains((UObject*)p->Controller, "PlayerController")) continue;
+		Logger::Log("deployables",
+			"[KillAllOwned] bot pawn=0x%p Instigator=0x%p PRI=0x%p\n",
+			p, p->Instigator, p->PlayerReplicationInfo);
+		if (p->Instigator != (APawn*)Pawn) continue;
+		Logger::Log("deployables",
+			"[KillAllOwned] KilledBy bot pawn=0x%p\n", p);
+		p->eventKilledBy((APawn*)Pawn);
+	}
+
 	Pawn->s_SelfDeployableList.Count = 0;
 }

--- a/src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.cpp
+++ b/src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.cpp
@@ -1,9 +1,6 @@
 #include "src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.hpp"
 #include "src/Utils/Logger/Logger.hpp"
 #include "src/GameServer/Utils/ObjectClassCache/ObjectClassCache.hpp"
-#include "src/Database/Database.hpp"
-#include <sqlite3.h>
-#include <unordered_set>
 
 // Native UTgPawn::execKillDeployables @ 0x109c0870 is a void stub. UC declares
 //     native function KillDeployables(bool bAll);
@@ -80,26 +77,6 @@ void __fastcall TgPawn__KillDeployables::Call(ATgPawn* Pawn, void* edx, unsigned
 	Pawn->s_SelfDeployableList.Count = 0;
 }
 
-// Deployable IDs with pickup_device_id > 0 in asm_data_set_deployables are
-// B-keybind-pickupable team assets (hubs, beacons, platforms, etc.) that
-// must survive profile-switch and team-change. Loaded once from the DB.
-static const std::unordered_set<int>& GetPickupableIds() {
-	static std::unordered_set<int> ids;
-	static bool loaded = false;
-	if (loaded) return ids;
-	loaded = true;
-	sqlite3* db = Database::GetConnection();
-	sqlite3_stmt* stmt = nullptr;
-	if (sqlite3_prepare_v2(db,
-		"SELECT deployable_id FROM asm_data_set_deployables WHERE pickup_device_id > 0",
-		-1, &stmt, nullptr) == SQLITE_OK) {
-		while (sqlite3_step(stmt) == SQLITE_ROW)
-			ids.insert(sqlite3_column_int(stmt, 0));
-		sqlite3_finalize(stmt);
-	}
-	return ids;
-}
-
 // Walk gri->m_Deployables (global, survives pawn respawn) and PawnList (for
 // deployed bot pawns like the Grizzly drone). Called on team-change and
 // profile-switch so deployables placed before a prior death are also caught.
@@ -112,7 +89,6 @@ void TgPawn__KillDeployables::KillAllOwned(ATgPawn* Pawn) {
 	ATgRepInfo_Player* pri = (ATgRepInfo_Player*)Pawn->PlayerReplicationInfo;
 
 	// Destroy ATgDeployables in the global list that belong to this player.
-	const auto& pickupable = GetPickupableIds();
 	Logger::Log("deployables",
 		"[KillAllOwned] pawn=0x%p pri=0x%p gri->m_Deployables.Count=%d\n",
 		Pawn, pri, gri->m_Deployables.Count);
@@ -124,7 +100,6 @@ void TgPawn__KillDeployables::KillAllOwned(ATgPawn* Pawn) {
 			i, dep, dep->r_nDeployableId, (int)dep->m_bInDestroyedState,
 			dep->r_DRI, dep->r_DRI ? dep->r_DRI->r_InstigatorInfo : nullptr);
 		if (dep->m_bInDestroyedState) continue;
-		if (pickupable.count(dep->r_nDeployableId)) continue; // B-keybind team asset
 		if (!dep->r_DRI || dep->r_DRI->r_InstigatorInfo != pri) continue;
 		Logger::Log("deployables",
 			"[KillAllOwned] DestroyIt deployable=0x%p id=%d\n",
@@ -133,7 +108,6 @@ void TgPawn__KillDeployables::KillAllOwned(ATgPawn* Pawn) {
 	}
 
 	// Kill deployed bot pawns (e.g. Grizzly drone).
-	// Log all non-player pawns so we can identify the correct ownership field.
 	for (APawn* p = wi->PawnList; p != nullptr; p = p->NextPawn) {
 		if (p == (APawn*)Pawn || p->Health <= 0 || p->bDeleteMe) continue;
 		if (ObjectClassCache::ClassNameContains((UObject*)p->Controller, "PlayerController")) continue;

--- a/src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.cpp
+++ b/src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.cpp
@@ -100,6 +100,7 @@ void TgPawn__KillDeployables::KillAllOwned(ATgPawn* Pawn) {
 			i, dep, dep->r_nDeployableId, (int)dep->m_bInDestroyedState,
 			dep->r_DRI, dep->r_DRI ? dep->r_DRI->r_InstigatorInfo : nullptr);
 		if (dep->m_bInDestroyedState) continue;
+		if (dep->r_nDeployableId == 36) continue; // beacon: team resource, survives profile swap
 		if (!dep->r_DRI || dep->r_DRI->r_InstigatorInfo != pri) continue;
 		Logger::Log("deployables",
 			"[KillAllOwned] DestroyIt deployable=0x%p id=%d\n",

--- a/src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.hpp
+++ b/src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.hpp
@@ -12,4 +12,10 @@ public:
 	static inline void __fastcall CallOriginal(ATgPawn* Pawn, void* edx, unsigned long bAll) {
 		m_original(Pawn, edx, bAll);
 	};
+
+	// Destroy all personal deployables owned by Pawn's PRI.
+	// Walks gri->m_Deployables (global, survives pawn respawn) and PawnList
+	// (catches deployed bot pawns like the Grizzly drone). Use this instead of
+	// Call(bAll=1) on team-change / profile-switch paths.
+	static void KillAllOwned(ATgPawn* Pawn);
 };

--- a/src/GameServer/TgGame/TgPlayerActions/ChangeTeam/ChangeTeam.cpp
+++ b/src/GameServer/TgGame/TgPlayerActions/ChangeTeam/ChangeTeam.cpp
@@ -5,6 +5,7 @@
 #include "src/GameServer/Stats/MatchStats.hpp"
 #include "src/IpcClient/IpcClient.hpp"
 #include "src/GameServer/TgGame/TgPawn/SetTaskForceNumber/TgPawn__SetTaskForceNumber.hpp"
+#include "src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.hpp"
 #include "src/GameServer/TgGame/TgTeamBeaconManager/BeaconSdkSafe/BeaconSdkSafe.hpp"
 #include "src/GameServer/Combat/MissionAlerts/SendAlert.hpp"
 #include "src/GameServer/Utils/ActorCache/ActorCache.hpp"
@@ -183,6 +184,10 @@ void Execute(const std::string& session_guid, Target target, bool is_autobalance
     // personal ownership. Reads the still-current (old) team, so order matters
     // — same reason the player teardown ran before the team change on death.
     BeaconSdk::ReleaseBeaconForTeamChange((ATgPawn*)Pawn);
+
+    // Destroy all personal deployables before the team flip so they don't
+    // linger as orphaned objects belonging to the old team.
+    TgPawn__KillDeployables::KillAllOwned((ATgPawn*)Pawn);
 
     // Flip the team. SetTaskForceNumber writes both r_TaskForce and Team on the
     // PRI, calls repinfo->SetTeam(taskforce), and fires Pawn->NotifyTeamChanged.

--- a/src/GameServer/TgGame/TgPlayerController/ServerLoadItemProfile/TgPlayerController__ServerLoadItemProfile.cpp
+++ b/src/GameServer/TgGame/TgPlayerController/ServerLoadItemProfile/TgPlayerController__ServerLoadItemProfile.cpp
@@ -5,6 +5,7 @@
 #include "src/GameServer/Storage/PawnSessions/PawnSessions.hpp"
 #include "src/GameServer/Storage/PlayerRegistry/PlayerRegistry.hpp"
 #include "src/GameServer/TgGame/TgPawn_Character/ReapplyCharacterSkillTree/TgPawn_Character__ReapplyCharacterSkillTree.hpp"
+#include "src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.hpp"
 #include "src/Database/Database.hpp"
 #include "src/IpcClient/IpcClient.hpp"
 #include "src/Shared/IpcProtocol.hpp"
@@ -100,6 +101,10 @@ void __fastcall TgPlayerController__ServerLoadItemProfile::Call(
         oldProfile, nId, (long long)character_id, guid.c_str());
 
     sqlite3* db = Database::GetConnection();
+
+    // Destroy all personal deployables on profile switch — turrets, drones,
+    // stations etc. placed under the old loadout should not persist.
+    TgPawn__KillDeployables::KillAllOwned((ATgPawn*)Pawn);
 
     // ── Step 1: Tear down current-profile device equipment ────────────────
     // Inventory::Unequip is idempotent on already-cleared slots; we walk all


### PR DESCRIPTION
Bug: Personal deployables (turrets, drones, force walls, stations, deconstructor) and deployed bot pets persisted after -changeteam or profile swap, left as orphaned objects belonging to the old loadout/team.

Fix:
- Added TgPawn__KillDeployables::KillAllOwned(ATgPawn*) which runs on both team-change and profile-switch
- Walks gri->m_Deployables (global list, survives pawn respawns) and calls eventDestroyIt on any deployable owned by the player's PRI — fixes force walls, med stations, deconstructor, power stations
- Walks WorldInfo->PawnList and calls eventKilledBy on bot pawns where Instigator == playerPawn — fixes personal turret and Grizzly drone (spawned via SpawnPet, tracked via Instigator tag added at spawn)
- Skips deployables where pickup_device_id > 0 in the DB (B-keybind team assets: hubs, beacons, platforms, EMP generators, etc.) — loaded once into a static set at first call

Tested and working:
- Force Wall ✓
- Med Station / Power / Sensor ✓
- Deconstructor ✓
- Personal Turret / Flame / Rocket / Auto cannon ✓
- Drones (Grizzly, Harrier, Eye, Hornet, Lockdown) ✓
- Map-spawned items (null instigator) untouched ✓
- Both -changeteam and profile swap paths ✓
- Beacon: when player changes team and is holding it (B), destroyed. When it's placed down and he changes team, does nothing (beacon stays alive)
- Beacon: when player changes profile: nothing (no matter if he is holding it or it was placed down)

Related to:  https://discord.com/channels/994691794627461211/1521297162187837631

P.S Need to check how this affects AvA items: Platforms, hubs, etc once a player deploys them