### PR TITLE
Added -fullheal command on VR, 15s cd, fixed healpad on VR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,7 @@ SOURCE_FILES= \
 			  $(SRC_DIR)/GameServer/TgGame/TgPlayerActions/ReturnHomeArea/ReturnHomeArea.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/TgPlayerActions/TopDown/TopDown.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/TgPlayerActions/Coords/Coords.cpp \
+			  $(SRC_DIR)/GameServer/TgGame/TgPlayerActions/FullHeal/FullHeal.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/TgPawn/SwapAttachedDeviceMaterials/TgPawn__SwapAttachedDeviceMaterials.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/TgTeamBeaconManager/SpawnNewBeaconForTeam/TgTeamBeaconManager__SpawnNewBeaconForTeam.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/TgTeamBeaconManager/BeaconSdkSafe/BeaconSdkSafe.cpp \

--- a/src/ControlServer/ChatSession/ChatCommand.cpp
+++ b/src/ControlServer/ChatSession/ChatCommand.cpp
@@ -193,6 +193,14 @@ ParseResult TryParseChatCommand(const std::string& message_text) {
         return out;
     }
 
+    if (cmd_name == "-fullheal") {
+        // No args — heal the player's pawn to full (DLL gates map + cooldown).
+        out.recognized = true;
+        out.suppress_broadcast = true;
+        if (rest.empty()) out.fullheal = true;
+        return out;
+    }
+
     if (cmd_name == "-possess") {
         out.recognized = true;
         out.suppress_broadcast = true;
@@ -367,6 +375,7 @@ static void DispatchSimpleAction(const std::string& action_name, const std::stri
 void DispatchPossess(const std::string& session_guid)   { DispatchSimpleAction("possess",   session_guid); }
 void DispatchUnpossess(const std::string& session_guid) { DispatchSimpleAction("unpossess", session_guid); }
 void DispatchCoords(const std::string& session_guid)    { DispatchSimpleAction("coords",    session_guid); }
+void DispatchFullHeal(const std::string& session_guid)  { DispatchSimpleAction("fullheal",  session_guid); }
 
 void DispatchTopDown(const TopDownArgs& args, const std::string& session_guid) {
     if (session_guid.empty()) {

--- a/src/ControlServer/ChatSession/ChatCommand.hpp
+++ b/src/ControlServer/ChatSession/ChatCommand.hpp
@@ -71,6 +71,10 @@ struct ParseResult {
     // -coords — report the player's current XYZ (map-prep tooling). No args.
     bool coords = false;
 
+    // -fullheal — restore the player's pawn to full health (VR arena / 1v1
+    // practice; DLL enforces map gate + per-player cooldown). No args.
+    bool fullheal = false;
+
     // -reload-queues — re-read ga_queues + ga_map_pool_entries. Handled
     // entirely on the control server; no PLAYER_ACTION IPC dispatched.
     bool reload_queues = false;
@@ -114,6 +118,10 @@ void DispatchUnpossess(const std::string& session_guid);
 // Send -coords to the game DLL. Same delivery path; the DLL logs + shows the
 // requesting player's current XYZ.
 void DispatchCoords(const std::string& session_guid);
+
+// Send -fullheal to the game DLL. Same delivery path; map gate + cooldown
+// are enforced DLL-side.
+void DispatchFullHeal(const std::string& session_guid);
 
 // Send -topdown to the game DLL. Toggles top-down view in the DLL — repeated
 // invocations alternate enter/restore. lift_z=0 means "use the DLL default".

--- a/src/ControlServer/ChatSession/ChatSession.cpp
+++ b/src/ControlServer/ChatSession/ChatSession.cpp
@@ -154,6 +154,8 @@ bool HasParsedCommandAction(const ChatCommand::ParseResult& parsed) {
         || parsed.topdown.has_value()
         || parsed.possess
         || parsed.unpossess
+        || parsed.coords
+        || parsed.fullheal
         || parsed.reload_queues;
 }
 
@@ -374,6 +376,9 @@ void ChatSession::handle_packet(const uint8_t* data, size_t length) {
         }
         if (parsed.recognized && parsed.coords) {
             ChatCommand::DispatchCoords(session_guid_);
+        }
+        if (parsed.recognized && parsed.fullheal) {
+            ChatCommand::DispatchFullHeal(session_guid_);
         }
         if (parsed.recognized && parsed.topdown) {
             ChatCommand::DispatchTopDown(*parsed.topdown, session_guid_);

--- a/src/Database/Database.cpp
+++ b/src/Database/Database.cpp
@@ -7756,6 +7756,17 @@ void Database::Init() {
 		Logger::Log("db", "v123: DomeCityDefense bot factory spawn table 102 -> 99\n");
 	}
 
+	// VR heal pad: enforce the pad device unconditionally (idempotent) —
+	// branch-divergent DBs have version counters past the v101/v102 gates.
+	// 2064 = Medical Station pulse (1.0s refire, FX 432 visual pulse);
+	// 5134 = ER-2 flat +100, no FX. Testing 2064 for feel-comparison vs 5134.
+	result = sqlite3_exec(db,
+		"UPDATE map_object_config SET value = '2064' "
+		"WHERE map_name = 'Dome3_VR_Arena_P' AND map_object_id = 11041 "
+		"  AND column_name = 's_n_device_id' AND value <> '2064';",
+		nullptr, nullptr, &err);
+	if (result != SQLITE_OK) { Logger::Log("db", "Failed VR heal pad device enforce: %s\n", err); return; }
+
 	result = sqlite3_exec(db, "UPDATE version_info SET version = 123", nullptr, nullptr, &err);
 	if (result != SQLITE_OK) {
 		Logger::Log("db", "Failed to update version_info: %s\n", err);

--- a/src/GameServer/Engine/GameEngine/Tick/GameEngine__Tick.cpp
+++ b/src/GameServer/Engine/GameEngine/Tick/GameEngine__Tick.cpp
@@ -6,6 +6,7 @@
 #include "src/GameServer/Stats/MatchStats.hpp"
 #include "src/GameServer/Engine/KismetWebDump/KismetWebDump.hpp"
 #include "src/GameServer/TgGame/MissionVODirector/MissionVODirector.hpp"
+#include "src/GameServer/TgGame/TgDeviceVolume/setupDevice/TgDeviceVolume__setupDevice.hpp"
 
 void __fastcall GameEngine__Tick::Call(void* Engine, void* edx, float DeltaSeconds) {
 	IpcClient::DrainInbound();
@@ -29,5 +30,8 @@ void __fastcall GameEngine__Tick::Call(void* Engine, void* edx, float DeltaSecon
 	// (Bancroft_HalfwayPoint/_30sRemaining/_10sRemaining) off the round timer.
 	// Self-gates on map name + Defense round state; no-op elsewhere.
 	MissionVODirector::Tick(DeltaSeconds);
+	// One-shot: verify (and if needed redo) the VR heal pad's PostBeginPlay
+	// arming ~5s after setupDevice registered it. No-op on other maps.
+	DomeVrHealPad::TickArmCheck();
 	CallOriginal(Engine, edx, DeltaSeconds);
 }

--- a/src/GameServer/TgGame/TgDeviceFire/GetEffectGroup/TgDeviceFire__GetEffectGroup.cpp
+++ b/src/GameServer/TgGame/TgDeviceFire/GetEffectGroup/TgDeviceFire__GetEffectGroup.cpp
@@ -1,4 +1,5 @@
 #include "src/GameServer/TgGame/TgDeviceFire/GetEffectGroup/TgDeviceFire__GetEffectGroup.hpp"
+#include "src/GameServer/TgGame/TgDeviceVolume/setupDevice/TgDeviceVolume__setupDevice.hpp"
 #include "src/GameServer/Utils/ClassPreloader/ClassPreloader.hpp"
 #include "src/Database/Database.hpp"
 #include "src/Utils/Logger/Logger.hpp"
@@ -590,6 +591,10 @@ UTgEffectGroup* __fastcall TgDeviceFire__GetEffectGroup::Call(UTgDeviceFire* pTh
 		}
 	}
 
+	// VR heal pad chain diagnostic: proves the volume's ApplyHit reached
+	// SubmitHitEffects and shows whether the pad's effect groups got built.
+	const bool padLog = DomeVrHealPad::IsPadFireMode(pThis) && Logger::IsChannelEnabled("healpad");
+
 	// Search for a group matching nType
 	int startIdx = (nIndex && *nIndex >= 0) ? *nIndex : 0;
 	TArray<UTgEffectGroup*>& list = pThis->s_EffectGroupList;
@@ -609,6 +614,12 @@ UTgEffectGroup* __fastcall TgDeviceFire__GetEffectGroup::Call(UTgDeviceFire* pTh
 
 			if (nIndex) *nIndex = i;
 
+			if (padLog) {
+				Logger::Log("healpad",
+					"[GetEffectGroup] nType=%d startIdx=%d -> egId=%d (list=%d)\n",
+					nType, startIdx, g->m_nEffectGroupId, list.Count);
+			}
+
 			if (Logger::IsChannelEnabled("effects")) {
 				Logger::Log("effects",
 					"[GET] fireMode=%s nType=%d -> egId=%d (startIdx=%d resultIdx=%d)\n",
@@ -619,6 +630,12 @@ UTgEffectGroup* __fastcall TgDeviceFire__GetEffectGroup::Call(UTgDeviceFire* pTh
 	}
 
 	if (nIndex) *nIndex = -1;
+
+	if (padLog) {
+		Logger::Log("healpad",
+			"[GetEffectGroup] nType=%d startIdx=%d -> NONE (list=%d)\n",
+			nType, startIdx, list.Count);
+	}
 
 	if (Logger::IsChannelEnabled("effects")) {
 		Logger::Log("effects",

--- a/src/GameServer/TgGame/TgDeviceFire/IsValidTarget/TgDeviceFire__IsValidTarget.cpp
+++ b/src/GameServer/TgGame/TgDeviceFire/IsValidTarget/TgDeviceFire__IsValidTarget.cpp
@@ -1,4 +1,5 @@
 #include "src/GameServer/TgGame/TgDeviceFire/IsValidTarget/TgDeviceFire__IsValidTarget.hpp"
+#include "src/GameServer/TgGame/TgDeviceVolume/setupDevice/TgDeviceVolume__setupDevice.hpp"
 #include "src/Utils/Logger/Logger.hpp"
 #include <string>
 
@@ -34,6 +35,21 @@ bool __fastcall TgDeviceFire__IsValidTarget::Call(
 		UTgDeviceFire* FireMode, void* edx, AActor* TargetActor, char OverrideTargeterType) {
 
 	bool result = CallOriginal(FireMode, edx, TargetActor, OverrideTargeterType);
+
+	// VR heal pad chain diagnostic. A hit here proves the volume's
+	// TimerPop/Touch → CausePainTo → ApplyHit path is reaching the fire mode.
+	if (DomeVrHealPad::IsPadFireMode(FireMode) && Logger::IsChannelEnabled("healpad")) {
+		std::string tgtCls = SafeGetFullName(TargetActor);
+		int physType = -1;
+		if (TargetActor && tgtCls.find("TgPawn") != std::string::npos) {
+			physType = ((ATgPawn*)TargetActor)->r_nPhysicalType;
+		}
+		Logger::Log("healpad",
+			"[IsValidTarget] target=%p (%s) override=%d targeter=%d affects=%d physType=%d -> %s\n",
+			(void*)TargetActor, tgtCls.c_str(), (int)(uint8_t)OverrideTargeterType,
+			(int)FireMode->m_eTargeterType, FireMode->m_nTargetAffectsType, physType,
+			result ? "VALID" : "reject");
+	}
 
 	// EMP / deployable-bomb diagnostic (channel "deployablefactory"). A
 	// deployable bomb's victims are PAWNS, which the combat-trace block below

--- a/src/GameServer/TgGame/TgDeviceVolume/setupDevice/TgDeviceVolume__setupDevice.cpp
+++ b/src/GameServer/TgGame/TgDeviceVolume/setupDevice/TgDeviceVolume__setupDevice.cpp
@@ -3,10 +3,22 @@
 #include "src/GameServer/Engine/MapObjectConfig/MapObjectConfig.hpp"
 #include "src/GameServer/Utils/ClassPreloader/ClassPreloader.hpp"
 #include "src/GameServer/Utils/ObjectCache/ObjectCache.hpp"
+#include "src/GameServer/TgGame/TgDeviceFire/GetEffectGroup/TgDeviceFire__GetEffectGroup.hpp"
 #include "src/Utils/Logger/Logger.hpp"
+#include "src/GameServer/Storage/ClientConnectionsData/ClientConnectionsData.hpp"
+
+#include <string>
 
 namespace {
 	ATgDeviceVolume* g_domeVrHealPadVolume = nullptr;
+	// Stashed at registration — UC PostBeginPlay nulls the volume's
+	// s_DeviceFireMode when the stripped exec thunk misreports our return.
+	UTgDeviceFire*   g_padFireMode         = nullptr;
+	uint64_t         g_padRegisteredAtMs   = 0;
+	bool             g_padArmChecked       = false;
+	// egIds of the kept (instant-heal) groups, recorded by the ArmCheck prune.
+	int              g_padHealEgIds[4]     = {};
+	int              g_padHealEgCount      = 0;
 
 	bool IsDomeVrHealPadVolume(ATgDeviceVolume* Volume) {
 		if (!Volume) return false;
@@ -17,6 +29,168 @@ namespace {
 
 ATgDeviceVolume* DomeVrHealPad::GetRegisteredVolume() {
 	return g_domeVrHealPadVolume;
+}
+
+bool DomeVrHealPad::IsPadFireMode(UTgDeviceFire* fm) {
+	return fm && fm == g_padFireMode;
+}
+
+bool DomeVrHealPad::IsPadHealEffectGroup(int egId) {
+	for (int i = 0; i < g_padHealEgCount; i++) {
+		if (g_padHealEgIds[i] == egId) return true;
+	}
+	return false;
+}
+
+void DomeVrHealPad::TickArmCheck() {
+	if (!g_domeVrHealPadVolume) return;
+	if (g_padArmChecked) {
+		ATgDeviceVolume* V = g_domeVrHealPadVolume;
+		const uint64_t now = GetTickCount64();
+
+		// (Server-driven pulse removed — logs/292 proved the engine's own
+		// Timer→TimerPop dispatch works; the pulse was double-healing on top
+		// of it. The engine PainTimer now runs at 1s via the m_fFireTime
+		// override at registration.)
+
+		// Diagnostic monitor (only while the "healpad" channel is on): the pad
+		// is armed but IsValidTarget never fires — this shows whether pawns
+		// ever enter the volume's Touching list, and whether they'd pass
+		// TimerPop's bCanBeDamaged/!bStatic filter.
+		static uint64_t lastMonitorMs = 0;
+		if (!Logger::IsChannelEnabled("healpad") || now - lastMonitorMs < 3000) return;
+		lastMonitorMs = now;
+		ATgDeviceVolumeInfo* info = (ATgDeviceVolumeInfo*)V->PainTimer;
+		Logger::Log("healpad",
+			"[Monitor] touching=%d painTimer=0x%p painTimer.V=0x%p fireMode=0x%p bPainCausing=%d s_bDeviceActive=%d\n",
+			V->Touching.Data ? V->Touching.Num() : -1,
+			info, info ? info->V : nullptr,
+			V->s_DeviceFireMode, (int)V->bPainCausing, (int)V->s_bDeviceActive);
+		// Brush bounds — tests the "volume isn't where the visible pad is"
+		// theory. Origin/BoxExtent are world-space.
+		if (V->CollisionComponent) {
+			const FBoxSphereBounds& b = V->CollisionComponent->Bounds;
+			Logger::Log("healpad",
+				"[Monitor]   bounds origin=(%.1f, %.1f, %.1f) extent=(%.1f, %.1f, %.1f) radius=%.1f\n",
+				b.Origin.X, b.Origin.Y, b.Origin.Z,
+				b.BoxExtent.X, b.BoxExtent.Y, b.BoxExtent.Z, b.SphereRadius);
+		}
+		// Player pawn positions vs the volume — shows how far the player is
+		// from the brush while standing on the visible pad.
+		for (auto& kv : GClientConnectionsData) {
+			ATgPawn_Character* p = kv.second.Pawn;
+			if (!p) continue;
+			Logger::Log("healpad",
+				"[Monitor]   pawn=0x%p loc=(%.1f, %.1f, %.1f)\n",
+				p, p->Location.X, p->Location.Y, p->Location.Z);
+		}
+		// Touching list: statics are noise — count them, print everything else.
+		if (V->Touching.Data) {
+			int staticCount = 0;
+			for (int i = 0; i < V->Touching.Num(); i++) {
+				AActor* a = V->Touching.Data[i];
+				if (!a) continue;
+				const char* raw = a->Class ? a->Class->GetFullName() : nullptr;
+				const std::string cls(raw ? raw : "<null>");
+				if (cls.find("StaticMeshActor") != std::string::npos) { staticCount++; continue; }
+				// Team data feeds the client's FX friend/foe tint — dump it to
+				// chase the inverted heal-pulse colors (yellow self / green enemy).
+				int tf = -1, teamIdx = -1;
+				if (cls.find("TgPawn") != std::string::npos) {
+					ATgPawn* tp = (ATgPawn*)a;
+					ATgRepInfo_Player* pri = (ATgRepInfo_Player*)tp->PlayerReplicationInfo;
+					if (pri) {
+						tf = pri->r_TaskForce ? pri->r_TaskForce->r_nTaskForce : -1;
+						teamIdx = pri->Team ? pri->Team->TeamIndex : -1;
+					}
+				}
+				Logger::Log("healpad",
+					"[Monitor]   touching[%d]=0x%p (%s) bCanBeDamaged=%d bStatic=%d tf=%d teamIdx=%d loc=(%.1f, %.1f, %.1f)\n",
+					i, a, cls.c_str(), (int)a->bCanBeDamaged, (int)a->bStatic,
+					tf, teamIdx,
+					a->Location.X, a->Location.Y, a->Location.Z);
+			}
+			Logger::Log("healpad", "[Monitor]   (+%d StaticMeshActors)\n", staticCount);
+		}
+		return;
+	}
+	if (GetTickCount64() - g_padRegisteredAtMs < 5000) return;  // let PostBeginPlay settle
+	g_padArmChecked = true;
+
+	ATgDeviceVolume* V = g_domeVrHealPadVolume;
+	Logger::Log("healpad",
+		"[ArmCheck] fireMode=0x%p bPainCausing=%d s_bDeviceActive=%d painTimer=0x%p\n",
+		V->s_DeviceFireMode, (int)V->bPainCausing, (int)V->s_bDeviceActive, V->PainTimer);
+
+	// Build + prune the pad's effect groups: keep only the instant
+	// (lifetime<=0) type-264 heal group. Device 5134's mode also carries two
+	// lifetime>0 264 groups (HoT/buff) that register HUD buff icons on every
+	// pulse and stack extra healing — the original pad showed neither
+	// (logs/291 + screenshot). Call the hook's Call directly to force the
+	// lazy list build (the SDK GetEffectGroup wrapper corrupts its out-param).
+	if (g_padFireMode) {
+		int idx = 0;
+		TgDeviceFire__GetEffectGroup::Call(g_padFireMode, nullptr, 264, &idx);
+		TArray<UTgEffectGroup*>& gl = g_padFireMode->s_EffectGroupList;
+		if (gl.Data) {
+			int kept = 0;
+			for (int i = 0; i < gl.Num(); i++) {
+				UTgEffectGroup* g = gl.Data[i];
+				if (!g) continue;
+				if (g->m_nType == 264 && g->m_fLifeTime <= 0.0f) {
+					gl.Data[kept++] = g;
+					if (g_padHealEgCount < 4)
+						g_padHealEgIds[g_padHealEgCount++] = g->m_nEffectGroupId;
+					// Pad heals +100/s (original rate); device 2064's Medical
+					// Station pulse ships +154. Patch only this fire mode's
+					// group copies — the DB row is shared with the real
+					// Medical Station deployable.
+					if (g->m_Effects.Data) {
+						for (int e = 0; e < g->m_Effects.Num(); e++) {
+							UTgEffect* eff = g->m_Effects.Data[e];
+							if (eff && eff->m_fBase > 100.0f) {
+								Logger::Log("healpad",
+									"[ArmCheck] heal base %.0f -> 100 (egId=%d propId=%d)\n",
+									eff->m_fBase, g->m_nEffectGroupId, eff->m_nPropertyId);
+								eff->m_fBase = 100.0f;
+							}
+						}
+					}
+				} else {
+					Logger::Log("healpad",
+						"[ArmCheck] pruned egId=%d type=%d lifetime=%.1f\n",
+						g->m_nEffectGroupId, g->m_nType, g->m_fLifeTime);
+				}
+			}
+			gl.Count = kept;
+		}
+	}
+
+	if (V->s_DeviceFireMode && V->bPainCausing && V->s_bDeviceActive && V->PainTimer) {
+		return;  // UC PostBeginPlay armed it — nothing to do
+	}
+
+	// Redo TgDeviceVolume.uc PostBeginPlay's arming.
+	V->s_DeviceFireMode    = g_padFireMode;
+	V->bPainCausing        = 1;
+	V->BACKUP_bPainCausing = 1;
+	V->s_bDeviceActive     = 1;
+
+	if (!V->PainTimer) {
+		UClass* infoClass = ClassPreloader::GetClass("Class TgGame.TgDeviceVolumeInfo");
+		if (!infoClass) {
+			Logger::Log("healpad",
+				"[ArmCheck] TgDeviceVolumeInfo class not resident; cannot spawn pain timer\n");
+			return;
+		}
+		// The info's own PostBeginPlay sets a 1s looping timer and V=Owner —
+		// matches this device's 1.00s refire, so no SetTimer call needed here.
+		V->PainTimer = (AInfo*)V->Spawn(infoClass, V, FName(),
+			V->Location, V->Rotation, nullptr, 1);
+	}
+
+	Logger::Log("healpad", "[ArmCheck] re-armed: fireMode=0x%p painTimer=0x%p\n",
+		V->s_DeviceFireMode, V->PainTimer);
 }
 
 // TgDeviceVolume::setupDevice — stripped native (0x109aeec0, decompiles to
@@ -80,9 +254,20 @@ bool __fastcall TgDeviceVolume_setupDevice::Call(ATgDeviceVolume* Volume, void* 
 		Volume->s_nTeamNumber, (int)Volume->s_nTaskForce,
 		Volume->Location.X, Volume->Location.Y, Volume->Location.Z);
 
+	// Mirror the VR pad's whole setupDevice trace onto "healpad" so a single
+	// channel shows why arming failed (the generic logs stay on device-volume).
+	const bool isPad = IsDomeVrHealPadVolume(Volume);
+	if (isPad) {
+		Logger::Log("healpad",
+			"[setupDevice] enter mapObj=%d deviceId=%d team=%d tf=%d\n",
+			Volume->m_nMapObjectId, Volume->s_nDeviceId,
+			Volume->s_nTeamNumber, (int)Volume->s_nTaskForce);
+	}
+
 	if (Volume->s_nDeviceId == 0) {
 		Logger::Log("device-volume",
 			"[setupDevice] volume=0x%p: no s_nDeviceId; no fire mode wired\n", Volume);
+		if (isPad) Logger::Log("healpad", "[setupDevice] FAIL: no s_nDeviceId\n");
 		return false;
 	}
 
@@ -90,6 +275,7 @@ bool __fastcall TgDeviceVolume_setupDevice::Call(ATgDeviceVolume* Volume, void* 
 	if (!DeviceClass) {
 		Logger::Log("device-volume",
 			"[setupDevice] volume=0x%p: TgDevice class not preloaded; aborting\n", Volume);
+		if (isPad) Logger::Log("healpad", "[setupDevice] FAIL: TgDevice class not preloaded\n");
 		return false;
 	}
 
@@ -107,6 +293,7 @@ bool __fastcall TgDeviceVolume_setupDevice::Call(ATgDeviceVolume* Volume, void* 
 		Logger::Log("device-volume",
 			"[setupDevice] volume=0x%p deviceId=%d: Spawn(TgDevice) returned null\n",
 			Volume, Volume->s_nDeviceId);
+		if (isPad) Logger::Log("healpad", "[setupDevice] FAIL: Spawn(TgDevice) null\n");
 		return false;
 	}
 
@@ -124,15 +311,52 @@ bool __fastcall TgDeviceVolume_setupDevice::Call(ATgDeviceVolume* Volume, void* 
 		Logger::Log("device-volume",
 			"[setupDevice] volume=0x%p deviceId=%d: m_FireMode empty after ApplyDeviceSetup\n",
 			Volume, Volume->s_nDeviceId);
+		if (isPad) {
+			Logger::Log("healpad",
+				"[setupDevice] FAIL: deviceId=%d ApplyDeviceSetup ret=%d m_FireMode.Num=%d\n",
+				Volume->s_nDeviceId, rc,
+				Device->m_FireMode.Data ? Device->m_FireMode.Num() : -1);
+		}
 		return false;
 	}
 
 	Volume->s_DeviceFireMode = Device->m_FireMode.Data[0];
-	if (IsDomeVrHealPadVolume(Volume)) {
+	if (isPad) {
 		g_domeVrHealPadVolume = Volume;
+		g_padFireMode         = Volume->s_DeviceFireMode;
+		g_padRegisteredAtMs   = GetTickCount64();
+		g_padArmChecked       = false;
+		g_padHealEgCount      = 0;
+		// Hazard-volume semantics: the pad affects anyone standing on it,
+		// like the lava/toxic volume devices which ship target="All"
+		// (device_volumes.md). Device 5134 is a handheld heal gun whose mode
+		// ships a Friend targeter — and the pad's spawned TgDevice has no
+		// team/instigator, so IsValidTarget rejected every pawn (logs/290).
+		// Force All and clear the physicality gate.
+		g_padFireMode->m_eTargeterType      = 6;  // TGDTT All
+		// Physicality gate: 860 = the player-character physical type (logs/296:
+		// TgPawn_Character=860, pets=861, deployables differ). IsValidTarget
+		// natively rejects mismatches, so drones/turrets/pets/deployables get
+		// neither heal nor FX from the pad.
+		g_padFireMode->m_nTargetAffectsType = 860;
+		// Original pad cadence is +100 per second; 5134's gun mode fires every
+		// 0.5s. UC PostBeginPlay reads GetRefireTime() (= m_fFireTime) right
+		// after setupDevice returns to arm the engine PainTimer, so setting it
+		// here slows the engine-driven TimerPop to 1s. (logs/292 proved the
+		// engine Timer→TimerPop dispatch works — the only real defect was the
+		// Friend-targeter rejection.)
+		g_padFireMode->m_fFireTime = 1.0f;
 		Logger::Log("device-volume",
 			"[setupDevice] registered Dome VR heal pad volume=0x%p fireMode=0x%p\n",
 			Volume, Volume->s_DeviceFireMode);
+		Logger::Log("healpad",
+			"[setupDevice] armed: volume=0x%p deviceId=%d fireMode=0x%p refire=%.2fs "
+			"team=%d tf=%d collision=%d loc=(%.1f, %.1f, %.1f)\n",
+			Volume, Volume->s_nDeviceId, Volume->s_DeviceFireMode,
+			Volume->s_DeviceFireMode->GetRefireTime(),
+			Volume->s_nTeamNumber, (int)Volume->s_nTaskForce,
+			(int)Volume->bCollideActors,
+			Volume->Location.X, Volume->Location.Y, Volume->Location.Z);
 	}
 
 	Logger::Log("device-volume",

--- a/src/GameServer/TgGame/TgDeviceVolume/setupDevice/TgDeviceVolume__setupDevice.hpp
+++ b/src/GameServer/TgGame/TgDeviceVolume/setupDevice/TgDeviceVolume__setupDevice.hpp
@@ -5,6 +5,19 @@
 
 namespace DomeVrHealPad {
 	ATgDeviceVolume* GetRegisteredVolume();
+	// True when fm is the registered VR heal pad's fire mode — gate for the
+	// "healpad" diagnostic channel in the TgDeviceFire hooks.
+	bool IsPadFireMode(UTgDeviceFire* fm);
+	// True for the pad's kept heal effect group ids (recorded by the ArmCheck
+	// prune). SetEffectRep forces bIsBuff for these — the volume instigator
+	// fails IsEnemy, so UC's IsBuff() reps the heal as a debuff and the client
+	// FX tint inverts (yellow self / green enemy).
+	bool IsPadHealEffectGroup(int egId);
+	// One-shot post-PostBeginPlay arm check, driven from GameEngine__Tick.
+	// UC PostBeginPlay disarms the pad when the stripped setupDevice exec
+	// thunk misreports our hook's return; this samples the volume's armed
+	// state ~5s after registration and redoes the UC arming if needed.
+	void TickArmCheck();
 }
 
 class TgDeviceVolume_setupDevice : public HookBase<

--- a/src/GameServer/TgGame/TgEffectManager/SetEffectRep/TgEffectManager__SetEffectRep.cpp
+++ b/src/GameServer/TgGame/TgEffectManager/SetEffectRep/TgEffectManager__SetEffectRep.cpp
@@ -1,4 +1,5 @@
 #include "src/GameServer/TgGame/TgEffectManager/SetEffectRep/TgEffectManager__SetEffectRep.hpp"
+#include "src/GameServer/TgGame/TgDeviceVolume/setupDevice/TgDeviceVolume__setupDevice.hpp"
 #include "src/Utils/Logger/Logger.hpp"
 
 // TgEffectManager::SetEffectRep — the native @ 0x10a6ffe0 is INTACT (it does
@@ -24,6 +25,18 @@
 
 int __fastcall TgEffectManager__SetEffectRep::Call(ATgEffectManager* Manager, void* edx,
 		int nEffectGroupID, float fTime, unsigned long bIsBuff, int nHealthChange) {
+	// VR heal pad: UC computes bIsBuff via TgEffectGroup.IsBuff(), whose default
+	// branch is `m_Instigator != none && !m_Instigator.IsEnemy(m_Target)` — the
+	// pad's instigator is the team-0 TgDeviceVolume, which fails IsEnemy, so the
+	// heal reps as a debuff. The client packs this bit into the queue entry
+	// (bit 24) and sets TgEffectForm.c_bIsDebuff from it, inverting the FX tint
+	// (yellow self / green enemy instead of the Medical Station's green/yellow).
+	// A heal is a buff regardless of instigator — force the bit for the pad's
+	// heal group ids.
+	if (!bIsBuff && DomeVrHealPad::IsPadHealEffectGroup(nEffectGroupID)) {
+		bIsBuff = 1;
+		Logger::Log("healpad", "[SetEffectRep] forced bIsBuff for egId=%d\n", nEffectGroupID);
+	}
 	// The intact native does all replication (queue / managed-list / forms).
 	const int ret = CallOriginal(Manager, edx, nEffectGroupID, fTime, bIsBuff, nHealthChange);
 

--- a/src/GameServer/TgGame/TgPlayerActions/FullHeal/FullHeal.cpp
+++ b/src/GameServer/TgGame/TgPlayerActions/FullHeal/FullHeal.cpp
@@ -1,0 +1,129 @@
+#include "src/GameServer/TgGame/TgPlayerActions/FullHeal/FullHeal.hpp"
+
+#include "src/Config/Config.hpp"
+#include "src/GameServer/Storage/ClientConnectionsData/ClientConnectionsData.hpp"
+#include "src/GameServer/Combat/MissionAlerts/SendAlert.hpp"
+#include "src/GameServer/TgGame/TgPawn/SyncPawnHealth/SyncPawnHealth.hpp"
+#include <vector>
+#include "src/Utils/Logger/Logger.hpp"
+
+#include <windows.h>
+#include <cstdio>
+#include <cstring>
+#include <map>
+#include <string>
+
+namespace TgPlayerActions::FullHealCmd {
+
+namespace {
+
+constexpr uint64_t kCooldownMs = 15000;  // 15s per player
+
+std::map<std::string, uint64_t> g_lastUseMs;
+
+ATgPawn_Character* FindPawnBySessionGuid(const std::string& guid) {
+	for (auto& kv : GClientConnectionsData) {
+		if (kv.second.SessionGuid == guid) {
+			return kv.second.Pawn;
+		}
+	}
+	return nullptr;
+}
+
+void AlertPlayer(ATgPawn_Character* pawn, const char* msg) {
+	if (!pawn->Controller) return;
+	const char* raw = pawn->Controller->Class ? pawn->Controller->Class->GetFullName() : nullptr;
+	const std::string ctrlClass(raw ? raw : "");
+	if (ctrlClass.find("PlayerController") == std::string::npos) return;
+
+	APlayerController* PC = (APlayerController*)pawn->Controller;
+	if (!PC->Player) return;
+	UNetConnection* Connection = (UNetConnection*)PC->Player;
+
+	// ASCII zero-extend widen (message text is ASCII-only).
+	const std::wstring wmsg(msg, msg + std::strlen(msg));
+	SendAlert::SendText(Connection, wmsg.c_str(), 1, 0, 3.0f);
+}
+
+} // namespace
+
+void Execute(const std::string& session_guid) {
+	// VR arena only (Dome3_VR_Arena_P + _reserved 1v1 instances).
+	if (Config::GetMapNameChar().rfind("Dome3_VR_Arena_P", 0) != 0) {
+		Logger::Log("chat-command",
+			"[ChatCmd][DLL] fullheal guid=%s: blocked outside VR arena (map=%s)\n",
+			session_guid.c_str(), Config::GetMapNameChar().c_str());
+		return;
+	}
+
+	ATgPawn_Character* pawn = FindPawnBySessionGuid(session_guid);
+	if (!pawn) {
+		Logger::Log("chat-command", "[ChatCmd][DLL] fullheal guid=%s: no pawn\n",
+			session_guid.c_str());
+		return;
+	}
+	if (pawn->Health <= 0) {
+		Logger::Log("chat-command", "[ChatCmd][DLL] fullheal guid=%s: pawn dead; ignored\n",
+			session_guid.c_str());
+		return;
+	}
+
+	const uint64_t now = GetTickCount64();
+	auto it = g_lastUseMs.find(session_guid);
+	if (it != g_lastUseMs.end() && now - it->second < kCooldownMs) {
+		char buf[64];
+		std::snprintf(buf, sizeof(buf), "Full heal on cooldown (%llus)",
+			(unsigned long long)((kCooldownMs - (now - it->second) + 999) / 1000));
+		AlertPlayer(pawn, buf);
+		return;
+	}
+	g_lastUseMs[session_guid] = now;
+
+	// Cleanse first: remove every timed debuff group (poison, venom, slow,
+	// fire DoT, EMP stun, ...), self-inflicted included. Two selection rules:
+	//  - !IsBuff(): TgEffectGroup.uc:836 — hard-debuff categories are false
+	//    regardless of instigator; default categories are false when the
+	//    instigator is an enemy.
+	//  - CC posture: self-inflicted defaults (medic self-poison, recon
+	//    self-EMP) pass IsBuff (instigator not an enemy), but anything that
+	//    forces a crowd-control posture is a debuff.
+	// Lifetime<=0 groups (skill-tree/armor passives, instant hits) are never
+	// touched. RemoveEffectGroup is the intact native — reverses removable
+	// effects and tears down HUD icons/FX.
+	int cleansed = 0;
+	bool resetPosture = false;
+	ATgEffectManager* mgr = pawn->r_EffectManager;
+	if (mgr && mgr->s_AppliedEffectGroups.Data) {
+		auto isCcPosture = [](int p) { return (p >= 3 && p <= 14) || p == 24; };
+		std::vector<UTgEffectGroup*> debuffs;
+		for (int i = 0; i < mgr->s_AppliedEffectGroups.Num(); i++) {
+			UTgEffectGroup* g = mgr->s_AppliedEffectGroups.Data[i];
+			if (!g || g->m_fLifeTime <= 0.0f) continue;
+			if (!g->IsBuff() || isCcPosture(g->m_nPosture)) debuffs.push_back(g);
+		}
+		for (UTgEffectGroup* g : debuffs) {
+			const bool hadCcPosture = isCcPosture(g->m_nPosture);
+			if (mgr->RemoveEffectGroup(g)) {
+				cleansed++;
+				if (hadCcPosture) resetPosture = true;
+			}
+		}
+	}
+	// End the lingering stun/disease animation: SetPosture writes replicated
+	// r_ePosture (repnotify -> client OnPostureChange). 0 = TG_POSTURE_DEFAULT.
+	if (resetPosture) pawn->eventSetPosture(0, 1.0f, false);
+
+	const int oldHealth = pawn->Health;
+	// Full engine + property + PRI fan-out; notifyClient=true is the opt-in
+	// post-spawn heal path (see SyncPawnHealth.cpp).
+	SyncPawnHealth::Apply(pawn, pawn->r_nHealthMaximum, pawn->r_nHealthMaximum, true);
+
+	Logger::Log("chat-command",
+		"[ChatCmd][DLL] fullheal guid=%s: %d -> %d (cleansed %d debuff groups%s)\n",
+		session_guid.c_str(), oldHealth, pawn->Health, cleansed,
+		resetPosture ? ", posture reset" : "");
+
+	AlertPlayer(pawn, "Healed to full");
+}
+
+} // namespace TgPlayerActions::FullHealCmd

--- a/src/GameServer/TgGame/TgPlayerActions/FullHeal/FullHeal.hpp
+++ b/src/GameServer/TgGame/TgPlayerActions/FullHeal/FullHeal.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+namespace TgPlayerActions::FullHealCmd {
+
+// -fullheal: restore the requesting player's pawn to full health. Only active
+// on the VR arena maps (Dome3_VR_Arena_P*) — practice / 1v1 use. Per-player
+// cooldown to prevent spam mid-duel; remaining time is shown as an alert.
+//
+// MUST be called on the game thread (sole caller path is IpcClient::DrainInbound
+// from Actor::Tick).
+void Execute(const std::string& session_guid);
+
+} // namespace TgPlayerActions::FullHealCmd

--- a/src/IpcClient/IpcClient.cpp
+++ b/src/IpcClient/IpcClient.cpp
@@ -12,6 +12,7 @@
 #include "src/GameServer/TgGame/TgPlayerActions/ReturnHomeArea/ReturnHomeArea.hpp"
 #include "src/GameServer/TgGame/TgPlayerActions/TopDown/TopDown.hpp"
 #include "src/GameServer/TgGame/TgPlayerActions/Coords/Coords.hpp"
+#include "src/GameServer/TgGame/TgPlayerActions/FullHeal/FullHeal.hpp"
 #include "src/GameServer/Storage/ClientConnectionsData/ClientConnectionsData.hpp"
 #include "src/GameServer/IpDrv/NetConnection/Cleanup/NetConnection__Cleanup.hpp"
 #include "src/GameServer/Stats/MatchStats.hpp"
@@ -652,6 +653,8 @@ void IpcClient::DrainInbound() {
                 TgPlayerActions::PossessCmd::ExecuteUnpossess(guid);
             } else if (action == "coords") {
                 TgPlayerActions::CoordsCmd::Execute(guid);
+            } else if (action == "fullheal") {
+                TgPlayerActions::FullHealCmd::Execute(guid);
             } else if (action == "topdown") {
                 if (CurrentMatchIsPVP()) {
                     Logger::Log("chat-command",

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -485,7 +485,10 @@ DWORD WINAPI ModuleThread(LPVOID) {
 	TgDeviceFire__Deploy::Install();
 	TgDeviceFire__SpawnPet::Install();
 	// TgDeviceFire__CheckTeamPassThrough::Install();
-	// TgDeviceFire__IsValidTarget::Install();
+	// Diagnostic hook (pass-through + channel-gated logging). Re-enabled for
+	// the VR heal pad chain trace — the "healpad" block needs it to see UC's
+	// ApplyHit → IsValidTarget calls.
+	TgDeviceFire__IsValidTarget::Install();
 	// TgDevice__HasMinimumPowerPool::Install();
 	TgEffectManager__RemoveAllEffectGroups::Install();
 	TgEffectManager__RemoveAllEffects::Install();


### PR DESCRIPTION
VR Arena: heal pad + -fullheal command

Bug 1: Heal pad did nothing

Symptom: The visible heal pad in the middle of Dome3_VR_Arena_P (map object 11041) never healed anyone.

Root cause: The pad's device fire mode ships with a Friend targeter, but the spawned TgDevice has no team or instigator — so the native IsValidTarget rejected every pawn that stood on it. (Several earlier theories — dead timer dispatch, wrong volume coordinates — were artifacts of the IsValidTarget hook never being installed in dllmain; that install is also part of this PR.)

Fix: At setupDevice registration the pad's fire mode is forced to targeter All (hazard-volume semantics — same as lava/toxic volumes, affects anyone standing on it), matching the original behavior.

Bug 2: Pad healed too fast and showed stray HUD buff icons

Symptom: ~300 HP/s instead of the original +100/s, plus two buff icons on the HUD that the original pad never showed.

Root cause: The device's effect-group list carries lifetime>0 HoT/buff groups (they register managed HUD slots and stack extra healing), and the mode's 0.5s refire doubled the tick rate. Device 2064's Medical Station data also ships +154 per tick.

Fix: One-shot arm-check prunes the fire mode's effect list down to the instant (lifetime≤0) heal group, caps the heal base at 100, and sets refire to 1s. All in-memory, scoped to this fire mode — the DB row is shared with the real Medical Station deployable.

Bug 3: Pad healed drones, turrets, pets, deployables

Fix: Physicality gate set to 860 (player characters) on the pad's fire mode — the native IsValidTarget now rejects non-humans before any heal or FX happens. Humans on both teams still pass.

Bug 4: Heal FX tint inverted (yellow on self, green on enemies)

Symptom: Opposite of the Medical Station's authentic green-friendly / yellow-enemy tint.

Root cause: The server replicates a buff/debuff bit per effect application (SetEffectRep), computed by TgEffectGroup.IsBuff(), whose fallback rule is "instigator is not my enemy." The pad's instigator is the team-0 volume itself, which fails IsEnemy — so the heal replicated as a debuff, and the client FX layer flips the tint on that bit (verified end-to-end in the binary: bit 24 of the replicated queue entry → TgEffectForm.c_bIsDebuff).

Fix: The SetEffectRep hook forces the buff bit for the pad's heal effect-group ids. Correct even where the real Medical Station shares the id — a heal is a buff regardless of instigator.

Tested:  Works with skills that add healing recived: 
	- Medic Battle Medic 6%
	- Assault Heavy Armor 7%

Feature: -fullheal chat command

VR-arena-only chat command with a 15s per-player cooldown. On activation it:
1. Cleanses debuffs first — removes every timed (lifetime>0) effect group that fails IsBuff() (poison, venom, slow, fire DoT — hard-coded debuff categories) or forces a crowd-control posture (catches self-inflicted debuffs like a medic's own poison or a recon's own EMP, which IsBuff() misclassifies because the instigator isn't an enemy). Lifetime-0 passives (skill tree, armor) are never touched.
2. Resets posture if a removed group forced one — ends the lingering disease/stun animation via replicated r_ePosture.
3. Heals to full with full HP fan-out and client notify.


Related to https://discord.com/channels/994691794627461211/1519549430032896081