### PR TITLE
Attempt to fix Dome Boost from robos disappearing

### DIFF
--- a/src/GameServer/Core/UObject/ProcessEvent/UObject__ProcessEvent.cpp
+++ b/src/GameServer/Core/UObject/ProcessEvent/UObject__ProcessEvent.cpp
@@ -11,6 +11,7 @@
 #include "src/GameServer/Stats/MatchStats.hpp"
 #include "src/GameServer/Combat/MissionAlerts/SendAlert.hpp"
 #include "src/GameServer/Utils/ObjectClassCache/ObjectClassCache.hpp"
+#include "src/GameServer/TgGame/_deployable_classify/DeployableClassify.hpp"
 #include "src/GameServer/Storage/ClientConnectionsData/ClientConnectionsData.hpp"
 #include "src/GameServer/Storage/TeamsData/TeamsData.hpp"
 #include "src/GameServer/GameModes/SuperAgent/SuperAgent.hpp"
@@ -174,6 +175,7 @@ enum class DispatchTag : uint8_t {
 	SeqOpActivated,               // kismet op eventActivated — TgSeqAct_AlarmBots raises the global alarm
 	TgTriggerBeaconEntrance,      // Pre-call: record teammate beacon-teleport usage for match stats
 	SuperAgentCaptureGate,        // Super Agent mode: freeze proximity capture per the all-players / drain gate, then detect A's capture
+	PayloadDeployableCrush,       // Payload (TgObjectiveAttachActor) Touch/RanInto/EncroachingOn — skip for morale Dome Shields
 	// GameTimerDiagnostic,          // Diagnostic-only: before/after snapshots around original timer/match flow
 };
 
