### PR TITLE
Fix lingering shield bar on buff timeout

### DIFF
--- a/src/GameServer/TgGame/TgEffectManager/RemoveEffectGroup/TgEffectManager__RemoveEffectGroup.cpp
+++ b/src/GameServer/TgGame/TgEffectManager/RemoveEffectGroup/TgEffectManager__RemoveEffectGroup.cpp
@@ -149,6 +149,24 @@ bool __fastcall TgEffectManager__RemoveEffectGroup::Call(ATgEffectManager* Manag
 			Manager, nullptr, removedCategory, 1u);
 	}
 
+	// 6. Shield-bar clear. A finite-HP shield group (m_nHealth > 0) publishes the
+	//    pawn's yellow r_nShieldHealthMax/Remaining bar at apply time. The
+	//    damage-break path (SubmitMitigationDamage) clears it, but lifetime
+	//    expiry (LifeDone timer) / stack-replace route here without clearing —
+	//    leaving the bar stuck when the buff times out before HP is drained.
+	//    Clear it centrally so every removal reason drops the bar. UC scopes
+	//    shield HP to one active group, so a lone match is safe.
+	if (applied->m_nHealth > 0) {
+		AActor* owner = Manager->r_Owner;
+		if (owner && ObjectClassCache::GetClassName(owner).compare(0, 19, "Class TgGame.TgPawn") == 0) {
+			ATgPawn* pawn = (ATgPawn*)owner;
+			pawn->r_nShieldHealthMax = 0;
+			pawn->r_nShieldHealthRemaining = 0;
+			pawn->bNetDirty = 1;
+			pawn->bForceNetUpdate = 1;
+		}
+	}
+
 	Manager->bNetDirty = 1;
 	if (Logger::IsChannelEnabled("effects")) {
 		Logger::Log("effects", "[REMOVE-GROUP] removed egId=%d cat=%d slot=%d\n",

--- a/src/GameServer/TgGame/TgEffectManager/SubmitMitigationDamage/TgEffectManager__SubmitMitigationDamage.cpp
+++ b/src/GameServer/TgGame/TgEffectManager/SubmitMitigationDamage/TgEffectManager__SubmitMitigationDamage.cpp
@@ -108,15 +108,17 @@ void __fastcall TgEffectManager__SubmitMitigationDamage::Call(
 		}
 		TgEffectManager__RemoveEffectGroup::Call(Manager, nullptr, shield);
 
-		// Clear the published bar so the client HUD's shield indicator
-		// disappears. UC apply rewrites these on the next shield, so we don't
-		// need to reset on every mitigation — just on shield-break.
-		if (ownerIsPawn) {
-			ATgPawn* pawn = (ATgPawn*)owner;
-			pawn->r_nShieldHealthMax = 0;
-			pawn->r_nShieldHealthRemaining = 0;
-			pawn->bNetDirty = 1;
-			pawn->bForceNetUpdate = 1;
-		}
+		// Bar clear now lives centrally in RemoveEffectGroup (fires for any
+		// m_nHealth>0 group on every removal reason — damage-break, lifetime
+		// timeout, stack-replace). The break path above already found this
+		// shield in s_AppliedEffectGroups, so RemoveEffectGroup finds the same
+		// entry and zeroes the bar. Kept commented as the local reference.
+		// if (ownerIsPawn) {
+		// 	ATgPawn* pawn = (ATgPawn*)owner;
+		// 	pawn->r_nShieldHealthMax = 0;
+		// 	pawn->r_nShieldHealthRemaining = 0;
+		// 	pawn->bNetDirty = 1;
+		// 	pawn->bForceNetUpdate = 1;
+		// }
 	}
 }


### PR DESCRIPTION
Symptom
When an enemy player's shield (ranged, AOE, Assault's Protection Boost, etc.) runs out on its lifetime timer — e.g. the 10s buff expiring — before its HP pool is fully drained, the yellow secondary bar under the health bar stays stuck on their nameplate. If the shield instead breaks by taking enough damage, the bar disappears correctly. So the bar was only being cleared on one of the two ways a shield can end.

Root cause
The yellow bar is driven by r_nShieldHealthMax / r_nShieldHealthRemaining on ATgPawn, published at apply time by the engine for any finite-HP shield group (m_nHealth > 0). The bar was only zeroed on the damage-break path inside SubmitMitigationDamage (when the absorbed pool hit 0). Every other way a shield group ends — lifetime-timer expiry (LifeDone) and stack-replace — routes through RemoveEffectGroup, which tore down the group, timers, and HUD slot but never cleared the replicated bar fields. On timeout the group was gone server-side while the pawn kept replicating a non-zero shield value, so the client kept drawing the bar.

Fix
Move the bar-clear to the shared removal path. RemoveEffectGroup now zeroes r_nShieldHealthMax / r_nShieldHealthRemaining (and flags the pawn net-dirty) whenever the removed group is a finite-HP shield (m_nHealth > 0), so every removal reason — timeout, damage-break, stack-replace — drops the bar. This is the root-cause fix: one guard in the function all removals funnel through, rather than patching each caller.

The now-redundant clear in SubmitMitigationDamage was commented out (not deleted) with a pointer to the central one — keeping a single source of truth and avoiding two copies of the same invariant drifting apart.

Coverage note
Source-agnostic by design: it keys only on m_nHealth > 0, so any ability that shows the yellow bar is covered. Verified against the effect-group data — Protection Boost is a health=2000 finite-HP shield (same shape as ranged/AOE), while Protection Wave is a pure %-reduction buff with health=0 that never shows the bar, so it's correctly unaffected.

Testing
Tested in-game — bar now drops on both timeout and HP-depletion for:
- Range shield
- AOE shield
- Protection Boost

Files
- TgEffectManager__RemoveEffectGroup.cpp — central bar-clear on shield-group removal.
- TgEffectManager__SubmitMitigationDamage.cpp — redundant clear commented out.

Related to:  https://discord.com/channels/994691794627461211/1523612833038995466