### PR TITLE
Decoy visual fix (recon offhand "Decoy", device 2129)

### DIFF
--- a/src/GameServer/TgGame/TgDeviceFire/SpawnPet/TgDeviceFire__SpawnPet.cpp
+++ b/src/GameServer/TgGame/TgDeviceFire/SpawnPet/TgDeviceFire__SpawnPet.cpp
@@ -8,6 +8,7 @@
 #include "src/Utils/Logger/Logger.hpp"
 #include "src/GameServer/Utils/ObjectClassCache/ObjectClassCache.hpp"
 #include "src/GameServer/Misc/CAmBot/LoadBotMarshal/CAmBot__LoadBotMarshal.hpp"
+#include "src/GameServer/Constants/GameTypes.h"
 #include <string>
 
 // BOT_TYPE_VALUE_ID (BotConfig+0x5C) that marks a spawned pet as a decoy.
@@ -313,18 +314,24 @@ void __fastcall TgDeviceFire__SpawnPet::Call(UTgDeviceFire* pThis, void* edx, BO
 				ownerName.Count = ownerName.Max = 0;
 			}
 
-			// NOTE: melee mimicry (give the decoy the recon's ES1 melee so the
-			// follow-AI swings it) is NOT done here. The device-equip helper
-			// GiveDeviceById crashes: it reads deviceId (an EBX-frame-spilled
-			// local) after calling UpdateClientDevices, which returns with EBX
-			// clobbered (a hooked native not preserving the callee-saved reg —
-			// same class of bug as the SpawnBotById frame trap). Needs a
-			// crash-safe equip path (UpdateClientDevices as the final call, no
-			// local reads after) — pending.
-
 			PetPawn->bNetDirty       = 1;
 			PetPawn->bForceNetUpdate = 1;
 			if (PetRep) { PetRep->bNetDirty = 1; PetRep->bForceNetUpdate = 1; }
+
+			// Melee mimicry: give the decoy the recon's ES1 melee weapon (engine
+			// equip point 1) and set it in-hand so the already-engaging follow-AI
+			// swings it. The weapon's dye rides along in r_CustomCharacterAssembly
+			// (DyeList[3]=WeaponColor, [4]=WeaponEmissive), copied above. No damage
+			// results — r_bIsDecoy makes TgDeviceFire::IsDecoyEffect short-circuit
+			// SubmitEffect. Uses the crash-safe single-device equip helper (NOT the
+			// landmined GiveDeviceById). Done LAST in this block, after all local
+			// reads, since EquipInHandDevice ends in UpdateClientDevices.
+			ATgDevice* ownerMelee = pawn->m_EquippedDevices[1];
+			if (ownerMelee && ownerMelee->r_nDeviceId != 0) {
+				TgGame__SpawnBotById::EquipInHandDevice(
+					PetPawn, PetRep, ownerMelee->r_nDeviceId,
+					/*equipPoint=*/1, ownerMelee->r_nQualityValueId, GA_G::TGDT_MELEE);
+			}
 		}
 
 		// Pet auto-despawn timer. Prop 354 TGPID_PET_LIFESPAN on the spawn-pet

--- a/src/GameServer/TgGame/TgDeviceFire/SpawnPet/TgDeviceFire__SpawnPet.cpp
+++ b/src/GameServer/TgGame/TgDeviceFire/SpawnPet/TgDeviceFire__SpawnPet.cpp
@@ -7,7 +7,12 @@
 #include "src/GameServer/Engine/World/GetGameInfo/World__GetGameInfo.hpp"
 #include "src/Utils/Logger/Logger.hpp"
 #include "src/GameServer/Utils/ObjectClassCache/ObjectClassCache.hpp"
+#include "src/GameServer/Misc/CAmBot/LoadBotMarshal/CAmBot__LoadBotMarshal.hpp"
 #include <string>
+
+// BOT_TYPE_VALUE_ID (BotConfig+0x5C) that marks a spawned pet as a decoy.
+// UC: const TG_BOT_TYPE_DECOY = 628.
+static constexpr int TG_BOT_TYPE_DECOY = 628;
 
 // Placement trace helper (FUN_10a1b7e0) — same one TgDeviceFire::Deploy uses.
 // Client UpdateDeployModeStatus calls this with the bot's collision cylinder
