### PR TITLE
Fix stale enemy-sensor "detected" warning

### DIFF
--- a/src/GameServer/Core/UObject/ProcessEvent/UObject__ProcessEvent.cpp
+++ b/src/GameServer/Core/UObject/ProcessEvent/UObject__ProcessEvent.cpp
@@ -176,6 +176,7 @@ enum class DispatchTag : uint8_t {
 	TgTriggerBeaconEntrance,      // Pre-call: record teammate beacon-teleport usage for match stats
 	SuperAgentCaptureGate,        // Super Agent mode: freeze proximity capture per the all-players / drain gate, then detect A's capture
 	PayloadDeployableCrush,       // Payload (TgObjectiveAttachActor) Touch/RanInto/EncroachingOn — skip for morale Dome Shields
+	SensorProximitySweep,         // Post-call: remove TouchedPlayers beyond config radius (UC loop can't see pawns outside m_fProximityDistance)
 	// GameTimerDiagnostic,          // Diagnostic-only: before/after snapshots around original timer/match flow
 };
 
@@ -592,6 +593,13 @@ static DispatchTag ClassifyFunction(UFunction* fn) {
 	    strcmp(name, "Function TgGame.TgObjectiveAttachActor.RanInto") == 0 ||
 	    strcmp(name, "Function TgGame.TgObjectiveAttachActor.EncroachingOn") == 0)
 		return DispatchTag::PayloadDeployableCrush;
+	// Sensor 0.2s proximity poll (engine-timer dispatch, TgDeploy_Sensor.uc:48).
+	// UC's foreach only iterates pawns WITHIN m_fProximityDistance of the sensor,
+	// so a detected pawn that moves beyond that envelope is never removed from
+	// TouchedPlayers and its r_nSensorAlertLevel (HUD "detected" icon) sticks
+	// forever. Post-call sweep removes out-of-range entries.
+	if (strcmp(name, "Function TgGame.TgDeploy_Sensor.CheckPlayersWithInProximity") == 0)
+		return DispatchTag::SensorProximitySweep;
 	// if (IsGameTimerDiagnosticFunction(name)) return DispatchTag::GameTimerDiagnostic;
 
 	return DispatchTag::Unknown;
@@ -2103,6 +2111,33 @@ void __fastcall UObject__ProcessEvent::Call(UObject* Object, void* edx, UFunctio
 			break;  // skip CallOriginal → no dome.DestroyIt()
 		}
 		CallOriginal(Object, edx, Function, Params, Result);
+		break;
+	}
+
+	// Stale-detection sweep for deployed sensors. The UC poll's
+	// `foreach AllPawns(..., Location, m_fProximityDistance)` never iterates a
+	// pawn outside that radius, so RemovePlayerFromList is unreachable for
+	// pawns that left the envelope — their s_nSensorAlertList slot (and the
+	// replicated r_nSensorAlertLevel HUD icon) stayed set forever. Walk each
+	// config's TouchedPlayers after the original and remove anyone beyond that
+	// config's radius; RemovePlayerFromList recomputes the pawn's alert level.
+	case DispatchTag::SensorProximitySweep: {
+		CallOriginal(Object, edx, Function, Params, Result);
+		ATgDeploy_Sensor* sensor = (ATgDeploy_Sensor*)Object;
+		for (int idx = 0; idx < sensor->m_DeploySensorConfig.Count; ++idx) {
+			FDeploySensorConfig& cfg = sensor->m_DeploySensorConfig.Data[idx];
+			const float maxDistSq = cfg.fProximityDistance * cfg.fProximityDistance;
+			// Reverse walk — RemovePlayerFromList does RemoveItem on this array.
+			for (int i = cfg.TouchedPlayers.Count - 1; i >= 0; --i) {
+				ATgPawn* p = cfg.TouchedPlayers.Data[i];
+				if (!p) continue;
+				const float dx = p->Location.X - sensor->Location.X;
+				const float dy = p->Location.Y - sensor->Location.Y;
+				const float dz = p->Location.Z - sensor->Location.Z;
+				if (dx * dx + dy * dy + dz * dz <= maxDistSq) continue;
+				sensor->RemovePlayerFromList(p, idx);
+			}
+		}
 		break;
 	}
 