@@ -582,6 +584,14 @@ static DispatchTag ClassifyFunction(UFunction* fn) {
 	// capture. Intercept Tick (which DOES route through ProcessEvent) rather than
 	// the inner CalculateNearByPlayers (an intra-UC call that does not).
 	if (strcmp(name, "Function TgGame.TgMissionObjective_Proximity.Tick") == 0) return DispatchTag::SuperAgentCaptureGate;
+	// Escort/payload crush. The payload is a TgObjectiveAttachActor whose
+	// Touch / RanInto / EncroachingOn each do
+	// `if (TgDeployable(Other)) Other.DestroyIt()`. Skip all three for morale
+	// Dome Shields so the payload passes through without destroying them.
+	if (strcmp(name, "Function TgGame.TgObjectiveAttachActor.Touch") == 0 ||
+	    strcmp(name, "Function TgGame.TgObjectiveAttachActor.RanInto") == 0 ||
+	    strcmp(name, "Function TgGame.TgObjectiveAttachActor.EncroachingOn") == 0)
+		return DispatchTag::PayloadDeployableCrush;
 	// if (IsGameTimerDiagnosticFunction(name)) return DispatchTag::GameTimerDiagnostic;
 
 	return DispatchTag::Unknown;
@@ -1920,6 +1930,30 @@ void __fastcall UObject__ProcessEvent::Call(UObject* Object, void* edx, UFunctio
 	// per-frame escape mechanics must keep ticking even while capture is frozen,
 	// e.g. the periodic escape alarm while players are off-point). It early-
 	// returns for every objective that isn't our A, and for non-Super-Agent matches.
+	case DispatchTag::PayloadDeployableCrush: {
+		// Payload crush immunity for the Robotics Morale Dome Shield. The escort
+		// payload is a TgObjectiveAttachActor; its Touch / RanInto /
+		// EncroachingOn each call `if (TgDeployable(Other)) Other.DestroyIt()`.
+		// For a self-spawning force-field dome, skip the whole handler so the
+		// DestroyIt never runs and the payload passes through it. Turrets
+		// (Suicide) and other deployables are unaffected — only self-spawn domes
+		// match. `Other` is param 0. EncroachingOn returns bool at Params+4
+		// (Touch/RanInto are void — must NOT write past their smaller Parms).
+		AActor* other = Params ? *(AActor**)Params : nullptr;
+		if (other &&
+		    ObjectClassCache::ClassNameContains(other, "TgDeploy_ForceField") &&
+		    DeployableClassify::DeploysOnSelf(((ATgDeployable*)other)->r_nDeployableId)) {
+			const char* fn = Function->GetFullName();
+			if (fn && strstr(fn, "EncroachingOn")) {
+				if (Params) *(uint32_t*)((char*)Params + 4) = 0;  // ReturnValue = false (don't stop)
+				if (Result) *(uint32_t*)Result = 0;
+			}
+			break;  // skip CallOriginal → no dome.DestroyIt()
+		}
+		CallOriginal(Object, edx, Function, Params, Result);
+		break;
+	}
+
 	case DispatchTag::SuperAgentCaptureGate: {
 		ATgMissionObjective_Proximity* Obj = (ATgMissionObjective_Proximity*)Object;
 		if (SuperAgent::ShouldRunCapture(Obj)) {

--- a/src/GameServer/TgGame/TgDeviceFire/Deploy/TgDeviceFire__Deploy.cpp
+++ b/src/GameServer/TgGame/TgDeviceFire/Deploy/TgDeviceFire__Deploy.cpp
@@ -236,6 +236,18 @@ void __fastcall TgDeviceFire__Deploy::Call(UTgDeviceFire* pThis, void* edx) {
 			}
 		}
 
+		// The native ApplyDeployableSetup runs the deployable's FULL deploy
+		// lifecycle synchronously (StartDeploy → Deploy → DeployComplete →
+		// UpdateHealth → Active). Our InitializeDefaultProps — which sets
+		// r_nHealth to the real max — runs AFTER, so without this the lifecycle
+		// executes at r_nHealth==0 and health<=0 code paths can treat the dome
+		// as already dead and destroy it at launch. Seed the real health FIRST
+		// so it deploys alive; InitializeDefaultProps re-applies it right after.
+		{
+			const int seedHp = DeployableClassify::GetMaxHealth(deployableId);
+			if (seedHp > 0) Deployable->r_nHealth = seedHp;
+		}
+
 		Deployable->ApplyDeployableSetup();
 		Deployable->InitializeDefaultProps();
 

--- a/src/GameServer/TgGame/_deployable_classify/DeployableClassify.cpp
+++ b/src/GameServer/TgGame/_deployable_classify/DeployableClassify.cpp
@@ -109,4 +109,32 @@ bool IsDestructible(int nDeployableId) {
 	return destructible == 1;
 }
 
+int GetMaxHealth(int nDeployableId) {
+	// asm_data_set_deployables.health (0 when absent). Cached per id. Used to
+	// pre-seed r_nHealth before ApplyDeployableSetup so a deployable's in-setup
+	// deploy lifecycle doesn't run at 0 HP (which lets an incidental hit event
+	// drop it to <=0 → DestroyIt → instant despawn).
+	static std::unordered_map<int, int> s_cache;
+	auto it = s_cache.find(nDeployableId);
+	if (it != s_cache.end()) return it->second;
+
+	int health = 0;
+	sqlite3* db = Database::GetConnection();
+	if (db) {
+		sqlite3_stmt* stmt = nullptr;
+		if (sqlite3_prepare_v2(db,
+			"SELECT health FROM asm_data_set_deployables WHERE deployable_id = ? LIMIT 1;",
+			-1, &stmt, nullptr) == SQLITE_OK) {
+			sqlite3_bind_int(stmt, 1, nDeployableId);
+			if (sqlite3_step(stmt) == SQLITE_ROW) {
+				const int h = sqlite3_column_int(stmt, 0);
+				if (h > 0) health = h;
+			}
+			sqlite3_finalize(stmt);
+		}
+	}
+	s_cache[nDeployableId] = health;
+	return health;
+}
+
 }  // namespace DeployableClassify

--- a/src/GameServer/TgGame/_deployable_classify/DeployableClassify.hpp
+++ b/src/GameServer/TgGame/_deployable_classify/DeployableClassify.hpp
@@ -39,6 +39,9 @@ namespace DeployableClassify {
 	// positive HP and remain damageable. Cached per id.
 	bool IsDestructible(int nDeployableId);
 
+	// asm_data_set_deployables.health for this id (0 if absent/unset). Cached.
+	int GetMaxHealth(int nDeployableId);
+
 	// True iff ANY device-mode that deploys this deployable has
 	// `require_los_flag = 0` — i.e. the deploy action doesn't need a line-of-
 	// sight aim trace because the deployable spawns on the firing pawn rather


### PR DESCRIPTION
Summary: Robotics "Dome Shield Boost" disappearing

Symptom: The Morale Dome Shield (device 2886 → deployable 22, TgDeploy_ForceField) would sometimes vanish the instant it was cast — morale spent, rally announced, but no dome. Turned out to be two independent causes.

Part 1 — Dome launches at 0 HP // Can't seem to reproduce the bug, might need more test time.

Cause: The dome self-spawns and the native ApplyDeployableSetup runs its entire deploy lifecycle synchronously (StartDeploy → DeployComplete → UpdateHealth → Active). But our InitializeDefaultProps — which sets the dome's real health — runs after ApplyDeployableSetup. So during that lifecycle r_nHealth is still 0, and health‑<=0 code paths could treat the freshly-spawned dome as already dead and destroy it at launch.

Fix: Seed the real health before ApplyDeployableSetup so the lifecycle runs on a live deployable; InitializeDefaultProps re-applies the authoritative value right after.
- TgDeviceFire__Deploy.cpp: Deployable->r_nHealth = GetMaxHealth(deployableId) before setup.
- DeployableClassify::GetMaxHealth() — cached asm_data_set_deployables.health getter.

Part 2 — Payload crushes the dome

Cause: On escort/payload maps the payload is a TgObjectiveAttachActor. Its Touch, RanInto, and EncroachingOn handlers each do if (TgDeployable(Other)) TgDeployable(Other).DestroyIt() — i.e. it destroys any deployable it overlaps. Casting the dome onto/near the payload (or the payload rolling into it) destroyed it at full HP. (It was invisible in tracing because DestroyIt is a cross-object call routed through ProcessInternal, not ProcessEvent.)

Fix: Intercept those three TgObjectiveAttachActor handlers in the ProcessEvent hook (PayloadDeployableCrush dispatch tag). When the encroached Other is a self-spawning force-field dome, skip the handler so DestroyIt never runs and the payload passes through it. For EncroachingOn (returns bool), the return is set to false so the mover doesn't stop.
- Scoped to self-spawn force-field domes only → turrets, stations, and engineer force-field walls are still crushed as intended.

Result: The morale dome now deploys reliably, blocks shots, takes enemy damage, dies on its ~15s timer, survives the payload passing through it — and other deployables are unaffected by this change

Related to: https://discord.com/channels/994691794627461211/1525538973949100215