### PR TITLE
Fix robo/Techro summons not dying when their owner is killed

### DIFF
--- a/src/GameServer/TgGame/TgGame/SpawnBotById/TgGame__SpawnBotById.cpp
+++ b/src/GameServer/TgGame/TgGame/SpawnBotById/TgGame__SpawnBotById.cpp
@@ -707,6 +707,13 @@ ATgPawn* __fastcall TgGame__SpawnBotById::Call(
 	// }
 
 	Bot->r_bIsBot = 1;
+	// Cascade-kill-on-owner-death: pets/drones (Grizzly, Hornet, Lockdown,
+	// Harrier, Eye, decoys) carry destroy_on_owner_death_flag=1 in bot config.
+	// The intact native KillOwnedBots (fired from PlayDying at owner death)
+	// only kills bots with this flag set — without it the drone lingers until
+	// the owner pawn is finally Destroyed (much later), which is the
+	// "drone stays alive too long" symptom. Turrets/map enemies have flag=0.
+	Bot->m_bDestroyOnOwnerDeathFlag = GetDestroyOnOwnerDeathFlag(nBotId) ? 1 : 0;
 	// The AI test evaluator's "Time Since Spawned" (test 1486) reads this; UC
 	// only stamps it on player spawn / revive / arena paths, so bot spawns must
 	// stamp it here. Left at 0, every time-since-spawn gate sees match-elapsed

--- a/src/GameServer/TgGame/TgGame/SpawnBotById/TgGame__SpawnBotById.hpp
+++ b/src/GameServer/TgGame/TgGame/SpawnBotById/TgGame__SpawnBotById.hpp
@@ -94,6 +94,35 @@ public:
 		return ins->second;
 	}
 
+	// asm_data_set_bots.destroy_on_owner_death_flag — whether this bot is
+	// cascade-killed when its owner pawn dies. Set on pets/drones (Grizzly,
+	// Hornet, Lockdown, Harrier, Eye, decoys), clear on emplaced turrets and
+	// standalone map enemies. Read by the intact native KillOwnedBots
+	// (0x109e5090), fired from TgPawn.PlayDying at the moment of owner death —
+	// it only kills bots with r_bIsBot + r_Owner==dead-pawn + THIS flag. Cached.
+	static bool GetDestroyOnOwnerDeathFlag(int nBotId) {
+		static std::unordered_map<int, bool> cache;
+		auto it = cache.find(nBotId);
+		if (it != cache.end()) return it->second;
+
+		bool flag = false;
+		sqlite3* db = Database::GetConnection();
+		if (db) {
+			sqlite3_stmt* stmt = nullptr;
+			if (sqlite3_prepare_v2(db,
+				"SELECT destroy_on_owner_death_flag FROM asm_data_set_bots "
+				"WHERE bot_id = ? LIMIT 1;",
+				-1, &stmt, nullptr) == SQLITE_OK) {
+				sqlite3_bind_int(stmt, 1, nBotId);
+				if (sqlite3_step(stmt) == SQLITE_ROW)
+					flag = sqlite3_column_int(stmt, 0) != 0;
+				sqlite3_finalize(stmt);
+			}
+		}
+		cache[nBotId] = flag;
+		return flag;
+	}
+
 	// Helper used by spawn-Z-lift callers (SpawnNextBot, SpawnObjectiveBot,
 	// SpawnPet, SpawnWave, PlayerActions::SpawnBot). Returns the primary
 	// cylinder dimensions — same as what ApplyBotCollisionData installs.