--- a/src/GameServer/TgGame/TgDeployable/SetProperty/TgDeployable__SetProperty.cpp
+++ b/src/GameServer/TgGame/TgDeployable/SetProperty/TgDeployable__SetProperty.cpp
@@ -104,7 +104,7 @@ void __fastcall TgDeployable__SetProperty::Call(ATgDeployable* D, void* edx, int
 			// at 0 HP and TakeDamage's health<=0 early-out (uc:1211) makes it
 			// permanently indestructible.
 			if (oldHp > 0 && newHp <= 0 && !D->m_bInDestroyedState) {
-				D->eventDestroyIt(0);
+				DeployableClassify::DispatchDestroyIt(D, 0);
 			}
 
 			Logger::Log("heal_tick",

--- a/src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.cpp
+++ b/src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.cpp
@@ -1,6 +1,7 @@
 #include "src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.hpp"
 #include "src/Utils/Logger/Logger.hpp"
 #include "src/GameServer/Utils/ObjectClassCache/ObjectClassCache.hpp"
+#include "src/GameServer/TgGame/_deployable_classify/DeployableClassify.hpp"
 
 // Native UTgPawn::execKillDeployables @ 0x109c0870 is a void stub. UC declares
 //     native function KillDeployables(bool bAll);
@@ -78,11 +79,12 @@ void __fastcall TgPawn__KillDeployables::Call(ATgPawn* Pawn, void* edx, unsigned
 			"  [KillDeployables] DestroyIt [%d] 0x%p deployableId=%d\n",
 			i, dep, dep->r_nDeployableId);
 
-		// UC `Dep.eventDestroyIt(false)` — runs the full UC DestroyIt event
+		// UC `Dep.DestroyIt(false)` — runs the full UC DestroyIt event
 		// which: stops fire, sets LifeSpan, hides mesh, swaps to destroyed
 		// mesh, flips m_bInDestroyedState, bumps r_nReplicateDestroyIt to
-		// trigger the client-side repnotify.
-		dep->eventDestroyIt(0 /* bSkipFx */);
+		// trigger the client-side repnotify. Routed through DispatchDestroyIt
+		// so subclass overrides (sensor alert cleanup, etc.) run too.
+		DeployableClassify::DispatchDestroyIt(dep, 0 /* bSkipFx */);
 	}
 
 	// UC does `s_SelfDeployableList.Length = 0;` — reset the Count. Data
@@ -119,7 +121,7 @@ void TgPawn__KillDeployables::KillAllOwned(ATgPawn* Pawn) {
 		Logger::Log("deployables",
 			"[KillAllOwned] DestroyIt deployable=0x%p id=%d\n",
 			dep, dep->r_nDeployableId);
-		dep->eventDestroyIt(0);
+		DeployableClassify::DispatchDestroyIt(dep, 0);
 	}
 
 	// Kill deployed bot pawns (e.g. Grizzly drone).

--- a/src/GameServer/TgGame/TgProj_Deployable/SpawnDeployable/TgProj_Deployable__SpawnDeployable.cpp
+++ b/src/GameServer/TgGame/TgProj_Deployable/SpawnDeployable/TgProj_Deployable__SpawnDeployable.cpp
@@ -695,12 +695,13 @@ void TgProj_Deployable__SpawnDeployable::EnforceDeployableLimit(
 			"[DeployableLimit]   destroying [%d] 0x%p deployableId=%d\n",
 			i, dep, dep->r_nDeployableId);
 
-		// `eventDestroyIt(false)` runs UC's full destroy event: stops fire,
+		// DestroyIt(false) runs UC's full destroy event: stops fire,
 		// sets LifeSpan, swaps to destroyed mesh, flips m_bInDestroyedState,
 		// and bumps r_nReplicateDestroyIt so the client repnotify fires.
 		// Match KillDeployables' approach so behavior is consistent across
-		// owner-death cleanup and limit-enforcement cleanup.
-		dep->eventDestroyIt(0 /* bSkipFx */);
+		// owner-death cleanup and limit-enforcement cleanup. Routed through
+		// DispatchDestroyIt so subclass overrides (sensor alert cleanup) run.
+		DeployableClassify::DispatchDestroyIt(dep, 0 /* bSkipFx */);
 		--toKill;
 	}
 }

--- a/src/GameServer/TgGame/_deployable_classify/DeployableClassify.cpp
+++ b/src/GameServer/TgGame/_deployable_classify/DeployableClassify.cpp
@@ -1,10 +1,28 @@
 #include "src/GameServer/TgGame/_deployable_classify/DeployableClassify.hpp"
 
+#include "src/pch.hpp"
 #include "src/Database/Database.hpp"
