### PR TITLE
Friends List (F3) implementation

### DIFF
--- a/src/ControlServer/ChatSession/ChatSession.cpp
+++ b/src/ControlServer/ChatSession/ChatSession.cpp
@@ -1,5 +1,6 @@
 #include "src/ControlServer/ChatSession/ChatSession.hpp"
 #include "src/ControlServer/ChatSession/ChatCommand.hpp"
+#include "src/ControlServer/Database/Database.hpp"
 #include "src/ControlServer/MatchmakingService/MatchmakingService.hpp"
 
 #include <algorithm>
@@ -458,6 +459,14 @@ void ChatSession::broadcast(const uint8_t* data, size_t length) {
         };
 
         const std::string& targetName = target->get_player_name();
+        // Ignore gate: recipient has the sender on their F3 ignore list.
+        if (Database::IsIgnoring(targetName, player_name_)) {
+            Logger::Log("friends", "[Friends] whisper blocked: '%s' ignores '%s'\n",
+                targetName.c_str(), player_name_.c_str());
+            deliver(BuildChatFrame(kSystemChannelId,
+                "*** " + targetName + " is ignoring you ***"));
+            return;
+        }
         target->deliver(makeWhisperFrame(player_name_, text, player_name_));
         if (target.get() != this)
             deliver(makeWhisperFrame("", "To " + targetName + ": " + text, targetName));