@@ -113,6 +118,10 @@ void __fastcall TgDeviceFire__SpawnPet::Call(UTgDeviceFire* pThis, void* edx, BO
     rot.Yaw   = spawnRot.Yaw;
     rot.Roll  = 0;
 
+	// Decoy detection is by the spawned bot's BOT_TYPE_VALUE_ID (== 628
+	// TG_BOT_TYPE_DECOY), NOT bPet: the Decoy offhand (device 2129) fires as a
+	// normal SPAWN_PET (attack_type 306, bPet=TRUE) exactly like turrets/drones.
+	// The decoy mimicry is applied below on the spawned pawn.
 	ATgPawn* PetPawn = TgGame__SpawnBotById::Call(game, nullptr, petId, spawnLocation, spawnRot, false, nullptr, true, pawn, false, pThis, 0.0f);
 	// ATgPawn* PetPawn = (ATgPawn*)game->SpawnBotById(petId, spawnLocation, spawnRot, false, nullptr, true, pawn, false, pThis, 0.0f);
 
@@ -258,6 +267,65 @@ void __fastcall TgDeviceFire__SpawnPet::Call(UTgDeviceFire* pThis, void* edx, BO
 		PetRep->Team = PawnRep->Team;
 		PetRep->SetTeam(PawnRep->r_TaskForce);
 		PetPawn->NotifyTeamChanged();
+
+		// --- Decoy: mimic the deploying player's appearance ---
+		// The Decoy offhand (device 2129) fires as a normal SPAWN_PET
+		// (attack_type 306, bPet=TRUE) just like turrets/drones, so bPet can't
+		// distinguish it. The spawned bot's BOT_TYPE_VALUE_ID (BotConfig+0x5C)
+		// == 628 (TG_BOT_TYPE_DECOY) is the discriminator. Copy the owner's
+		// custom-character assembly (Suit/Head/Hair/Helmet mesh + skin/dye/flair,
+		// incl. bValidCustomAssembly) onto the decoy pawn AND its PRI so the
+		// client's OnCustomAssemblyChanged -> IsCustomCharacter path rebuilds the
+		// decoy from the player's cosmetics (same mechanism SpawnBotPawn uses to
+		// render a bot as a custom character). r_bIsDecoy also drives the
+		// server-side taunt/threat mechanic (TgDeviceFire::IsDecoyEffect).
+		// Assembly + head-mesh writes are at ATgPawn_Character offsets, so gate
+		// them on both pawns actually being Characters; r_bIsDecoy / body-mesh /
+		// profile-type live on base ATgPawn.
+		void* botCfg = (void*)CAmBot__LoadBotMarshal::m_BotPointers[petId];
+		const int botTypeValueId = botCfg ? *(int*)((char*)botCfg + 0x5C) : 0;
+		const bool isDecoy = (botTypeValueId == TG_BOT_TYPE_DECOY);
+		if (isDecoy) {
+			PetPawn->r_bIsDecoy            = 1;
+			PetPawn->r_nProfileTypeValueId = pawn->r_nProfileTypeValueId;
+			PetPawn->r_nBodyMeshAsmId      = pawn->r_nBodyMeshAsmId;
+			const bool decoyIsChar = ObjectClassCache::ClassNameContains(PetPawn, "TgPawn_Character");
+			const bool ownerIsChar = ObjectClassCache::ClassNameContains(pawn, "TgPawn_Character");
+			if (decoyIsChar && ownerIsChar) {
+				ATgPawn_Character* ownerChar = (ATgPawn_Character*)pawn;
+				ATgPawn_Character* decoyChar = (ATgPawn_Character*)PetPawn;
+				decoyChar->r_CustomCharacterAssembly = ownerChar->r_CustomCharacterAssembly;
+				decoyChar->r_nHeadMeshAsmId          = ownerChar->r_nHeadMeshAsmId;
+				if (PetRep) PetRep->r_CustomCharacterAssembly = ownerChar->r_CustomCharacterAssembly;
+			}
+			// Nameplate: the client renders "<PlayerName> - Decoy" for r_bIsDecoy
+			// pawns. The decoy bot's PRI defaults to the bot's own name ("Decoy"),
+			// giving "Decoy - Decoy" — replace it with the owner's name so it reads
+			// "<Owner> - Decoy". Mirror SpawnPlayerCharacter's FString handoff:
+			// eventSetPlayerName memcpys our FString into its Parms and ProcessEvent
+			// may free the Data, so pass a COPY and null its Data before scope exit
+			// (never hand it PawnRep's own PlayerName.Data — that would free the
+			// owner's name).
+			if (PetRep && PawnRep && PawnRep->PlayerName.Data) {
+				FString ownerName(PawnRep->PlayerName.Data);
+				PetRep->eventSetPlayerName(ownerName);
+				ownerName.Data = nullptr;
+				ownerName.Count = ownerName.Max = 0;
+			}
+
+			// NOTE: melee mimicry (give the decoy the recon's ES1 melee so the
+			// follow-AI swings it) is NOT done here. The device-equip helper
+			// GiveDeviceById crashes: it reads deviceId (an EBX-frame-spilled
+			// local) after calling UpdateClientDevices, which returns with EBX
+			// clobbered (a hooked native not preserving the callee-saved reg —
+			// same class of bug as the SpawnBotById frame trap). Needs a
+			// crash-safe equip path (UpdateClientDevices as the final call, no
+			// local reads after) — pending.
+
+			PetPawn->bNetDirty       = 1;
+			PetPawn->bForceNetUpdate = 1;
+			if (PetRep) { PetRep->bNetDirty = 1; PetRep->bForceNetUpdate = 1; }
+		}
 
 		// Pet auto-despawn timer. Prop 354 TGPID_PET_LIFESPAN on the spawn-pet
 		// device-mode (drones 10-20s typical; turrets generally lack the row →

--- a/src/GameServer/TgGame/TgGame/SpawnBotById/TgGame__SpawnBotById.cpp
+++ b/src/GameServer/TgGame/TgGame/SpawnBotById/TgGame__SpawnBotById.cpp
@@ -1102,6 +1102,13 @@ ATgPawn* __fastcall TgGame__SpawnBotById::Call(
 
 	GiveDevicesFromBotConfig(Bot, BotRepInfo, nBotId);
 
+	// NOTE: decoy appearance mimicry (r_bIsDecoy + copy the deployer's custom-
+	// character assembly) is applied by the CALLER (TgDeviceFire::SpawnPet),
+	// not here. Doing it in this function crashed: the compiler spills
+	// pOwnerPawn/bIsDecoy to an EBX-based frame slot that is not valid across
+	// the GiveDevicesFromBotConfig call in the optimized build. SpawnPet holds
+	// clean pawn/PetPawn locals, so the copy is safe there.
+
 	// Corpse cleanup. TgPawn.Dying 'Begin:' arms SetTimer(m_fLifeAfterDeathSecs)
 	// whose Timer() does Controller.Destroy() + bTearOff + Destroy() for AI
 	// bots — but the field is 0 everywhere (no UC write, no defaultproperties;

--- a/src/GameServer/TgGame/TgGame/SpawnBotById/TgGame__SpawnBotById.cpp
+++ b/src/GameServer/TgGame/TgGame/SpawnBotById/TgGame__SpawnBotById.cpp
@@ -467,6 +467,57 @@ void TgGame__SpawnBotById::GiveDevicesFromBotConfig(ATgPawn* Bot, ATgRepInfo_Pla
 	// BotRepInfo->bForceNetUpdate = 1;
 }
 
+// Crash-safe post-spawn equip of one in-hand device. Same per-device wiring as
+// GiveDevicesFromBotConfig (the proven-safe path that already equips every bot's
+// devices), collapsed to a single device. CRITICAL: UpdateClientDevices is the
+// FINAL statement and nothing reads a spilled local after it — the legacy
+// GiveDeviceById crashes precisely because it reads deviceId after that call
+// (EBX clobbered across UpdateClientDevices). See project_spawnbotbyid-frame-trap.
+void TgGame__SpawnBotById::EquipInHandDevice(
+	ATgPawn* Pawn, ATgRepInfo_Player* PRI,
+	int deviceId, int equipPoint, int quality, int deviceType) {
+	if (Pawn == nullptr || Pawn->InvManager == nullptr || deviceId == 0) return;
+
+	ATgDevice* Device = Pawn->CreateEquipDevice(0, deviceId, equipPoint);
+	if (Device == nullptr) return;
+
+	// Permanent equip-effect groups (stand-in for the stripped m_EquipEffect
+	// path), same as the bot-config equip.
+	Inventory::ApplyDeviceEquipEffects(Pawn, deviceId);
+
+	const int invId = Inventory::NextId();
+	Device->r_nDeviceInstanceId = invId;
+	Device->r_eEquippedAt       = equipPoint;
+	Device->m_bIsOffHand        = false;   // in-hand weapon
+	Device->m_bHandDevice       = true;
+	Device->m_nDeviceType       = deviceType;
+	Device->r_nDeviceId         = deviceId;
+	Device->r_nQualityValueId   = quality;
+	Device->Instigator          = (APawn*)Pawn;
+
+	Pawn->m_EquippedDevices[equipPoint] = Device;
+
+	// Build the fire-mode m_Properties so the weapon's fire path (and thus the
+	// attack animation) resolves — same native pipeline the bot-config path runs.
+	BuildDeviceFireProperties(Device);
+	Device->Role = 3;
+
+	FEquipDeviceInfo info;
+	info.nDeviceId         = deviceId;
+	info.nDeviceInstanceId = invId;
+	info.nQualityValueId   = quality;
+	Pawn->r_EquipDeviceInfo[equipPoint] = info;
+	if (PRI) PRI->r_EquipDeviceInfo[equipPoint] = info;
+
+	// Make it the in-hand weapon so the engaging AI swings it.
+	Pawn->m_CurrentInHandDevice = Device;
+	Pawn->r_eDesiredInHand      = equipPoint;
+
+	Pawn->bNetDirty       = 1;
+	Pawn->bForceNetUpdate = 1;
+	Pawn->UpdateClientDevices(0, 0);   // FINAL — read no spilled local after this
+}
+
 
 // Pack-pet limit (prop 154 MAX_PLACEABLE_ENTITIES_OUT > 1 on the spawning fire
 // mode, e.g. Spider Grenades = 3): suicide the oldest live pets spawned by the

--- a/src/GameServer/TgGame/TgGame/SpawnBotById/TgGame__SpawnBotById.hpp
+++ b/src/GameServer/TgGame/TgGame/SpawnBotById/TgGame__SpawnBotById.hpp
@@ -240,6 +240,14 @@ public:
 		int nInventoryId
 	);
 	static void GiveDevicesFromBotConfig(ATgPawn* Bot, ATgRepInfo_Player* BotRepInfo, int nBotId);
+	// Crash-safe post-spawn equip of ONE in-hand device (decoy melee mimicry).
+	// Mirrors GiveDevicesFromBotConfig's proven per-device wiring and ends with
+	// UpdateClientDevices as the FINAL call — never add code after that call that
+	// reads spilled locals (that ordering is exactly what makes the legacy
+	// GiveDeviceById crash: EBX clobbered across UpdateClientDevices). See
+	// project_spawnbotbyid-frame-trap.
+	static void EquipInHandDevice(ATgPawn* Pawn, ATgRepInfo_Player* PRI,
+		int deviceId, int equipPoint, int quality, int deviceType);
 	static inline char* GetPawnClassName(int nBotId) {
 
 		const char* dbClass = LookupPawnClassFromDb(nBotId);


### PR DESCRIPTION
Bug: The recon's Decoy offhand spawned a bot that looked like a hardcoded placeholder NPC, was labeled "Decoy". 
In the original game the decoy impersonates the recon who deployed it — same cosmetics, same name, and it fake-attacks nearby enemies with the recon's melee weapon (dealing no damage).

Root cause: The decoy spawns as an ordinary SPAWN_PET (attack_type 306) with the deployer's bot config, so it rendered as bot 735's default body and never received the deployer's identity. The server-side decoy path had never been reimplemented after the original server was lost.

Fix (all server-side, in TgDeviceFire::SpawnPet): When a spawned pet's BOT_TYPE_VALUE_ID is 628 (TG_BOT_TYPE_DECOY):
- Copy the deployer's r_CustomCharacterAssembly (suit/head/hair/helmet meshes, skin, and dyes — including weapon dye) plus body/head mesh onto the decoy pawn and its PRI, and set r_bIsDecoy. The client's IsCustomCharacter path then rebuilds the decoy as the player's character.
- Set the decoy PRI's name to the deployer's, so the nameplate reads <Owner> - Decoy instead of Decoy - Decoy.
- Equip a copy of the recon's ES1 melee weapon in-hand, so the existing follow-AI swings it. Zero damage is guaranteed by the game's own r_bIsDecoy → IsDecoyEffect gate.

Notable landmine (documented in-code): the legacy GiveDeviceById equip helper is dead code that crashes on first use — it reads a spilled local (deviceId) after UpdateClientDevices, which returns with the callee-saved EBX register clobbered. The melee equip instead uses a neructured so UpdateClientDevices is the finalcall. Same class of frame-corruption forced the cosmetic/name copy to live in the SpawnPet caller rather than deep  inside SpawnBotById.

Testing: Verified in-game that the decoy correctly mirrors the deployer's cosmetics, dyes, and name, and swings the equipped weapon with no damage. Tested acrosns: Dual Daggers, Ghost Sword, and AssassinBlade.

Related to:  https://discord.com/channels/994691794627461211/1524273974693855352