+#include "src/GameServer/Utils/ObjectClassCache/ObjectClassCache.hpp"
 
 #include <unordered_map>
 
 namespace DeployableClassify {
+
+void DispatchDestroyIt(ATgDeployable* Dep, unsigned long bSkipFx) {
+	if (!Dep) return;
+	// Exact class-name match, not ClassNameContains — "TgDeploy_Beacon" is a
+	// substring of "TgDeploy_BeaconEntrance" (which has no override and must
+	// take the base path).
+	const std::string& cls = ObjectClassCache::GetClassName((UObject*)Dep);
+	if (cls == "Class TgGame.TgDeploy_Sensor")
+		((ATgDeploy_Sensor*)Dep)->DestroyIt(bSkipFx);
+	else if (cls == "Class TgGame.TgDeploy_Beacon")
+		((ATgDeploy_Beacon*)Dep)->DestroyIt(bSkipFx);
+	else if (cls == "Class TgGame.TgDeploy_DestructibleCover")
+		((ATgDeploy_DestructibleCover*)Dep)->DestroyIt(bSkipFx);
+	else
+		Dep->eventDestroyIt(bSkipFx);
+}
 
 bool IsKnownDeployableId(int nDeployableId) {
 	if (nDeployableId <= 0) return false;

--- a/src/GameServer/TgGame/_deployable_classify/DeployableClassify.hpp
+++ b/src/GameServer/TgGame/_deployable_classify/DeployableClassify.hpp
@@ -14,7 +14,19 @@
 // Keeping these classifiers in a shared module avoids any hook depending on
 // the implementation file of another hook.
 
+class ATgDeployable;
+
 namespace DeployableClassify {
+
+	// Destroy a deployable running its UC subclass's DestroyIt override. The
+	// SDK's `eventDestroyIt` resolves the UFunction of the pointer's STATIC
+	// type (no virtual dispatch — see docs/claude/hooking-and-sdk.md), so
+	// calling it on a generic ATgDeployable* skipped the overrides:
+	// TgDeploy_Sensor's clears detected players' r_nSensorAlertLevel (HUD
+	// "detected" icon stuck forever), Beacon's deregisters from the beacon
+	// manager, DestructibleCover's runs CheckDeathBehavior. Every C++ destroy
+	// site on a generic ATgDeployable* must route through this.
+	void DispatchDestroyIt(ATgDeployable* Dep, unsigned long bSkipFx);
 
 	// True iff `asm_data_set_deployables` contains this deployable_id.
 	// Debug chat commands can pass arbitrary ids; missing rows must fail


### PR DESCRIPTION
Bug

The "detected by enemy sensor" HUD warning (TgPawn.r_nSensorAlertLevel) could get stuck on permanently: it kept showing after the sensor was destroyed, after the detected player left the sensor's radius, and after the owner re-deployed the sensor somewhere else.

Root causes (two, independent)

1. Destroy paths skipped the sensor's UC cleanup.
TgDeploy_Sensor.DestroyIt clears every detected player's alert level via RemoveAllPlayersFromList. But the C++ destroy sites called the SDK's eventDestroyIt, which resolves the base TgDeployable.DestroyIt UFunction with no virtual dispatch — the sensor override never ran when a sensor died via owner death (KillDeployables), effect-damage reaching 0 HP (SetProperty mirror), or deploy-limit replacement (re-deploying elsewhere destroys the oldest — the "sensor moved" case). Weapon kills go through UC TakeDamage and were unaffected.

2. Leaving the radius could never un-detect.
TgDeploy_Sensor.CheckPlayersWithInProximity (0.2s poll) iterates AllPawns(..., Location, m_fProximityDistance) — and that envelope equals the largest detection ring exactly. A pawn beyond it is never iterated, so RemovePlayerFromList was unreachable and the alert stuck forever. (Sensors carry no prox-cylinder prop, so the UnTouch path is dead — retail data.)

Fix

- New DeployableClassify::DispatchDestroyIt(): dispatches DestroyIt by exact class name (Sensor / Beacon / DestructibleCover overrides, base otherwise; exact match because TgDeploy_BeaconEntrance contains TgDeploy_Beacon). All generic C++ destroy sites route through it.
- New ProcessEvent dispatch tag SensorProximitySweep on CheckPlayersWithInProximity: after the original runs, reverse-walk each config's TouchedPlayers and call UC RemovePlayerFromList for anyone beyond that config's ring. Also covers a carried/re-placed sensor, since distance is measured from the sensor's current location.

Tested (all clear the warning, log 484)

- [x] Sensor destroyed while a player is detected
- [x] Detected player sprints out of the detection radius
- [x] Owner re-deploys the sensor far away (limit replacement destroys the old one)
- [x] Enemy robo -changeteam right next to the sensor (friend→enemy flip with no movement)
- [x] Normal detection still works: warning inside ring, stealth reveal inside the inner ring (verified two-ring retail design: purple sensor 125 ft warn / 25 ft reveal)

Related to:  https://discord.com/channels/994691794627461211/1527788516342370564