@@ -494,7 +503,26 @@ void ChatSession::broadcast(const uint8_t* data, size_t length) {
                     peer->deliver(chunk);
                 }
             } else {
+                // Ignore gate: don't show this sender's lines to players who
+                // have them on the F3 ignore list.
+                if (peer.get() != this &&
+                    Database::IsIgnoring(peer->get_player_name(), player_name_)) {
+                    continue;
+                }
                 peer->deliver(chunk);
+            }
+        }
+    }
+}
+
+void ChatSession::SystemMessageTo(const std::string& player_name, const std::string& text) {
+    if (player_name.empty()) return;
+    auto frame = BuildChatFrame(kSystemChannelId, text);
+    for (auto& weak : g_chat_sessions) {
+        if (auto peer = weak.lock()) {
+            if (peer->get_player_name() == player_name) {
+                peer->deliver(frame);
+                return;
             }
         }
     }

--- a/src/ControlServer/ChatSession/ChatSession.cpp
+++ b/src/ControlServer/ChatSession/ChatSession.cpp
@@ -460,7 +460,7 @@ void ChatSession::broadcast(const uint8_t* data, size_t length) {
 
         const std::string& targetName = target->get_player_name();
         // Ignore gate: recipient has the sender on their F3 ignore list.
-        if (Database::IsIgnoring(targetName, player_name_)) {
+        if (target->is_ignoring(player_name_)) {
             Logger::Log("friends", "[Friends] whisper blocked: '%s' ignores '%s'\n",
                 targetName.c_str(), player_name_.c_str());
             deliver(BuildChatFrame(kSystemChannelId,
@@ -506,13 +506,28 @@ void ChatSession::broadcast(const uint8_t* data, size_t length) {
                 // Ignore gate: don't show this sender's lines to players who
                 // have them on the F3 ignore list.
                 if (peer.get() != this &&
-                    Database::IsIgnoring(peer->get_player_name(), player_name_)) {
+                    peer->is_ignoring(player_name_)) {
                     continue;
                 }
                 peer->deliver(chunk);
             }
         }
     }
+}
+
+bool ChatSession::is_ignoring(const std::string& sender_name) {
+    const uint64_t epoch = Database::FriendsEpoch();
+    if (epoch != ignore_epoch_) {
+        ignored_lower_.clear();
+        for (auto& name : Database::GetIgnoredNames(player_name_))
+            ignored_lower_.insert(std::move(name));
+        ignore_epoch_ = epoch;
+    }
+    if (ignored_lower_.empty()) return false;
+    std::string lower = sender_name;
+    std::transform(lower.begin(), lower.end(), lower.begin(),
+        [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return ignored_lower_.count(lower) != 0;
 }
 
 void ChatSession::SystemMessageTo(const std::string& player_name, const std::string& text) {

--- a/src/ControlServer/ChatSession/ChatSession.hpp
+++ b/src/ControlServer/ChatSession/ChatSession.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <sstream>
 #include <iomanip>
+#include <unordered_set>
 
 #include "src/ControlServer/Constants/TcpFunctions.h"
 #include "src/ControlServer/Constants/TcpTypes.h"
@@ -20,6 +21,10 @@ public:
     void start();
     void deliver(const std::vector<uint8_t>& msg);
     const std::string& get_player_name() const { return player_name_; }
+    // True when this session's player ignores `sender_name`. Backed by a
+    // per-session cached ignore set, reloaded only when
+    // Database::FriendsEpoch() has changed since the last check.
+    bool is_ignoring(const std::string& sender_name);
 
     // Deliver a system chat line to one player's chat session, if they have
     // one. Used by TcpSession (e.g. friends "player not found" feedback).
@@ -38,6 +43,10 @@ private:
     std::deque<std::vector<uint8_t>> write_queue_;
     std::string player_name_;
     std::string session_guid_;
+    // Cached ignore list (lowercased names) + the friends-epoch it was built
+    // at. 0 = never loaded (Database epoch starts at 1).
+    std::unordered_set<std::string> ignored_lower_;
+    uint64_t ignore_epoch_ = 0;
     int bind_retry_attempts_ = 0;
     bool announced_join_ = false;
     // Single-shot lifecycle guard. Set by TearDown(); checked in every async

--- a/src/ControlServer/ChatSession/ChatSession.hpp
+++ b/src/ControlServer/ChatSession/ChatSession.hpp
@@ -21,6 +21,10 @@ public:
     void deliver(const std::vector<uint8_t>& msg);
     const std::string& get_player_name() const { return player_name_; }
 
+    // Deliver a system chat line to one player's chat session, if they have
+    // one. Used by TcpSession (e.g. friends "player not found" feedback).
+    static void SystemMessageTo(const std::string& player_name, const std::string& text);
+
 private:
     asio::ip::tcp::socket socket_;
     asio::steady_timer bind_retry_timer_;

--- a/src/ControlServer/Database/Database.cpp
+++ b/src/ControlServer/Database/Database.cpp
@@ -1929,6 +1929,25 @@ void Database::Init() {
 		}
 	}
 
+	// Friends list (chat server F3 menu). UNCONDITIONAL + idempotent —
+	// shared version counter, same rationale as the moderation block.
+	{
+		result = sqlite3_exec(db,
+			"CREATE TABLE IF NOT EXISTS ga_friends ("
+			"  user_id        INTEGER NOT NULL,"
+			"  friend_user_id INTEGER NOT NULL,"
+			"  ignore_flag    INTEGER NOT NULL DEFAULT 0,"
+			"  notes          TEXT NOT NULL DEFAULT '',"
+			"  PRIMARY KEY (user_id, friend_user_id)"
+			");",
+			nullptr, nullptr, &err);
+		if (result != SQLITE_OK) {
+			Logger::Log("db", "Failed to create ga_friends table: %s\n", err);
+			sqlite3_free(err);
+			err = nullptr;
+		}
+	}
+
 	// Match stats tables + ga_instances outcome columns (design
 	// 2026-06-12-match-stats-tracking). UNCONDITIONAL + idempotent —
 	// shared version counter, same rationale as the moderation block.
@@ -2490,6 +2509,129 @@ int64_t Database::FindUserIdByUsername(const std::string& username) {
 	if (sqlite3_step(stmt) == SQLITE_ROW) id = sqlite3_column_int64(stmt, 0);
 	sqlite3_finalize(stmt);
 	return id;
+}
+
+std::vector<Database::FriendRow> Database::GetFriendsForUser(int64_t user_id) {
+	std::vector<FriendRow> rows;
+	if (user_id <= 0) return rows;
+	sqlite3* db = GetConnection();
+	sqlite3_stmt* stmt = nullptr;
+	int rc = sqlite3_prepare_v2(db,
+		"SELECT f.friend_user_id, u.username, f.ignore_flag, f.notes "
+		"FROM ga_friends f JOIN ga_users u ON u.id = f.friend_user_id "
+		"WHERE f.user_id = ? ORDER BY u.username",
+		-1, &stmt, nullptr);
+	if (rc != SQLITE_OK || !stmt) {
+		Logger::Log("db", "[Friends] GetFriendsForUser prepare failed: %s\n", sqlite3_errmsg(db));
+		return rows;
+	}
+	sqlite3_bind_int64(stmt, 1, user_id);
+	while (sqlite3_step(stmt) == SQLITE_ROW) {
+		FriendRow r;
+		r.friend_user_id = sqlite3_column_int64(stmt, 0);
+		const char* name = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
+		r.friend_name = name ? name : "";
+		r.ignore_flag = sqlite3_column_int(stmt, 2) != 0;
+		const char* notes = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 3));
+		r.notes = notes ? notes : "";
+		rows.push_back(std::move(r));
+	}
+	sqlite3_finalize(stmt);
+	return rows;
+}
+
+bool Database::AddFriend(int64_t user_id, const std::string& name, bool ignore_flag) {
+	if (user_id <= 0 || name.empty()) return false;
+	sqlite3* db = GetConnection();
+	sqlite3_stmt* stmt = nullptr;
+	int rc = sqlite3_prepare_v2(db,
+		"SELECT id FROM ga_users WHERE username = ? COLLATE NOCASE LIMIT 1",
+		-1, &stmt, nullptr);
+	if (rc != SQLITE_OK || !stmt) {
+		Logger::Log("db", "[Friends] AddFriend lookup prepare failed: %s\n", sqlite3_errmsg(db));
+		return false;
+	}
+	sqlite3_bind_text(stmt, 1, name.c_str(), -1, SQLITE_TRANSIENT);
+	int64_t friend_id = 0;
+	if (sqlite3_step(stmt) == SQLITE_ROW) friend_id = sqlite3_column_int64(stmt, 0);
+	sqlite3_finalize(stmt);
+	if (friend_id == 0) return false;
+	if (friend_id == user_id) return true;  // self-add: silently ignore
+
+	stmt = nullptr;
+	rc = sqlite3_prepare_v2(db,
+		"INSERT INTO ga_friends (user_id, friend_user_id, ignore_flag) VALUES (?, ?, ?) "
+		"ON CONFLICT(user_id, friend_user_id) DO UPDATE SET ignore_flag = excluded.ignore_flag",
+		-1, &stmt, nullptr);
+	if (rc != SQLITE_OK || !stmt) {
+		Logger::Log("db", "[Friends] AddFriend insert prepare failed: %s\n", sqlite3_errmsg(db));
+		return false;
+	}
+	sqlite3_bind_int64(stmt, 1, user_id);
+	sqlite3_bind_int64(stmt, 2, friend_id);
+	sqlite3_bind_int(stmt, 3, ignore_flag ? 1 : 0);
+	if (sqlite3_step(stmt) != SQLITE_DONE) {
+		Logger::Log("db", "[Friends] AddFriend insert failed: %s\n", sqlite3_errmsg(db));
+	}
+	sqlite3_finalize(stmt);
+	return true;
+}
+
+void Database::RemoveFriend(int64_t user_id, int64_t friend_user_id) {
+	if (user_id <= 0 || friend_user_id <= 0) return;
+	sqlite3* db = GetConnection();
+	sqlite3_stmt* stmt = nullptr;
+	int rc = sqlite3_prepare_v2(db,
+		"DELETE FROM ga_friends WHERE user_id = ? AND friend_user_id = ?",
+		-1, &stmt, nullptr);
+	if (rc != SQLITE_OK || !stmt) {
+		Logger::Log("db", "[Friends] RemoveFriend prepare failed: %s\n", sqlite3_errmsg(db));
+		return;
+	}
+	sqlite3_bind_int64(stmt, 1, user_id);
+	sqlite3_bind_int64(stmt, 2, friend_user_id);
+	sqlite3_step(stmt);
+	sqlite3_finalize(stmt);
+}
+
+void Database::SetFriendNotes(int64_t user_id, int64_t friend_user_id, const std::string& notes) {
+	if (user_id <= 0 || friend_user_id <= 0) return;
+	sqlite3* db = GetConnection();
+	sqlite3_stmt* stmt = nullptr;
+	int rc = sqlite3_prepare_v2(db,
+		"UPDATE ga_friends SET notes = ? WHERE user_id = ? AND friend_user_id = ?",
+		-1, &stmt, nullptr);
+	if (rc != SQLITE_OK || !stmt) {
+		Logger::Log("db", "[Friends] SetFriendNotes prepare failed: %s\n", sqlite3_errmsg(db));
+		return;
+	}
+	sqlite3_bind_text(stmt, 1, notes.c_str(), -1, SQLITE_TRANSIENT);
+	sqlite3_bind_int64(stmt, 2, user_id);
+	sqlite3_bind_int64(stmt, 3, friend_user_id);
+	sqlite3_step(stmt);
+	sqlite3_finalize(stmt);
+}
+
+bool Database::IsIgnoring(const std::string& owner_name, const std::string& other_name) {
+	if (owner_name.empty() || other_name.empty()) return false;
+	sqlite3* db = GetConnection();
+	sqlite3_stmt* stmt = nullptr;
+	int rc = sqlite3_prepare_v2(db,
+		"SELECT 1 FROM ga_friends f "
+		"JOIN ga_users o ON o.id = f.user_id "
+		"JOIN ga_users t ON t.id = f.friend_user_id "
+		"WHERE o.username = ?1 COLLATE NOCASE AND t.username = ?2 COLLATE NOCASE "
+		"AND f.ignore_flag = 1 LIMIT 1",
+		-1, &stmt, nullptr);
+	if (rc != SQLITE_OK || !stmt) {
+		Logger::Log("db", "[Friends] IsIgnoring prepare failed: %s\n", sqlite3_errmsg(db));
+		return false;
+	}
+	sqlite3_bind_text(stmt, 1, owner_name.c_str(), -1, SQLITE_TRANSIENT);
+	sqlite3_bind_text(stmt, 2, other_name.c_str(), -1, SQLITE_TRANSIENT);
+	const bool ignoring = sqlite3_step(stmt) == SQLITE_ROW;
+	sqlite3_finalize(stmt);
+	return ignoring;
 }
 
 bool Database::SetUserPvpVerification(int64_t user_id, bool verified) {

--- a/src/ControlServer/Database/Database.cpp
+++ b/src/ControlServer/Database/Database.cpp
@@ -4,6 +4,11 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <atomic>
+
+// Bumped on every ga_friends mutation; starts at 1 so a fresh ChatSession
+// cache (epoch 0) always loads on first use.
+static std::atomic<uint64_t> g_friends_epoch{1};
 
 sqlite3* Database::connection = nullptr;
 std::string Database::db_path_ = "server.db";
@@ -2574,6 +2579,7 @@ bool Database::AddFriend(int64_t user_id, const std::string& name, bool ignore_f
 		Logger::Log("db", "[Friends] AddFriend insert failed: %s\n", sqlite3_errmsg(db));
 	}
 	sqlite3_finalize(stmt);
+	g_friends_epoch++;
 	return true;
 }
 
@@ -2592,6 +2598,7 @@ void Database::RemoveFriend(int64_t user_id, int64_t friend_user_id) {
 	sqlite3_bind_int64(stmt, 2, friend_user_id);
 	sqlite3_step(stmt);
 	sqlite3_finalize(stmt);
+	g_friends_epoch++;
 }
 
 void Database::SetFriendNotes(int64_t user_id, int64_t friend_user_id, const std::string& notes) {
@@ -2632,6 +2639,34 @@ bool Database::IsIgnoring(const std::string& owner_name, const std::string& othe
 	const bool ignoring = sqlite3_step(stmt) == SQLITE_ROW;
 	sqlite3_finalize(stmt);
 	return ignoring;
+}
+
+uint64_t Database::FriendsEpoch() {
+	return g_friends_epoch.load();
+}
+
+std::vector<std::string> Database::GetIgnoredNames(const std::string& owner_name) {
+	std::vector<std::string> out;
+	if (owner_name.empty()) return out;
+	sqlite3* db = GetConnection();
+	sqlite3_stmt* stmt = nullptr;
+	int rc = sqlite3_prepare_v2(db,
+		"SELECT lower(t.username) FROM ga_friends f "
+		"JOIN ga_users o ON o.id = f.user_id "
+		"JOIN ga_users t ON t.id = f.friend_user_id "
+		"WHERE o.username = ? COLLATE NOCASE AND f.ignore_flag = 1",
+		-1, &stmt, nullptr);
+	if (rc != SQLITE_OK || !stmt) {
+		Logger::Log("db", "[Friends] GetIgnoredNames prepare failed: %s\n", sqlite3_errmsg(db));
+		return out;
+	}
+	sqlite3_bind_text(stmt, 1, owner_name.c_str(), -1, SQLITE_TRANSIENT);
+	while (sqlite3_step(stmt) == SQLITE_ROW) {
+		const char* name = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
+		if (name) out.push_back(name);
+	}
+	sqlite3_finalize(stmt);
+	return out;
 }
 
 bool Database::SetUserPvpVerification(int64_t user_id, bool verified) {

--- a/src/ControlServer/Database/Database.hpp
+++ b/src/ControlServer/Database/Database.hpp
@@ -93,6 +93,24 @@ public:
     // registered_at is left untouched. Returns false if the update failed.
     static bool ClearUserVerifier(int64_t user_id);
 
+    // ---- Friends list (chat server, F3 menu) -------------------------------
+    struct FriendRow {
+        int64_t     friend_user_id = 0;
+        std::string friend_name;          // canonical ga_users.username
+        bool        ignore_flag = false;  // 0 = friend, 1 = ignore list
+        std::string notes;
+    };
+    static std::vector<FriendRow> GetFriendsForUser(int64_t user_id);
+    // Resolves `name` (case-insensitive) against ga_users and upserts the
+    // friendship row; re-adding an existing entry updates ignore_flag.
+    // Returns false if no such user exists.
+    static bool AddFriend(int64_t user_id, const std::string& name, bool ignore_flag);
+    static void RemoveFriend(int64_t user_id, int64_t friend_user_id);
+    static void SetFriendNotes(int64_t user_id, int64_t friend_user_id, const std::string& notes);
+    // True when `owner_name` has `other_name` on their ignore list (both are
+    // ga_users.username, matched case-insensitively). Used by the whisper gate.
+    static bool IsIgnoring(const std::string& owner_name, const std::string& other_name);
+
     // ---- Match stats (design 2026-06-12) -----------------------------------
     struct MatchEventRow {
         int64_t instance_id = 0;

--- a/src/ControlServer/Database/Database.hpp
+++ b/src/ControlServer/Database/Database.hpp
@@ -108,8 +108,15 @@ public:
     static void RemoveFriend(int64_t user_id, int64_t friend_user_id);
     static void SetFriendNotes(int64_t user_id, int64_t friend_user_id, const std::string& notes);
     // True when `owner_name` has `other_name` on their ignore list (both are
-    // ga_users.username, matched case-insensitively). Used by the whisper gate.
+    // ga_users.username, matched case-insensitively). Used by the team-invite
+    // gate; chat gates use the ChatSession per-session cache instead.
     static bool IsIgnoring(const std::string& owner_name, const std::string& other_name);
+    // Monotonic counter bumped on every ga_friends mutation. ChatSession
+    // compares it against its cached value to know when to reload its
+    // ignore set.
+    static uint64_t FriendsEpoch();
+    // Lowercased usernames on owner_name's ignore list.
+    static std::vector<std::string> GetIgnoredNames(const std::string& owner_name);
 
     // ---- Match stats (design 2026-06-12) -----------------------------------
     struct MatchEventRow {

--- a/src/ControlServer/TcpSession/TcpSession.cpp
+++ b/src/ControlServer/TcpSession/TcpSession.cpp
@@ -1,4 +1,5 @@
 #include "src/ControlServer/TcpSession/TcpSession.hpp"
+#include "src/ControlServer/ChatSession/ChatSession.hpp"
 #include "src/ControlServer/Database/Database.hpp"
 #include "src/ControlServer/Auth/LoginAuth.hpp"
 #include "src/ControlServer/Constants/DeviceIds.hpp"
@@ -1791,6 +1792,17 @@ void TcpSession::handle_packet(const uint8_t* data, size_t length) {
 			send_query_players_response(pkt);
 			break;
 		}
+		case GA_U::FRIEND_GET_LIST:
+			send_friends_list();
+			break;
+		case GA_U::FRIEND_UPDATE: {
+			PacketView pkt(data + 6, length - 6);
+			handle_friend_update(pkt);
+			// No incoming FRIEND_UPDATE handler on the client — ack every
+			// update by re-sending the full list (client re-renders on 0x1AE).
+			send_friends_list();
+			break;
+		}
 		case GA_U::TEAM_INVITE: {
 			Logger::Log("tcp", "[%s] Received: TEAM_INVITE [0x%04X], item count: %d\n", Logger::GetTime(), packet_type, item_count);
 			PacketView pkt(data + 6, length - 6);
@@ -1798,6 +1810,16 @@ void TcpSession::handle_packet(const uint8_t* data, size_t length) {
 			if (target.empty() || session_guid_.empty()) {
 				Logger::Log("tcp", "[TCP] TEAM_INVITE dropped (target='%s' guid='%s')\n",
 					target.c_str(), session_guid_.c_str());
+				break;
+			}
+			// Ignore gate: invitee has the inviter on their F3 ignore list —
+			// the invite is never delivered, inviter gets the same chat line
+			// as a blocked whisper.
+			if (Database::IsIgnoring(target, player_name)) {
+				Logger::Log("friends", "[Friends] team invite blocked: '%s' ignores '%s'\n",
+					target.c_str(), player_name.c_str());
+				ChatSession::SystemMessageTo(player_name,
+					"*** " + target + " is ignoring you ***");
 				break;
 			}
 			TeamService::RequestInvite(session_guid_, player_name, target);
@@ -3161,6 +3183,122 @@ void TcpSession::send_query_players_response(const PacketView& pkt)
 
 	Logger::Log("tcp", "[TCP] QUERY_PLAYERS: caller_id=%u online=%d matched=%d\n",
 		caller_id, (int)players.size(), (int)row_count);
+
+	send_response(response);
+}
+
+void TcpSession::handle_friend_update(const PacketView& pkt)
+{
+	if (user_id_ == 0) return;
+	const auto friend_id = pkt.Read4B(GA_T::FRIEND_PLAYER_ID);
+
+	// Remove: PLAYER_NAME + IGNORE_FLAG + FRIEND_PLAYER_ID + DELETE_FLAG=1.
+	if (pkt.Exists(GA_T::DELETE_FLAG)) {
+		if (friend_id) {
+			Database::RemoveFriend(user_id_, static_cast<int64_t>(*friend_id));
+			Logger::Log("friends", "[Friends] user=%lld removed friend_id=%u\n",
+				(long long)user_id_, *friend_id);
+		}
+		return;
+	}
+
+	// Note edit: NOTES + FRIEND_PLAYER_ID (no PLAYER_NAME).
+	if (auto notes = pkt.ReadString(GA_T::NOTES)) {
+		if (friend_id) {
+			Database::SetFriendNotes(user_id_, static_cast<int64_t>(*friend_id), *notes);
+			Logger::Log("friends", "[Friends] user=%lld set notes for friend_id=%u\n",
+				(long long)user_id_, *friend_id);
+		}
+		return;
+	}
+
+	// Add: PLAYER_NAME + IGNORE_FLAG ("y" = ignore list, "n" = friend —
+	// bools ride the wire as 1-char strings; client accepts Y/y/T/t as true).
+	auto name = pkt.ReadString(GA_T::PLAYER_NAME);
+	if (!name || name->empty()) return;
+	const std::string flag = pkt.ReadString(GA_T::IGNORE_FLAG).value_or("n");
+	const bool ignore = !flag.empty() &&
+		(flag[0] == 'y' || flag[0] == 'Y' || flag[0] == 't' || flag[0] == 'T');
+	if (Database::AddFriend(user_id_, *name, ignore)) {
+		Logger::Log("friends", "[Friends] user=%lld added '%s' ignore=%d\n",
+			(long long)user_id_, name->c_str(), ignore ? 1 : 0);
+	} else {
+		Logger::Log("friends", "[Friends] user=%lld add failed, no such player '%s'\n",
+			(long long)user_id_, name->c_str());
+		ChatSession::SystemMessageTo(player_name, "Player '" + *name + "' not found.");
+	}
+}
+
+void TcpSession::send_friends_list()
+{
+	if (user_id_ == 0) return;
+	const auto rows = Database::GetFriendsForUser(user_id_);
+
+	// Online decoration (map / class / profile) from the same snapshot
+	// QUERY_PLAYERS uses. A friend absent from it is shown offline.
+	const auto online_players = InstanceRegistry::GetActiveSearchablePlayers();
+
+	std::vector<uint8_t> data_rows;
+	uint16_t row_count = 0;
+	for (const auto& r : rows) {
+		if (r.ignore_flag) {
+			append(data_rows, 0x04, 0x00);  // 4 fields
+			WriteString(data_rows, GA_T::IGNORE_FLAG, "y");
+			WriteString(data_rows, GA_T::PLAYER_NAME, r.friend_name);
+			WriteString(data_rows, GA_T::NOTES, r.notes);
+			Write4B(data_rows, GA_T::FRIEND_PLAYER_ID, static_cast<uint32_t>(r.friend_user_id));
+			++row_count;
+			continue;
+		}
+
+		const InstanceRegistry::SearchablePlayerRow* online = nullptr;
+		for (const auto& p : online_players) {
+			if (p.player_name == r.friend_name) { online = &p; break; }
+		}
+
+		if (online) {
+			uint32_t map_msg_id = 0;
+			if (auto rec = MapGameInfo::LookupByName(online->map_name))
+				map_msg_id = rec->friendly_name_msg_id;
+			append(data_rows, 0x09, 0x00);  // 9 fields
+			WriteString(data_rows, GA_T::IGNORE_FLAG, "n");
+			WriteString(data_rows, GA_T::PLAYER_NAME, r.friend_name);
+			WriteString(data_rows, GA_T::NOTES, r.notes);
+			Write4B(data_rows, GA_T::FRIEND_PLAYER_ID, static_cast<uint32_t>(r.friend_user_id));
+			Write1B(data_rows, GA_T::OFFLINE_FLAG, 0);
+			Write4B(data_rows, GA_T::MAP_NAME_MSG_ID, map_msg_id);
+			// CLASS_MSG_ID is a WCHAR_STR on the wire; the client converts.
+			WriteString(data_rows, GA_T::CLASS_MSG_ID,
+				std::to_string(ResolveClassMsgId(online->profile_id, 22976, "FRIENDS_LIST")));
+			Write4B(data_rows, GA_T::PROFILE_ID, online->profile_id);
+			// LEVEL presence is what routes the row into the client's online
+			// list (levels aren't tracked; 50 everywhere, like QUERY_PLAYERS).
+			Write4B(data_rows, GA_T::LEVEL, 50);
+		} else {
+			append(data_rows, 0x05, 0x00);  // 5 fields, no LEVEL → offline list
+			WriteString(data_rows, GA_T::IGNORE_FLAG, "n");
+			WriteString(data_rows, GA_T::PLAYER_NAME, r.friend_name);
+			WriteString(data_rows, GA_T::NOTES, r.notes);
+			Write4B(data_rows, GA_T::FRIEND_PLAYER_ID, static_cast<uint32_t>(r.friend_user_id));
+			Write1B(data_rows, GA_T::OFFLINE_FLAG, 1);
+		}
+		++row_count;
+	}
+
+	// Reply is packet type FRIEND_GET_LIST carrying DATA_SET_FRIENDS — the
+	// client dispatches 0x1AE to its friends-store populate handler, fires
+	// the F3 UI refresh event, then feeds the same packet to the chat-side
+	// friend/ignore name map.
+	std::vector<uint8_t> response;
+	uint16_t packet_type = GA_U::FRIEND_GET_LIST;
+	uint16_t item_count = 1;
+
+	append(response, packet_type & 0xFF, packet_type >> 8);
+	append(response, item_count & 0xFF, item_count >> 8);
+
+	append(response, GA_T::DATA_SET_FRIENDS & 0xFF, GA_T::DATA_SET_FRIENDS >> 8);
+	append(response, row_count & 0xFF, (row_count >> 8) & 0xFF);
+	WriteNBytesRaw(response, data_rows);
 
 	send_response(response);
 }

--- a/src/ControlServer/TcpSession/TcpSession.hpp
+++ b/src/ControlServer/TcpSession/TcpSession.hpp
@@ -552,6 +552,9 @@ private:
     // index) + a DATA_SET of matching online players. See
     // player-search-tcp-protocol.md.
     void send_query_players_response(const PacketView& pkt);
+// F3 friends menu (FRIEND_GET_LIST / FRIEND_UPDATE arrive on this socket).
+void handle_friend_update(const PacketView& pkt);
+void send_friends_list();
 
     // Team wire helpers. Opcodes 0x4A/0x4D/0x4E/0x4F all route to the client's
     // message-display handler (vt[0x54]: MSG_ID 0x36E template + @@token@@


### PR DESCRIPTION
The gap

The F3 friends menu was completely non-functional: the client sends FRIEND_GET_LIST (0x01AE) and FRIEND_UPDATE (0x01AD) on the main TCP control socket, and the server dropped both as unknown packet types. No friends, no ignore list, no way to whisper/invite without typing exact names.

The fix

Reconstructed the wire protocol from the client binary (capstone disassembly of the dispatch table, the friends-store populate function, and the outgoing packet builders):

- Response format: packet type 0x1AE carrying DATA_SET_FRIENDS (0x0152) rows. Per-row fields: IGNORE_FLAG, PLAYER_NAME, NOTES, FRIEND_PLAYER_ID, plus for friends OFFLINE_FLAG, MAP_NAME_MSG_ID, CLASS_MSG_ID, PROFILE_ID, LEVEL. Notable client quirks honored: LEVEL presence is what routes a row to the online vs offline section; bool flags ride the wire as 1-char strings ("y"/"n"); CLASS_MSG_ID is a numeric string.
- Updates: the client has no incoming FRIEND_UPDATE handler — every add/remove/note edit is acked by re-sending the full list.
- Server side: TcpSession handles both opcodes; new ga_friends table (account-scoped: user → friend user, ignore flag, notes) with Database::{GetFriendsForUser, AddFriend, RemoveFriend, SetFriendNotes, IsIgnoring}. Online
status/class/map come from the same InstanceRS uses.
- Ignore enforcement via Database::IsIgnoring:
  - Whispers: blocked, sender gets *** X is ignoring you ***
  - Global chat: sender's lines hidden from tion — retail client's local filter can'tmatch our sender-less global frames; can be reverted independently)
  - Team invites: blocked before TeamService::RequestInvite, inviter gets the same chat line
- Failed add (name not in DB) responds with ew ChatSession::SystemMessageTo helper.

Tested

- ✅ Add friend / remove friend
- ✅ Ignore player / remove ignore
- ✅ Set note / remove note on friend
- ✅ Online friends show class, level and instance; offline friends listed separately
- ✅ Error message when adding a name that doesn't exist in the DB
- ✅ Whisper directly from the friends list
- ✅ Team invite directly from the friends list
- ✅ Ignore blocks whispers and global chat (global-chat hiding is our addition, revertible)
- ✅ Ignore blocks team invites

Deliberately out of scope

- "X has come online" friend notifications — redundant for now with the global *** X has joined the chat *** broadcast
- Agency invite ignore-gating — AGENCY_INVITE has no handler yet; noted to include the same gate when agencies are implemented

Related to: https://discord.com/channels/994691794627461211/1527984322613743726