### PR TITLE
Fix repair-arm claw animation: make r_nRestDeviceSlot transient

### DIFF
--- a/src/GameServer/Core/UObject/ProcessEvent/UObject__ProcessEvent.cpp
+++ b/src/GameServer/Core/UObject/ProcessEvent/UObject__ProcessEvent.cpp
@@ -160,6 +160,7 @@ enum class DispatchTag : uint8_t {
 	SpectateVisualState,          // Diagnostic for black-screen/fade/view-target join races
 	DyingBeginState,              // CallOriginal then BotDied
 	DeviceFiringEndState,         // CallOriginal then jetpack-flag clear
+	DeviceFiringBeginState,       // Rest device: set r_nRestDeviceSlot while resting (transient)
 	ServerStopFire,               // CallOriginal then RemoveEffectGroupsByCategory(stealth)
 	TgEffectRemove,               // DoCatchAll — TgEffectBuff.Remove now reverses buffs canonically
 	PostPawnSetup,                // CallOriginal (sets PHYS_Falling) then restore PHYS_Flying for flying bots
@@ -560,6 +561,7 @@ static DispatchTag ClassifyFunction(UFunction* fn) {
 	}
 	if (strcmp(name, "Function TgPawn.Dying.BeginState") == 0)                       return DispatchTag::DyingBeginState;
 	if (strcmp(name, "Function TgDevice.DeviceFiring.EndState") == 0)                return DispatchTag::DeviceFiringEndState;
+	if (strcmp(name, "Function TgDevice.DeviceFiring.BeginState") == 0)              return DispatchTag::DeviceFiringBeginState;
 	if (strcmp(name, "Function TgGame.TgDevice.ServerStopFire") == 0)                return DispatchTag::ServerStopFire;
 	if (strcmp(name, "Function TgGame.TgDevice.ServerStartFire") == 0)               return DispatchTag::ServerStartFire;
 	if (strcmp(name, "Function TgGame.TgEffect.Remove") == 0)                        return DispatchTag::TgEffectRemove;
@@ -1267,7 +1269,31 @@ void __fastcall UObject__ProcessEvent::Call(UObject* Object, void* edx, UFunctio
 		break;
 	}
 
+	case DispatchTag::DeviceFiringBeginState: {
+		// Rest device (864): expose r_nRestDeviceSlot only WHILE resting.
+		// InterruptRestDevice (client+server per-tick CheckInterrupt) uses it to
+		// stop an in-progress rest on movement; a permanently-set slot makes it
+		// call StopFire(864) every tick instead, flooding the flash queue and
+		// clearing the client's shared range-node m_bPendingFire each frame
+		// (kills every INTERRUPT_FIRE_ANIM_ON_REFIRE='n' held fire anim).
+		{
+			ATgDevice* Dev = (ATgDevice*)Object;
+			if (Dev && Dev->m_bIsRestDevice && Dev->Instigator) {
+				((ATgPawn*)Dev->Instigator)->r_nRestDeviceSlot = (int)Dev->r_eEquippedAt;
+			}
+		}
+		DoCatchAll();
+		break;
+	}
+
 	case DispatchTag::DeviceFiringEndState: {
+		// Rest device: rest over → hide the slot again (see BeginState above).
+		{
+			ATgDevice* Dev = (ATgDevice*)Object;
+			if (Dev && Dev->m_bIsRestDevice && Dev->Instigator) {
+				((ATgPawn*)Dev->Instigator)->r_nRestDeviceSlot = -1;
+			}
+		}
 		CallOriginal(Object, edx, Function, Params, Result);
 		ATgDevice* Device = (ATgDevice*)Object;
 

--- a/src/GameServer/Inventory/Inventory.cpp
+++ b/src/GameServer/Inventory/Inventory.cpp
@@ -619,7 +619,11 @@ ATgDevice* Inventory::Equip(ATgPawn* Pawn, int deviceId, int slot, int quality, 
 	if (deviceId == GA::DeviceId::RestDevice) {
 		Device->m_bIsRestDevice = 1;
 		Pawn->m_RestDevice = Device;
-		Pawn->r_nRestDeviceSlot = slot;
+		// r_nRestDeviceSlot must stay -1 (UC default) outside an active rest:
+		// a permanent slot makes per-tick CheckInterrupt→InterruptRestDevice
+		// StopFire(864) every tick, which kills every held ('n'-flag) fire anim.
+		// Set transiently in DeviceFiring Begin/EndState (UObject__ProcessEvent.cpp).
+		// Pawn->r_nRestDeviceSlot = slot;
 	}
 
 	// --- Stealth device flag ---

--- a/src/GameServer/TgGame/TgGame/SpawnBotById/TgGame__SpawnBotById.cpp
+++ b/src/GameServer/TgGame/TgGame/SpawnBotById/TgGame__SpawnBotById.cpp
@@ -209,7 +209,11 @@ void TgGame__SpawnBotById::GiveDeviceById(
 		if (deviceId == 864) {
 			*(uint32_t*)((char*)Device + 0x22C) |= 0x00020000;    // m_bIsRestDevice
 			*(ATgDevice**)((char*)Pawn + 0x0904) = Device;         // m_RestDevice
-			*(int*)((char*)Pawn + 0x1524) = equipPoint;             // r_nRestDeviceSlot (replicated)
+			// r_nRestDeviceSlot stays -1 outside an active rest — a permanent
+			// slot makes server+client CheckInterrupt spam StopFire(864) every
+			// tick, killing pending-fire ('n' flag) anims. Set transiently in
+			// DeviceFiring Begin/EndState (UObject__ProcessEvent.cpp).
+			// *(int*)((char*)Pawn + 0x1524) = equipPoint;             // r_nRestDeviceSlot (replicated)
 		}
 		if (deviceType == GA_G::TGDT_MORALE) {
 			*(int*)((char*)Pawn + 0x1520) = equipPoint;             // r_nMoraleDeviceSlot (replicated)
@@ -443,7 +447,9 @@ void TgGame__SpawnBotById::GiveDevicesFromBotConfig(ATgPawn* Bot, ATgRepInfo_Pla
 			if (deviceId == 864) {
 				*(uint32_t*)((char*)Device + 0x22C) |= 0x00020000;    // m_bIsRestDevice
 				*(ATgDevice**)((char*)Bot + 0x0904) = Device;         // m_RestDevice
-				*(int*)((char*)Bot + 0x1524) = equipPoint;             // r_nRestDeviceSlot (replicated)
+				// r_nRestDeviceSlot stays -1 outside an active rest — see
+				// Inventory.cpp rest-device block for the full rationale.
+				// *(int*)((char*)Bot + 0x1524) = equipPoint;             // r_nRestDeviceSlot (replicated)
 				Logger::Log("debug", "GiveDevicesFromBotConfig: REST device 864 at equipPoint=%d\n", equipPoint);
 			}
 


### PR DESCRIPTION
Bug

The Robotics repair-arm "claw" fire animation (the third  arm) never played on our server, even though healing worked. Affected every A.R.C. and Focused Repair Arm (Worked fine with Nanite Repair and Force Target).

These devices ship with INTERRUPT_FIRE_ANIM_ON_REFIRE='n' in retail assembly.dat, which means the client plays their fire animation as a held loop: it runs while the anim node's m_bPendingFire is set (set by each replicated Fire event) and is actively stopped the moment pending goes false. This is legitimate retail data, not a data regression — it worked on the original servers.

The chain that broke it on ours:

1. We set r_nRestDeviceSlot = 14 permanently at equip time (players in Inventory.cpp, bots in SpawnBotById.cpp) for the hidden rest device 864 (HUMAN BASE ATTRIBUTES, the R self-heal).
2. TgPawn.Tick runs CheckInterrupt → InterruptRestDevice every tick on both sides (client for the local pawn, server for every pawn). With a valid slot it calls StopFire() on device 864 every tick. Retail UC never sets r_nRestDeviceSlot (default -1), so on retail this path no-ops outside an active rest.
3. Device 864's c_DeviceForm on the client resolves to the TgDeviceForm_NewRange class default object (its form class is "Range" but the hidden device is never instanced) — with a live pawn scribbled into the CDO's PawnOwner.
4. Every per-tick StopFire on that CDO therefore executes PawnOwner.c_RangeAnimNodeBlendList.m_bPendingFire = false, wiping the shared range anim node every frame (server-side ticks flood the flash queue with StopFire entries too, so all clients are hit).
5. Result: every 'n'-flag held fire animation is cut one frame after it starts — the claw looks like it never plays. Healing is unaffected, which is why only the animation was missing.

Fix

Make r_nRestDeviceSlot transient, matching retail semantics: set it when the rest device enters DeviceFiring (new DeviceFiringBeginState dispatch in UObject__ProcessEvent.cpp), clear it on EndState. The slot's only consumer, InterruptRestDevice, exists to stop an in-progress rest — so move/combat interruption of a rest still works while resting, and the per-tick StopFire spam disappears outside of one.

The permanent writes in Inventory.cpp and both bot paths in SpawnBotById.cpp are commented out. Also includes a one-line return 0; in dllmainclient.cpp (ModuleThread fell off a non-void function — mingw emits ud2, insta-crashing any client-DLL build).

Testing

Verified working on a vanilla client with unpatched retail assembly.dat: both the Focuseepair Arm claw animations play correctly. R self-heal still works (slow-while-movingbehavior unchanged).                                                                                                                                                                                           
Client-side alternative (not needed, for the record)


// In case it's ever needed to patch client side //

Before the root cause was found, the workaround was patching the client's assembly.dat: flipping INTERRUPT_FIRE_ANIM_ON_REFIRE_FLAG (marshal tag 0x02CC, wire format tag u16 + 01 00 + 'y'/'n') from 'n' to 'y' on all 16 repair-arm fire-mode rows (devices 2046/1917/2043/2045 and 2915-2918, two modes each). That forces the client to restart the fire anim on every shot instead of using the pending-loop, bypassing the bug — but requires distributing a modified assembly.dat to every player. With this server fix, stock clients work and no dat patch is needed. Keep the flip procedure in mind only if a future case needs a client-data override.

Related to: https://discord.com/channels/994691794627461211/1526995595116544140