### PR TITLE
Fix /r reply target being wiped and block self-whisper

### DIFF
--- a/src/ControlServer/ChatSession/ChatSession.cpp
+++ b/src/ControlServer/ChatSession/ChatSession.cpp
@@ -467,6 +467,11 @@ void ChatSession::broadcast(const uint8_t* data, size_t length) {
                     return false;
             return true;
         };
+        if (ieq(recipient, player_name_)) {
+            deliver(BuildChatFrame(kSystemChannelId,
+                "*** You cannot whisper yourself ***"));
+            return;
+        }
         PruneExpiredSessions();
         std::shared_ptr<ChatSession> target;
         for (auto& weak : g_chat_sessions) {
@@ -479,9 +484,12 @@ void ChatSession::broadcast(const uint8_t* data, size_t length) {
                 "*** " + recipient + " is not online ***"));
             return;
         }
-        // Per-side frames. Client renders NAME (0x370) as "<name> says:" (or
-        // MESSAGE verbatim when NAME is empty — used for the sender echo) and
-        // caches PLAYER_NAME (0x3C5) as the reply-keybind target.
+        // Per-side frames. On channel 8 the client composes the line itself:
+        // NAME (0x370) == own player name + non-empty PLAYER_NAME (0x3C5)
+        // renders "To <PLAYER_NAME>: msg" (sender echo), otherwise
+        // "<NAME> says: msg". The reply cache is NAME, and it is overwritten on
+        // every ch8 line whose NAME != own name — so the echo MUST carry the
+        // sender's own name, else it blanks the cache and /r dies after one use.
         const std::string text = pkt.ReadString(GA_T::MESSAGE).value_or("");
         auto makeWhisperFrame = [this, channel](const std::string& displayName,
                                                 const std::string& msgText,
@@ -503,8 +511,7 @@ void ChatSession::broadcast(const uint8_t* data, size_t length) {
 
         const std::string& targetName = target->get_player_name();
         target->deliver(makeWhisperFrame(player_name_, text, player_name_));
-        if (target.get() != this)
-            deliver(makeWhisperFrame("", "To " + targetName + ": " + text, targetName));
+        deliver(makeWhisperFrame(player_name_, text, targetName));
         return;
     }
 


### PR DESCRIPTION
1. /r (or reply keybind) only worked once per received whisper

Reply to someone, and a second /r (or reply keybind) did nothing — the entry box just stayed on Local.

The client's reply target is a fixed 0x34-wchar buffer at chatObj+0x74. UTgUIChat's chat-line dispatcher (0x10901610) writes it from the NAME TLV (0x370), not PLAYER_NAME, on every channel-8 line whose NAME differs from the local player name. Our sender echo sent NAME="", so it copied an empty string over the cache. /r (0x113bf710) bails out and clears the entry box when that buffer is empty.

Fix: the echo now carries NAME = sender's own name, the raw message text, and PLAYER_NAME = recipient. The client composes the line itself (0x10901160): NAME == local player name + non-empty PLAYER_NAME renders To <recipient>: msg, otherwise <NAME> says: msg. Display is unchanged; the cache survives, so /r and the reply keybind stay usable indefinitely.

2. Whispering yourself

The client has no guard for it — SendWhisper (0x10901790) only rejects a blank message and names over 16 chars — and the render path can't express it (self-addressed lines always take the To X: branch, never says:). Never a designed case, just unguarded.

Fix: the server rejects it with *** You cannot whisper yourself ***. The now-dead target.get() != this echo guard was removed.

Related to https://discord.com/channels/994691794627461211/1527984322613743726