--- a/src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.cpp
+++ b/src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.cpp
@@ -19,6 +19,20 @@ void __fastcall TgPawn__KillDeployables::Call(ATgPawn* Pawn, void* edx, unsigned
 	if (!Pawn) return;
 
 	const int count = Pawn->s_SelfDeployableList.Count;
+
+	// An AI's death takes its deployables with it. The PlayDying path calls
+	// KillDeployables(false), which normally only reaps deployables flagged
+	// destroy_on_owner_death — that flag-gate exists so a PLAYER's death lets
+	// their turrets/etc. live out their own lifespan (the player respawns and
+	// the deployables get reaped later at pawn Destroyed). AI bosses (e.g.
+	// Elite Techro's Buff Station, deployable 209, flag=0) don't respawn, so
+	// there's no "later" — defer-to-Destroyed left the station standing.
+	// Treat a non-player owner's death as destroy-all so NPC summons die with
+	// the summoner, at the same PlayDying moment their owned bots do (KillOwnedBots).
+	const bool bOwnerIsAI =
+		!ObjectClassCache::ClassNameContains((UObject*)Pawn->Controller, "PlayerController");
+	const bool bDestroyAll = bAll || bOwnerIsAI;
+
 	Logger::Log("debug",
 		"[KillDeployables] pawn=0x%p pawnId=%d bAll=%d listCount=%d\n",
 		Pawn, (int)Pawn->r_nPawnId, (int)bAll, count);
@@ -46,7 +60,7 @@ void __fastcall TgPawn__KillDeployables::Call(ATgPawn* Pawn, void* edx, unsigned
 			continue;
 		}
 
-		const bool shouldDestroy = bAll || dep->m_bDestroyOnOwnerDeathFlag;
+		const bool shouldDestroy = bDestroyAll || dep->m_bDestroyOnOwnerDeathFlag;
 		if (!shouldDestroy) {
 			Logger::Log("debug",
 				"  [KillDeployables] keep [%d] 0x%p deployableId=%d (destroy_on_owner_death=0)\n",


### PR DESCRIPTION
Background

In the original game, killing a Robotics player (or the Elite Techro NPC) destroyed their deployed summons shortly after. On the current server these lingered far too long — drones/stations stayed alive until some much later cleanup. Root cause traced to spawn-time flags never being set, so the intact death-cascade natives skipped the summons.

---
Part 1 — Robo player drones (Grizzly, Hornet, Lockdown, Harrier, Eye)

Cause: At death, TgPawn.PlayDying calls the intact native KillOwnedBots (0x109e5090), which only kills bots matching r_bIsBot + r_Owner == dying pawn + m_bDestroyOnOwnerDeathFlag. SpawnBotById already set the first two but never set m_bDestroyOnOwnerDeathFlag, so the native skipped every drone. They only died later when the owner pawn was finally destroyed (Destroyed → KillPets), long after death.

Fix: Read asm_data_set_bots.destroy_on_owner_death_flag at spawn and set m_bDestroyOnOwnerDeathFlag on the pawn.
- TgGame__SpawnBotById.hpp — new cached GetDestroyOnOwnerDeathFlag(nBotId) (mirrors the existing GetBotCollisionData DB-read pattern).
- TgGame__SpawnBotById.cpp — Bot->m_bDestroyOnOwnerDeathFlag = GetDestroyOnOwnerDeathFlag(nBotId) right after r_bIsBot = 1.

Data-driven and self-limiting: the flag is authored per-bot in assembly.dat. Verified all 62 flag=1 bots are pets/drones/decoys (TgPawn_Hover, VanityPet, GroundPetA, …) and all 36 turret-variant bots are flag=0 — so turrets are untouched and keep persisting after the owner dies.

---
Part 2 — Elite Techro NPC summons (Support Drone + Buff Station)

Techro fires two devices on death-relevant slots:
- Support Drone (bot 1514, attack_type 306 SPAWN_PET) — flag=1 → already fixed by Part 1 via KillOwnedBots.
- Buff Station (deployable 209, attack_type 342) — destroy_on_owner_death_flag = 0 (authentic data). The original reclaimed it through the delayed Destroyed → KillAllOwnedPets → KillDeployables(true) path, which doesn't reliably fire for NPC corpses on our server, so the station stood forever.

Fix: In the KillDeployables hook, an AI owner's death destroys all its deployables, not just flagged ones.
- TgPawn__KillDeployables.cpp — compute bOwnerIsAI (owner's controller is not a PlayerController); shouldDestroy = bAll || bOwnerIsAI || m_bDestroyOnOwnerDeathFlag.

The flag-gate at PlayDying exists so a player's turrets survive their death (players respawn; deployables reaped later). NPCs don't respawn, so their summons should go with them — at the same PlayDying moment the drone dies. Part 1 already proves that path runs for Techro (it's how the drone now dies; KillDeployables(false) is the line directly above KillOwnedBots in PlayDying). Gated to non-player controllers only, so player deployable lifetimes are unchanged, and team beacons (id 36) stay excluded.

---
Files changed

- src/GameServer/TgGame/TgGame/SpawnBotById/TgGame__SpawnBotById.hpp
- src/GameServer/TgGame/TgGame/SpawnBotById/TgGame__SpawnBotById.cpp
- src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.cpp

No new files (no Makefile change). No DB/data edits. No client changes.

### Testing

- [x] Robo player: deploy each drone, get killed → drone dies shortly after (turrets and stations unaffected).
- [x] Elite Techro: let him summon drone + buff station, kill him → both die with him.

---

Related to:  https://discord.com/channels/994691794627461211/1526257460049084639