### PR TITLE
Add whisper (/w) support to the chat server

### DIFF
--- a/src/ControlServer/ChatSession/ChatSession.cpp
+++ b/src/ControlServer/ChatSession/ChatSession.cpp
@@ -3,6 +3,7 @@
 #include "src/ControlServer/MatchmakingService/MatchmakingService.hpp"
 
 #include <algorithm>
+#include <cctype>
 #include <chrono>
 #ifndef _WIN32
 #include <netinet/tcp.h>
@@ -413,7 +414,54 @@ void ChatSession::broadcast(const uint8_t* data, size_t length) {
     bool isDM = channel == 8;
 
     if (isDM) {
-        message = "DMs are not supported yet, sorry!";
+        // Whisper: recipient arrives in PLAYER_NAME (0x03C5), verified via live capture.
+        const std::string recipient = pkt.ReadString(GA_T::PLAYER_NAME).value_or("");
+        auto ieq = [](const std::string& a, const std::string& b) {
+            if (a.size() != b.size()) return false;
+            for (size_t i = 0; i < a.size(); i++)
+                if (std::tolower((unsigned char)a[i]) != std::tolower((unsigned char)b[i]))
+                    return false;
+            return true;
+        };
+        PruneExpiredSessions();
+        std::shared_ptr<ChatSession> target;
+        for (auto& weak : g_chat_sessions) {
+            if (auto peer = weak.lock()) {
+                if (ieq(peer->get_player_name(), recipient)) { target = peer; break; }
+            }
+        }
+        if (!target) {
+            deliver(BuildChatFrame(kSystemChannelId,
+                "*** " + recipient + " is not online ***"));
+            return;
+        }
+        // Per-side frames. Client renders NAME (0x370) as "<name> says:" (or
+        // MESSAGE verbatim when NAME is empty — used for the sender echo) and
+        // caches PLAYER_NAME (0x3C5) as the reply-keybind target.
+        const std::string text = pkt.ReadString(GA_T::MESSAGE).value_or("");
+        auto makeWhisperFrame = [this, channel](const std::string& displayName,
+                                                const std::string& msgText,
+                                                const std::string& replyToName) {
+            std::vector<uint8_t> body;
+            uint16_t pt = GA_U::CHAT_MESSAGE, ic = 4;
+            append(body, pt & 0xFF, pt >> 8, ic & 0xFF, ic >> 8);
+            Write4B(body, GA_T::CHAT_CH_TYPE, channel);
+            WriteString(body, GA_T::NAME, displayName);
+            WriteString(body, GA_T::MESSAGE, msgText);
+            WriteString(body, GA_T::PLAYER_NAME, replyToName);
+            std::vector<uint8_t> frame;
+            uint16_t sz = static_cast<uint16_t>(body.size());
+            frame.push_back(sz & 0xFF);
+            frame.push_back(sz >> 8);
+            frame.insert(frame.end(), body.begin(), body.end());
+            return frame;
+        };
+
+        const std::string& targetName = target->get_player_name();
+        target->deliver(makeWhisperFrame(player_name_, text, player_name_));
+        if (target.get() != this)
+            deliver(makeWhisperFrame("", "To " + targetName + ": " + text, targetName));
+        return;
     }
 
     Logger::Log("chat", "Broadcasting message '%s' to channel %u\n", message.c_str(), channel);


### PR DESCRIPTION
Whispers were stubbed: the client already parses /w <name> <msg> and sends it as a CHAT_MESSAGE on channel 8 with the recipient in a PLAYER_NAME TLV, but the control server's ChatSession only detected channel 8 and replied "DMs are not supported yet, sorry!" to the sender.

Fix (all in src/ControlServer/ChatSession/ChatSession.cpp):

- Channel-8 messages are no longer broadcast. The recipient is read from the PLAYER_NAME TLV and matched case-insensitively against connected chat sessions.
- Delivery uses per-side frames matching what the retail client's native receive path expects (confirmed by disassembly of the receive/display functions):
  - Recipient gets NAME = sender (rendered as "Angel says: …"), MESSAGE = raw text, and PLAYER_NAME = sender, which the client caches as the reply-keybind (Z) target.
  - Sender gets an echo with empty NAME and MESSAGE = "To X: …", with PLAYER_NAME = recipient, so Z on the sender's side continues the conversation.
- Whispering someone offline returns a sender-only system line: *** name is not online ***.

Tested with two clients: delivery both ways, correct per-side labels, whisper tint, no leakage to other sessions, offline error, and Z-reply working for both participants.

Tested with three clients: only sender and receiver get the message (It's private)

Related to:  https://discord.com/channels/994691794627461211/1527984322613743726

<img width="298" height="117" alt="image" src="https://github.com/user-attachments/assets/3127f6fe-864b-4280-887a-c960eae9c2ee" />
