### PR TITLE
Feature: Agencies & Alliances 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ These have been learned the hard way over hundreds of sessions. Re-deriving why 
 - `Makefile` — explicit source list. Add new `.cpp` here.
 - `server.db` — SQLite at repo root. Asset / blueprint / effect data.
 - `control-server.json` — runtime knobs, log channel toggles.
-- Existing technical docs in the repo: `bots.md`, `deployables.md`, `device_volumes.md`, `equip-slots.md`, `equippable-devices.md`, `medsec_spawn_tables.md`, `umax_spawn_tables.md`, `docs/gameplay/rest-device-slot14.md`. Read the relevant one before working in an area.
+- Existing technical docs in the repo: `agencies-alliances.md`, `bots.md`, `deployables.md`, `device_volumes.md`, `equip-slots.md`, `equippable-devices.md`, `medsec_spawn_tables.md`, `umax_spawn_tables.md`, `docs/gameplay/rest-device-slot14.md`. Read the relevant one before working in an area.
 
 ## Supporting docs (read on demand)
 

--- a/agencies-alliances.md
+++ b/agencies-alliances.md
@@ -1,0 +1,337 @@
+# Agencies & Alliances
+
+Read this before touching the agency/alliance subsystem. It carries the reversed
+wire protocol, the permission bit layout, and the findings that are NOT fixable
+so nobody re-derives them.
+
+## What this is
+
+The persistent **agency** + **alliance** subsystem, reimplemented server-side.
+The retail client sends these over the **ControlServer TCP connection** (same
+transport as login/team/whisper), handled in
+`src/ControlServer/TcpSession/TcpSession.cpp` `handle_packet()`. The client
+natives are NOT stubbed — the retail client genuinely emits the opcodes; we just
+had no server handlers or DB schema. All work is server-side (no client mods).
+
+Code: `Database.{cpp,hpp}` + `TcpSession.{cpp,hpp}`. No new `.cpp`, so the
+Makefile is untouched.
+
+## Testing notes
+
+- Log channels: `agency` (actions) and `tcp` (raw packets), enabled in
+  `out/control-server.json` → `enabled_channels`. `dbperf` reports SQLite
+  statements/sec if you're checking query load.
+- DB is `out/server.db`. Reset test data with:
+  `DELETE FROM ga_agency_members, ga_agency_ranks, ga_agencies,
+  ga_alliance_members, ga_alliances;`
+- Reversing note: the invite/accept natives are PlayerController vtable slots —
+  `execAgencyInvite` → slot **0x4cc**, `execAgencyAccept` → **0x4d0**. The PC
+  vtable base is NOT `0x11875fd8` (that table's 0x4cc is a mouse-hover trace).
+
+## Ghidra reversing = self-serve via curl
+
+The Ghidra MCP bridge is broken (-32000) but the **HTTP plugin is reachable at
+`http://127.0.0.1:8090`** — curl it directly. Client binary base `0x10900000`
+(matches hooks). Endpoints: `/decompile_function?address=0x..`,
+`/xrefs_to?address=`, `/xrefs_from?address=`, `/strings?filter=&limit=`,
+`/searchFunctions?query=`, `/segments`. Binary is stripped (FUN_xxxx).
+When Ghidra hasn't defined a function (vtable-only targets), **capstone** on
+`out/client/Binaries/GlobalAgenda.exe` works (pefile + capstone installed).
+
+**Key techniques used:**
+- Native exec: `/strings?filter=intUClassexecFn` → `/xrefs_to` gives the
+  registration name-slot; func ptr is at `name_slot+4` (`/xrefs_from`).
+- UI/data class vtable: find the class registration fn (asserts on
+  `.\Src\Class.cpp` OR `FUN_112f6230(...,L"ClassName",...,ctor,...)`), the ctor
+  sets `*this = &vtable`; read `*(vtable+slot)` for any virtual. Exec thunks do
+  `mov eax,[this]; call [eax+SLOT]` — disassemble to get SLOT.
+- Marshal primitives (client receive): `FUN_10938090`=GetInt32,
+  `FUN_10937ed0`=GetWStr, `FUN_10938050`=GetFlag(str: first char Y/y/T/t=true),
+  `FUN_10938110`=GetDataSet, `FUN_10938160`=GetDateTime(double).
+- Find a receiver by scanning `.text` for a function writing the object's field
+  offsets together (capstone regex on disp32 bytes).
+
+## Wire protocol — FULLY REVERSED
+
+### Transport / framing
+Packet = `[u16 len][u16 opcode][u16 item_count][TLV fields...]`. TLV = `[u16
+tag][value]`. Value encoding by tag TYPE (see `PacketView.hpp kTypeEnc` +
+`TcpTypes.h` "Type:" comments): 0=WCHAR_STR (`WriteString`: u8 len + 0x00 +
+narrow bytes — NOT wide), 1=FLOAT, 2=DOUBLE, 3=UINT32, 6=DATA_SET, 7=DATETIME
+(8-byte double = **unix epoch seconds**). DATA_SET = `[tag][u16 rowcount]` then
+per row `[u16 fieldcount][TLV...]`. Helpers: `Write1B/2B/4B/WriteString/
+WriteDouble/WriteFloat`, `append(...)`, `WriteNBytesRaw`. Read via `PacketView`.
+
+### Opcodes (GA_U, `TcpFunctions.h`)
+Agency: CREATE 0xB4, INVITE 0xB5, INVITATION 0xB6, ACCEPT_INVITE 0xB7,
+REJECT_INVITE 0xB8, PROMOTE 0xBB, DEMOTE 0xBC, REMOVE 0xBD (solo-leader remove =
+disband), PLAYER_REMOVE 0xBF, PLAYER_ADD 0xC0, LEAVE 0xC1, GET_ROSTER 0xC2,
+SET_SITE_ID 0xC3, SET_NOTE 0xC4 (MOTD/notes edit), UPDATE 0xC5,
+UPDATE_RECRUITING 0xCA, UPDATE_RANKS 0xCB.
+Alliance: CREATE 0xD1, DISBAND 0xD2, REMOVE 0xD3 (kick+leave), INVITE 0xD4,
+INVITATION 0xD5, ACCEPT_INVITE 0xD6, REJECT_INVITE 0xD7, GET_MEMBER_LIST 0xDA.
+
+### AGENCY_GET_ROSTER (0xC2) response — `append_agency_payload()` (12 fields)
+The client's receiver = `FUN_113cd3d0` (dispatcher `FUN_113a6590`, gated on
+PlayerController+0x6EC = m_AgencyData). Fields:
+- `ROSTER_FLAGS 0x44C` (u32) = **bit0** → clears m_bNoAgency [THE GATE].
+- `NAME 0x370` (str) = agency name **(NOT AGENCY_NAME 0x24)**.
+- `AGENCY_MOTD 0x23`, `AGENCY_INFORMATION 0x20` (str).
+- `RECRUITING_LISTING_TEXT 0x41F` (str); `RECRUITING_FLAG 0x41E` +
+  `RECRUITING_SUB_ONLY_FLAG 0x420` = **"y"/"n" strings** (WCHAR_STR, not bytes —
+  a raw byte desyncs the stream).
+- `AGENCY_ID 0x1F`; `PLAYER_ID 0x3C3` = local player member id (→
+  m_nLocalPlayerId, drives LocalPlayerIsLeader); `COUNT 0xE4` = #members.
+- `DATA_SET_RANKS 0x193` rows{`RANK_ID 0x417`, `RANK_LEVEL 0x418`,
+  `PERMISSION_FLAGS 0x3B0`, `NAME 0x370`} — rank name is 0x370, NOT RANK_NAME.
+- `DATA_SET_MEMBERS 0x179` rows{`PLAYER_NAME 0x3C5`, `PLAYER_ID 0x3C3`,
+  `RANK_ID 0x417`, `LEVEL 0x303`, `PROFILE_ID 0x3DF`} — member LEVEL/PROFILE are
+  currently **50/0 placeholders** (see TODO "show class/level/online").
+- "No agency" reset (after disband): send `MSG_ID 0x36E = 0x37B9` (1 field) —
+  sets m_bNoAgency + ClearData → creation menu returns.
+
+### ‼️ LEADER = rank_LEVEL 0
+`LocalPlayerIsLeader` (`FUN_113cc580`) returns
+`GetRankData(myRankId).nRankLevel == 0`. Seeded ranks: `{id0/level0=Leader
+perms 0xFFFFFFFF, id1/level1=Officer, id2/level2=Member}`, creator member
+rank_id 0. This gates the alliance Create panel (via `UpdateAllianceDisplay` →
+LocalPlayerIsLeader). Getting this wrong = blank/locked panels.
+
+### ALLIANCE_GET_MEMBER_LIST (0xDA) response — `append_alliance_payload()` (8)
+Receiver = `FUN_113ce850` (dispatcher `FUN_113a6840`, gated on PC+0x6F0 =
+m_AllianceData; row parser `FUN_113ce350`). Fields:
+- `ROSTER_FLAGS 0x44C` = **0x5** (bit0 core + **bit2 = DATA_SET_AGENCIES gate**;
+  flags=1 shows count but empty affiliated list — the member rows need bit2).
+- `NAME 0x370` = alliance name; `AGENCY_NAME 0x24` = owner agency name.
+- `ALLIANCE_ID 0x29`; `OWNER_AGENCY_ID 0x390`; `COUNT 0xE4` = #member-agencies.
+- `CREATED_DATETIME 0xE9` (DATETIME/double) → "Formed <date>". ‼️ The alliance
+  formatter (`FUN_10955ab0`, `FILETIME = K - input*(-864e9)`) reads this double
+  as **DAYS SINCE 1900-01-01** (input 0 → 01/01/1900). Send
+  `days = (unix_seconds + 2208988800) / 86400`. (NB: other DATETIME fields like
+  ACQUIRE_DATETIME use raw unix-seconds doubles — the representation depends on
+  which client formatter consumes it, so reverse the formatter per field.)
+- `DATA_SET_AGENCIES 0x113` rows{`AGENCY_NAME 0x24`, `AGENCY_ID 0x1F`,
+  `PLAYER_COUNT 0x3C2`, `TERRITORY_COUNT 0x4F5`}.
+- "No alliance" reset: send `MSG_ID 0x36E = 0x624F` (1 field) — sets
+  m_bNoAlliance + unlocks the in-tab Create panel. Empty response = blank tab.
+- **"Leader: Unknown" in the affiliated-agency detail is UNFIXABLE** — RE-VERIFIED
+  2026-07-19 at the binary. `sAllianceMemberInfo` (TgAllianceData.uc) does have
+  an `sLeaderName` field, but NOTHING on the wire ever fills it: the row parser
+  `FUN_113ce350` reads exactly 4 tags — 0x24 AGENCY_NAME → sMemberName, 0x1F,
+  0x3C2, 0x4F5 — and the whole receiver `FUN_113ce850` reads only 0x36E, 0x44C,
+  0x528, 0x370, 0x24, 0x29, 0x390, 0xE4, 0xE9, 0x113. No name tag anywhere, so
+  sLeaderName keeps its "" default and the label falls back to "Unknown". The
+  only lever would be smuggling the leader into AGENCY_NAME (e.g. "MESA
+  (Angel)"), which corrupts the list + header text — not worth it. Leave it.
+
+### Invitation popups = MSG_ID template + @@token@@
+Popup = `MSG_ID` (localized template) + substitution fields keyed by token name
+(@@leader_name@@ ← LEADER_NAME, @@alliance_name@@ ← ALLIANCE_NAME, etc). Msg
+templates live in DB table `asm_data_set_msg_translations(msg_id, message)`.
+Alliance invite = **MSG_ID 25111** "Invitation from @@leader_name@@ to join
+alliance @@alliance_name@@". Agency-invite equivalent = **14266**
+"@@leader_name@@ has invited you to join agency \"@@agency_name@@\".". Others:
+14261 sent-confirm, 25116 alliance sent-confirm, 25143 rank-no-permission,
+25112/25140 "respond to invite first", 22370/25148 self-invite.
+
+### Cross-session invitation delivery pattern (implemented for alliance)
+`static std::map<agency_id,alliance_id> pending_alliance_invites_` (+ mutex).
+INVITE: resolve target agency by leader name (`GetAgencyIdByLeaderName`, rank 0),
+store pending, `DeliverAllianceInvitation(target_user)` iterates `g_sessions_`
+by `user_id_` and sends the popup. ACCEPT (0xD6, 0 fields): pop pending for MY
+agency → `AddAgencyToAlliance`. REJECT (0xD7): erase pending. This design means
+accept/reject payloads don't matter — server pending state drives it. Mirror
+this for **agency** invites.
+
+## Implemented (all tested in the live client)
+
+### Agency + alliance foundations
+- **Create agency** (AGENCY_CREATE 0xB4, `handle_agency_create`). Request =
+  AGENCY_NAME 0x24 + LINEAR_COLOR_R/G/B (0x030D/0x030C/0x030B floats; alpha
+  0x030A absent, no abbreviation). `Database::CreateAgency` is one transaction:
+  insert agency + seed the 3 ranks + add the creator as a member. Reply is a
+  normal AGENCY_GET_ROSTER push (no separate create-ack) so the receiver clears
+  m_bNoAgency and the UI leaves the creation panel.
+  - Schema (idempotent CREATE block at the end of `Database::Init`):
+    `ga_agencies`, `ga_agency_members` (PK user_id ⇒ ONE AGENCY PER ACCOUNT),
+    `ga_agency_ranks`.
+  - ‼️ Two wire mistakes cost a full test cycle here, both recorded above: the
+    ROSTER_FLAGS 0x44C bit0 gate is mandatory (without it the client ignores the
+    entire block), and agency/rank NAME is **0x370**, not AGENCY_NAME/RANK_NAME.
+  - ‼️ LEADER = rank_**level** 0, not rank_id 0 (see the section above). Seeding
+    the leader at rank_id 1 hid the alliance Create panel.
+- **Disband agency** (0xBE DISBAND / 0xC1 LEAVE / 0xBD REMOVE all route to
+  `handle_agency_disband`; a solo leader's "remove last member" confirms as a
+  disband). `Database::DisbandAgency` deletes the agency + members + ranks + any
+  alliance it owns + its own alliance membership. Reply = the "no agency" reset
+  MSG_ID 0x37B9 so the creation menu comes back.
+  - Original symptom: solo leader → remove last member → confirm → nothing
+    happened, because no handler existed for any of the three opcodes.
+- **Create alliance** (ALLIANCE_CREATE 0xD1, name = NAME 0x370). Requires the
+  player be their agency's LEADER. `Database::CreateAlliance` inserts the
+  alliance and its owner agency as first member, atomically. Schema:
+  `ga_alliances` + `ga_alliance_members` (PK agency_id ⇒ one alliance per
+  agency).
+- **Disband alliance** (ALLIANCE_DISBAND 0xD2, 0 fields, owner agency only).
+  Reply = the "no alliance" reset MSG_ID 0x624F — an empty response is ignored
+  and leaves the tab blank.
+- **Invite an agency to an alliance** (ALLIANCE_INVITE 0xD4 = PLAYER_NAME 0x3C5
+  of the target agency's leader) → ALLIANCE_INVITATION 0xD5 popup → ACCEPT 0xD6
+  / REJECT 0xD7, both 0 fields (server pending state drives it — see the
+  cross-session pattern above). Popup text = MSG_ID 25111 + LEADER_NAME +
+  ALLIANCE_NAME; without the tokens it renders "Unknown".
+- **Kick / leave an alliance** (ALLIANCE_REMOVE 0xD3 = AGENCY_ID 0x1F of the
+  agency to drop; one opcode for both directions). Owner may kick anyone,
+  a member may drop itself, the owner agency can't be removed from its own
+  alliance (that's a disband). The owner having no Remove button is intended.
+- **Affiliated-agencies list** — was arriving EMPTY despite COUNT being right:
+  DATA_SET_AGENCIES 0x113 is gated by **ROSTER_FLAGS bit2**, so alliance flags
+  must be 0x5 (bit0 core + bit2 members). The agency member set 0x179 is NOT
+  flag-gated, which is why it worked with flags=1 — the asymmetry is the trap.
+- **"Formed <date>"** — CREATED_DATETIME 0xE9. v1 sent raw unix seconds and
+  rendered "00/4245/0000"; the alliance formatter reads DAYS SINCE 1900 (see
+  the ALLIANCE_GET_MEMBER_LIST section for the conversion).
+
+### Agency management
+
+- **Invite player to agency** (0xB5 → 0xB6 popup → 0xB7/0xB8). TESTED WORKING.
+  - Request 0xB5 carries PLAYER_NAME; accept = 0xB7, decline = 0xB8 (UC has a
+    single native `ATgPlayerController::AgencyAccept(bool bAccepted)`, but it
+    does split into the two opcodes).
+  - The popup is NOT a data receiver like the roster/alliance ones — it's the
+    HUD dialog `TgUIPrimaryHUD_DialogQuery` type `DialogInviteToAgency`, same
+    widget the team invite (0x4B) uses. Payload = 3 fields: MSG_ID **14266** +
+    LEADER_NAME + AGENCY_NAME (mirrors `send_team_invitation_popup`).
+  - Server state: `pending_agency_invites_` keyed by **user_id** (the alliance
+    map keys by agency_id). Target must be ONLINE — resolved by scanning
+    `g_sessions_` for `player_name`, no DB name lookup. Accept →
+    `Database::AddAgencyMember(..., rank_id 2 = Member)` → push roster.
+
+- **Promote / demote / kick / leave**. TESTED WORKING.
+  - Target arrives as `PLAYER_ID` = the member's **character_id** (that's what we
+    put in the DATA_SET_MEMBERS rows; UC: `TgAgencyData::Promote/Demote/Remove(
+    int nPlayerId)`). DB: `SetAgencyMemberRank` / `RemoveAgencyMember`, both
+    keyed by character_id.
+  - Promote/demote = one step along the `rank_level`-ASC rank list. Promote stops
+    one below rank_level 0 — moving INTO Leader is `TransferLeader`, a separate
+    native. Guard: actor must outrank both the target and the destination rank.
+  - Kick = 0xBF, or 0xBD carrying a PLAYER_ID that isn't mine. Self/no target =
+    the leave-or-disband path. Non-leader LEAVE used to be rejected outright
+    (pre-invite there was never a second member) — now drops just that row.
+- **Live push fan-out** (fixes "stale until relog / until you press O").
+  - `TcpSession::DeliverAgencyRefresh(user_id)` finds the live session and pushes
+    BOTH `send_agency_get_roster_response()` + `send_alliance_member_list_response()`.
+  - Why it's needed: the agency roster poll always runs, so the AgentInfo/agency
+    panel self-heals — but the **Alliance tab only refreshes while it's open**.
+    Any change a player didn't initiate must be pushed to them explicitly.
+  - Wired into: agency kick, agency disband (all other members), self-leave,
+    agency invite-accept, alliance create / accept / disband / remove. For the
+    delete paths, collect the affected user_ids BEFORE the DELETE (`Database::
+    GetAllianceMemberUserIds` / `GetAgencyMemberUserIds`) — afterwards the
+    membership rows are gone and the players are unreachable.
+
+- **MOTD / description / public+officer notes** (AGENCY_SET_NOTE 0xC4). TESTED.
+  - One opcode, four edits; the tag present says which: AGENCY_MOTD 0x23,
+    AGENCY_INFORMATION 0x20 (Management tab "description"), PUBLIC_COMMENT 0x3F3
+    / OFFICER_COMMENT 0x386 + PLAYER_ID for per-member notes.
+  - ‼️ The notes also have to be ECHOED BACK: DATA_SET_MEMBERS rows now carry 7
+    fields (added PUBLIC_COMMENT + OFFICER_COMMENT). The writes worked from day
+    one; the boxes were empty because the roster response never returned them.
+  - Officer text is withheld server-side from ranks without VIEW_OFFICER_MSG.
+- **Recruiting tab** (AGENCY_UPDATE_RECRUITING 0xCA). TESTED. Fields:
+  RECRUITING_LISTING_TEXT 0x41F + RECRUITING_FLAG 0x41E +
+  RECRUITING_SUB_ONLY_FLAG 0x420, the two flags as "y"/"n" strings.
+- **Transfer Leader** = **AGENCY_SET_OWNER 0xC6** (not a name — the client
+  resolves it and sends the target's PLAYER_ID/character_id). TESTED. Target
+  takes rank 0, old leader drops to the next rank, ga_agencies.leader_user_id
+  follows. NOTE: there is NO confirmation dialog anywhere — TgUIAgencyMenu_
+  Management.uc wires the button straight to TransferLeader(), and that class
+  has no OnConfirmYesClicked (General/Facilities/Inventory do). Not addable
+  server-side; the only push channels are the HUD invite dialog and MSG_ID
+  status lines, neither of which can gate an action on a Yes.
+- **Rank editor** (AGENCY_UPDATE_RANKS 0xCB). TESTED (checkbox edits, add rank,
+  delete rank all persist). Leader only.
+  - Request = DATA_SET_RANKS 0x193 with EVERY rank row {RANK_ID 0x417, NAME
+    0x370, PERMISSION_FLAGS 0x3B0, RANK_LEVEL 0x418} — a full replacement set,
+    so add / rename / delete / permission edits all arrive together.
+    `Database::ReplaceAgencyRanks` rewrites the table in one transaction,
+    refuses any set with no rank_level 0 row, and moves members off deleted
+    ranks to the bottom rank.
+  - **PERMISSION_FLAGS bits** (read off single-checkbox submits; baseline 0x0F
+    rides along on every submit and maps to no checkbox):
+    `0x40` Promote · `0x80` Demote · `0x100` Invite · `0x200` Remove/Kick ·
+    `0x400` Edit Description · `0x800` Edit Public Msg · `0x1000` Edit Officer
+    Msg · `0x2000` View Officer Msg · `0x8000` Edit MOTD · `0x20000` Facility
+    Mgmt · `0x40000` Inventory Removal. Enum `Database::AgencyPerm`.
+  - Enforced server-side on invite / promote / demote / kick / MOTD /
+    description / public+officer message. rank_level 0 always passes.
+    Verified in test: an Officer with Invite could invite, and was correctly
+    refused on Edit Description.
+- **Status/error lines** (`send_agency_message`): 14258 no permission, 14259
+  character not found, 14260 already a member, 14261 invite sent, 14262 member
+  of another agency, 14265 you have no agency, 14267 has a pending invite.
+  CARRIER CONFIRMED: echo on **AGENCY_INVITE (0xB5)** — the request opcode —
+  with MSG_ID + PLAYER_NAME. One send renders in all three places: the Invite
+  tab's label, a modal OK dialog, and the chat log. Never 0xB6 (HUD dialog).
+
+- **Member online status / class / location**. TESTED.
+  - Member row parser `FUN_113ccbe0` reads, in order: PLAYER_NAME 0x3C5,
+    PLAYER_ID 0x3C3, RANK_ID 0x417, LEVEL 0x303, PROFILE_ID 0x3DF,
+    ACTIVE_FLAG 0x16, MAP_NAME_MSG_ID 0x327, PUBLIC_COMMENT 0x3F3,
+    OFFICER_COMMENT 0x386. Nothing else exists on this row.
+  - ACTIVE_FLAG is stored INVERTED: `eMemberStatus = (flag == 0)` and UC has
+    `AGENCY_MEMBER_ONLINE = 0`, so **online must send "y"**.
+  - MAP_NAME_MSG_ID → the Location column (client localizes it into
+    sMemberLocationString). **Omit the field entirely when offline** — a 0 id
+    localizes to "Unknown"; an absent field leaves the string "" (blank). Field
+    count is per row, so offline rows send 8 fields and online ones 9.
+  - LEVEL stays **50** — no level is tracked anywhere on this server
+    (GSC_CHARACTER_LIST and QUERY_PLAYERS both hardcode 50). Not a placeholder
+    to fix here; fix it globally or not at all.
+- **Joined / Win-Loss / Last Online are UNFIXABLE**, same class as "Leader:
+  Unknown". `TgUIAgencyMenu_General.uc` has the widgets (`joinedValueLabel`,
+  `wlValueLabel`, `lastOnlineValueLabel` in `sMemberDetailPanel`), but the only
+  per-member data the client holds is `sAgencyMemberInfo`, whose complete field
+  list is: sMemberName, nMemberRankId, nMemberRankLevel, eMemberStatus,
+  nMemberLocationId, sMemberLocationString, nMemberPlayerId, nMemberLevel,
+  nMemberProfileId, sPublicComment, sOfficerComment. No date, no W/L field
+  exists, so no tag we could send would ever reach those labels.
+  `ga_agency_members.joined_at` is populated and has nowhere to go.
+
+## DB query rate (checked 2026-07-19)
+The roster is polled every **2s per online client** (alliance list every 5s), so
+anything per-member in that path multiplies fast. Two problems were found and
+fixed while wiring online status:
+- `GetAgencyInfo` looked up each member's class with a separate
+  `GetCharacterById` → **O(N) queries per poll** (a 40-member agency = 40 extra
+  queries every 2s, per online member). Now a `LEFT JOIN ga_characters` inside
+  the existing members query.
+- Online detection first used `InstanceRegistry::GetActiveSearchablePlayers()`,
+  a 5-table join that also pulls user/player names the roster already has. Now
+  `Database::GetOnlineAgencyMemberMaps(agency_id)` — one query, scoped to that
+  agency, returning character_id → map_name.
+
+Result: a **fixed 5 queries per roster poll regardless of member count** (agency
+id, meta, ranks, members, online map). No cache layer was added on purpose — a
+cache buys nothing measured here and reintroduces the stale-data class of bug
+this branch spent most of its time fixing. Measure first: enable log channel
+**`dbperf`** in `out/control-server.json` for a statements-per-second count
+(sqlite3_trace_v2 hook in `Database::GetConnection`, counts EVERY statement
+server-wide, including code we didn't write).
+
+## Still open
+- **Agency + alliance chat channels** — deliberately NOT here; they belong with
+  the wider chat rework (whisper / friends / ignore). Membership routing will
+  need agency_id/alliance_id checks against the ga_* tables; see
+  `src/ControlServer/ChatSession/`.
+- **Member detail panel**: nothing left that's server-reachable (see the
+  UNFIXABLE note above).
+- The same DB-rate check is worth running on the friends/ignore path — the
+  `dbperf` channel works server-wide.
+
+## Gotchas recap
+- Agency/alliance NAME renders ALL-CAPS in headers = client display font; DB
+  stores correct case ("Rez"). Not a bug.
+- One agency per ACCOUNT (ga_agency_members PK user_id); one alliance per AGENCY
+  (ga_alliance_members PK agency_id).
+- Real DB is `out/server.db` (repo-root `server.db` is 0 bytes / stale).

--- a/src/ControlServer/Database/Database.cpp
+++ b/src/ControlServer/Database/Database.cpp
@@ -3509,6 +3509,31 @@ int64_t Database::GetAgencyIdByLeaderName(const std::string& leader_name) {
 	return id;
 }
 
+std::map<int64_t, Database::AffiliationRow> Database::GetAffiliationsByCharacter() {
+	std::map<int64_t, AffiliationRow> out;
+	sqlite3* db = GetConnection();
+	sqlite3_stmt* stmt = nullptr;
+	if (sqlite3_prepare_v2(db,
+			"SELECT m.character_id, ag.name, COALESCE(al.name,'') "
+			"FROM ga_agency_members m "
+			"JOIN ga_agencies ag ON ag.id = m.agency_id "
+			"LEFT JOIN ga_alliance_members am ON am.agency_id = m.agency_id "
+			"LEFT JOIN ga_alliances al ON al.id = am.alliance_id "
+			"WHERE m.character_id > 0",
+			-1, &stmt, nullptr) != SQLITE_OK || !stmt) {
+		return out;
+	}
+	while (sqlite3_step(stmt) == SQLITE_ROW) {
+		auto txt = [&](int c) {
+			const unsigned char* t = sqlite3_column_text(stmt, c);
+			return t ? std::string(reinterpret_cast<const char*>(t)) : std::string();
+		};
+		out[sqlite3_column_int64(stmt, 0)] = AffiliationRow{ txt(1), txt(2) };
+	}
+	sqlite3_finalize(stmt);
+	return out;
+}
+
 void Database::RemoveAgencyFromAlliance(int64_t agency_id) {
 	if (agency_id <= 0) return;
 	sqlite3* db = GetConnection();

--- a/src/ControlServer/Database/Database.cpp
+++ b/src/ControlServer/Database/Database.cpp
@@ -4,6 +4,8 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <atomic>
+#include <ctime>
 
 sqlite3* Database::connection = nullptr;
 std::string Database::db_path_ = "server.db";
@@ -24,6 +26,26 @@ sqlite3* Database::GetConnection() {
 		// only ever reset to the start, never shrunk, so its size monotonically
 		// grows to the historical high-water mark (the 301 MB prod symptom).
 		sqlite3_exec(connection, "PRAGMA journal_size_limit=67108864;", nullptr, nullptr, nullptr);
+
+		// Query-rate meter, channel "dbperf" (off unless enabled in
+		// control-server.json). One trace hook counts every statement, and the
+		// count is dumped once per second — cheaper and more honest than
+		// instrumenting call sites, and it covers code we didn't write.
+		sqlite3_trace_v2(connection, SQLITE_TRACE_STMT,
+			[](unsigned, void*, void*, void*) -> int {
+				static std::atomic<long> count{0};
+				static std::atomic<long long> window_start{0};
+				const long long now = (long long)time(nullptr);
+				long long start = window_start.load();
+				if (start == 0) { window_start.store(now); start = now; }
+				count.fetch_add(1);
+				if (now > start) {
+					Logger::Log("dbperf", "[DB] %ld statements in %llds\n",
+						count.exchange(0), (long long)(now - start));
+					window_start.store(now);
+				}
+				return 0;
+			}, nullptr);
 	}
 
 	return Database::connection;
@@ -2078,6 +2100,68 @@ void Database::Init() {
 		}
 	}
 
+	// Agencies + alliances (design 2026-07-18-enable-agencies). UNCONDITIONAL +
+	// idempotent — shared version counter, same rationale as the moderation
+	// block. One agency per ACCOUNT (ga_agency_members keyed by user_id); one
+	// alliance per AGENCY (ga_alliance_members keyed by agency_id).
+	{
+		const char* kAgencySchema =
+			"CREATE TABLE IF NOT EXISTS ga_agencies ("
+			"  id              INTEGER PRIMARY KEY AUTOINCREMENT,"
+			"  name            TEXT NOT NULL UNIQUE,"
+			"  motd            TEXT NOT NULL DEFAULT '',"
+			"  information     TEXT NOT NULL DEFAULT '',"
+			"  color_r         REAL NOT NULL DEFAULT 0,"
+			"  color_g         REAL NOT NULL DEFAULT 0,"
+			"  color_b         REAL NOT NULL DEFAULT 0,"
+			"  recruiting      INTEGER NOT NULL DEFAULT 0,"
+			"  recruiting_text TEXT NOT NULL DEFAULT '',"
+			"  sub_only        INTEGER NOT NULL DEFAULT 0,"
+			"  leader_user_id  INTEGER NOT NULL,"
+			"  created_at      INTEGER NOT NULL"
+			");"
+			"CREATE TABLE IF NOT EXISTS ga_agency_members ("
+			"  user_id         INTEGER PRIMARY KEY,"           // one agency per account
+			"  agency_id       INTEGER NOT NULL,"
+			"  character_id    INTEGER NOT NULL DEFAULT 0,"
+			"  player_name     TEXT NOT NULL,"
+			"  rank_id         INTEGER NOT NULL,"
+			"  public_comment  TEXT NOT NULL DEFAULT '',"
+			"  officer_comment TEXT NOT NULL DEFAULT '',"
+			"  joined_at       INTEGER NOT NULL"
+			");"
+			"CREATE INDEX IF NOT EXISTS idx_ga_agency_members_agency "
+			"  ON ga_agency_members(agency_id);"
+			"CREATE TABLE IF NOT EXISTS ga_agency_ranks ("
+			"  agency_id       INTEGER NOT NULL,"
+			"  rank_id         INTEGER NOT NULL,"
+			"  rank_level      INTEGER NOT NULL,"
+			"  permissions     INTEGER NOT NULL,"
+			"  rank_name       TEXT NOT NULL,"
+			"  PRIMARY KEY (agency_id, rank_id)"
+			");"
+			"CREATE TABLE IF NOT EXISTS ga_alliances ("
+			"  id              INTEGER PRIMARY KEY AUTOINCREMENT,"
+			"  name            TEXT NOT NULL UNIQUE,"
+			"  motd            TEXT NOT NULL DEFAULT '',"
+			"  information     TEXT NOT NULL DEFAULT '',"
+			"  owner_agency_id INTEGER NOT NULL,"
+			"  created_at      INTEGER NOT NULL"
+			");"
+			"CREATE TABLE IF NOT EXISTS ga_alliance_members ("
+			"  agency_id       INTEGER PRIMARY KEY,"           // one alliance per agency
+			"  alliance_id     INTEGER NOT NULL,"
+			"  joined_at       INTEGER NOT NULL"
+			");"
+			"CREATE INDEX IF NOT EXISTS idx_ga_alliance_members_alliance "
+			"  ON ga_alliance_members(alliance_id);";
+		result = sqlite3_exec(db, kAgencySchema, nullptr, nullptr, &err);
+		if (result != SQLITE_OK) {
+			Logger::Log("db", "Failed to ensure agency schema: %s\n", err ? err : "?");
+			if (err) { sqlite3_free(err); err = nullptr; }
+		}
+	}
+
 	// NOTE: PlayerSessionStore::Init() is called separately from main.cpp -- not here.
 	Logger::Log("db", "[Database::Init] Schema at version >= 19, WAL mode enabled\n");
 }
@@ -2712,4 +2796,728 @@ void Database::SetInstanceDeathCounts(int64_t instance_id,
 		Logger::Log("matchstats", "[DeathCounts] instance=%lld attackers=%d defenders=%d\n",
 			(long long)instance_id, count_deaths_attackers, count_deaths_defenders);
 	}
+}
+
+// ---- Agencies (design 2026-07-18) ------------------------------------------
+
+int64_t Database::GetAgencyIdForUser(int64_t user_id) {
+	if (user_id <= 0) return 0;
+	sqlite3* db = GetConnection();
+	sqlite3_stmt* stmt = nullptr;
+	if (sqlite3_prepare_v2(db,
+			"SELECT agency_id FROM ga_agency_members WHERE user_id = ? LIMIT 1",
+			-1, &stmt, nullptr) != SQLITE_OK || !stmt) {
+		return 0;
+	}
+	sqlite3_bind_int64(stmt, 1, user_id);
+	int64_t id = 0;
+	if (sqlite3_step(stmt) == SQLITE_ROW) id = sqlite3_column_int64(stmt, 0);
+	sqlite3_finalize(stmt);
+	return id;
+}
+
+int64_t Database::CreateAgency(const std::string& name,
+                               float r, float g, float b,
+                               int64_t leader_user_id,
+                               int64_t leader_character_id,
+                               const std::string& leader_name) {
+	if (name.empty() || leader_user_id <= 0) return 0;
+	if (GetAgencyIdForUser(leader_user_id) != 0) {
+		Logger::Log("agency", "[DB] CreateAgency: user %lld already in an agency\n",
+			(long long)leader_user_id);
+		return 0;
+	}
+
+	sqlite3* db = GetConnection();
+	char* err = nullptr;
+	if (sqlite3_exec(db, "BEGIN IMMEDIATE", nullptr, nullptr, &err) != SQLITE_OK) {
+		if (err) sqlite3_free(err);
+		return 0;
+	}
+
+	int64_t agency_id = 0;
+	bool ok = true;
+	{
+		sqlite3_stmt* stmt = nullptr;
+		if (sqlite3_prepare_v2(db,
+				"INSERT INTO ga_agencies "
+				"(name, color_r, color_g, color_b, leader_user_id, created_at) "
+				"VALUES (?, ?, ?, ?, ?, strftime('%s','now'))",
+				-1, &stmt, nullptr) != SQLITE_OK || !stmt) {
+			ok = false;
+		} else {
+			sqlite3_bind_text(stmt, 1, name.c_str(), -1, SQLITE_TRANSIENT);
+			sqlite3_bind_double(stmt, 2, r);
+			sqlite3_bind_double(stmt, 3, g);
+			sqlite3_bind_double(stmt, 4, b);
+			sqlite3_bind_int64(stmt, 5, leader_user_id);
+			if (sqlite3_step(stmt) != SQLITE_DONE) ok = false;
+			sqlite3_finalize(stmt);
+		}
+		if (ok) agency_id = sqlite3_last_insert_rowid(db);
+	}
+
+	// The client identifies the leader as the rank whose rank_LEVEL == 0
+	// (LocalPlayerIsLeader checks GetRankData(myRankId).nRankLevel == 0).
+	// Leader MUST be rank_level 0; lower authority = higher level number.
+	if (ok) {
+		// Officer gets the people-management + message bits (see AgencyPerm);
+		// facility/inventory stay leader-only until the leader grants them.
+		static const int kOfficerPerms =
+			AGENCY_PERM_INVITE | AGENCY_PERM_PROMOTE | AGENCY_PERM_DEMOTE |
+			AGENCY_PERM_KICK | AGENCY_PERM_EDIT_MOTD | AGENCY_PERM_EDIT_PUBLIC_MSG |
+			AGENCY_PERM_EDIT_OFFICER_MSG | AGENCY_PERM_VIEW_OFFICER_MSG;
+		static const struct { int id, level, perms; const char* nm; } kRanks[] = {
+			{ 0, 0, (int)0xFFFFFFFF, "Leader"  },
+			{ 1, 1, kOfficerPerms,   "Officer" },
+			{ 2, 2, 0x00000000,      "Member"  },
+		};
+		sqlite3_stmt* stmt = nullptr;
+		if (sqlite3_prepare_v2(db,
+				"INSERT INTO ga_agency_ranks "
+				"(agency_id, rank_id, rank_level, permissions, rank_name) "
+				"VALUES (?, ?, ?, ?, ?)",
+				-1, &stmt, nullptr) != SQLITE_OK || !stmt) {
+			ok = false;
+		} else {
+			for (const auto& rk : kRanks) {
+				sqlite3_reset(stmt);
+				sqlite3_bind_int64(stmt, 1, agency_id);
+				sqlite3_bind_int(stmt, 2, rk.id);
+				sqlite3_bind_int(stmt, 3, rk.level);
+				sqlite3_bind_int(stmt, 4, rk.perms);
+				sqlite3_bind_text(stmt, 5, rk.nm, -1, SQLITE_STATIC);
+				if (sqlite3_step(stmt) != SQLITE_DONE) { ok = false; break; }
+			}
+			sqlite3_finalize(stmt);
+		}
+	}
+
+	// Add the creator as a member at the leader rank (rank_id 0).
+	if (ok) {
+		sqlite3_stmt* stmt = nullptr;
+		if (sqlite3_prepare_v2(db,
+				"INSERT INTO ga_agency_members "
+				"(user_id, agency_id, character_id, player_name, rank_id, joined_at) "
+				"VALUES (?, ?, ?, ?, 0, strftime('%s','now'))",
+				-1, &stmt, nullptr) != SQLITE_OK || !stmt) {
+			ok = false;
+		} else {
+			sqlite3_bind_int64(stmt, 1, leader_user_id);
+			sqlite3_bind_int64(stmt, 2, agency_id);
+			sqlite3_bind_int64(stmt, 3, leader_character_id);
+			sqlite3_bind_text(stmt, 4, leader_name.c_str(), -1, SQLITE_TRANSIENT);
+			if (sqlite3_step(stmt) != SQLITE_DONE) ok = false;
+			sqlite3_finalize(stmt);
+		}
+	}
+
+	if (ok) {
+		sqlite3_exec(db, "COMMIT", nullptr, nullptr, nullptr);
+		Logger::Log("agency", "[DB] CreateAgency '%s' id=%lld leader=%lld\n",
+			name.c_str(), (long long)agency_id, (long long)leader_user_id);
+		return agency_id;
+	}
+	sqlite3_exec(db, "ROLLBACK", nullptr, nullptr, nullptr);
+	Logger::Log("agency", "[DB] CreateAgency '%s' failed (name taken?)\n", name.c_str());
+	return 0;
+}
+
+std::optional<Database::AgencyInfo> Database::GetAgencyInfo(int64_t agency_id) {
+	if (agency_id <= 0) return std::nullopt;
+	sqlite3* db = GetConnection();
+
+	AgencyInfo info;
+	{
+		sqlite3_stmt* stmt = nullptr;
+		if (sqlite3_prepare_v2(db,
+				"SELECT id, name, motd, information, color_r, color_g, color_b, "
+				"       recruiting, recruiting_text, sub_only, leader_user_id "
+				"FROM ga_agencies WHERE id = ? LIMIT 1",
+				-1, &stmt, nullptr) != SQLITE_OK || !stmt) {
+			return std::nullopt;
+		}
+		sqlite3_bind_int64(stmt, 1, agency_id);
+		if (sqlite3_step(stmt) != SQLITE_ROW) {
+			sqlite3_finalize(stmt);
+			return std::nullopt;
+		}
+		auto col_text = [&](int c) {
+			const unsigned char* t = sqlite3_column_text(stmt, c);
+			return t ? std::string(reinterpret_cast<const char*>(t)) : std::string();
+		};
+		info.id             = sqlite3_column_int64(stmt, 0);
+		info.name           = col_text(1);
+		info.motd           = col_text(2);
+		info.information    = col_text(3);
+		info.color_r        = (float)sqlite3_column_double(stmt, 4);
+		info.color_g        = (float)sqlite3_column_double(stmt, 5);
+		info.color_b        = (float)sqlite3_column_double(stmt, 6);
+		info.recruiting     = sqlite3_column_int(stmt, 7) != 0;
+		info.recruiting_text= col_text(8);
+		info.sub_only       = sqlite3_column_int(stmt, 9) != 0;
+		info.leader_user_id = sqlite3_column_int64(stmt, 10);
+		sqlite3_finalize(stmt);
+	}
+
+	{
+		sqlite3_stmt* stmt = nullptr;
+		if (sqlite3_prepare_v2(db,
+				"SELECT rank_id, rank_level, permissions, rank_name "
+				"FROM ga_agency_ranks WHERE agency_id = ? ORDER BY rank_level ASC",
+				-1, &stmt, nullptr) == SQLITE_OK && stmt) {
+			sqlite3_bind_int64(stmt, 1, agency_id);
+			while (sqlite3_step(stmt) == SQLITE_ROW) {
+				AgencyRankRow rk;
+				rk.rank_id     = sqlite3_column_int(stmt, 0);
+				rk.rank_level  = sqlite3_column_int(stmt, 1);
+				rk.permissions = sqlite3_column_int(stmt, 2);
+				const unsigned char* nm = sqlite3_column_text(stmt, 3);
+				rk.rank_name   = nm ? reinterpret_cast<const char*>(nm) : "";
+				info.ranks.push_back(std::move(rk));
+			}
+			sqlite3_finalize(stmt);
+		}
+	}
+
+	{
+		sqlite3_stmt* stmt = nullptr;
+		// profile_id is joined in rather than looked up per member — the roster
+		// is polled every 2s per client, so a per-member query would be O(N)
+		// round trips per poll.
+		if (sqlite3_prepare_v2(db,
+				"SELECT m.user_id, m.character_id, m.player_name, m.rank_id, "
+				"       m.public_comment, m.officer_comment, COALESCE(c.profile_id, 0) "
+				"FROM ga_agency_members m "
+				"LEFT JOIN ga_characters c ON c.id = m.character_id "
+				"WHERE m.agency_id = ?",
+				-1, &stmt, nullptr) == SQLITE_OK && stmt) {
+			sqlite3_bind_int64(stmt, 1, agency_id);
+			while (sqlite3_step(stmt) == SQLITE_ROW) {
+				AgencyMemberRow m;
+				m.user_id      = sqlite3_column_int64(stmt, 0);
+				m.character_id = sqlite3_column_int64(stmt, 1);
+				const unsigned char* nm = sqlite3_column_text(stmt, 2);
+				m.player_name  = nm ? reinterpret_cast<const char*>(nm) : "";
+				m.rank_id      = sqlite3_column_int(stmt, 3);
+				const unsigned char* pc = sqlite3_column_text(stmt, 4);
+				m.public_comment  = pc ? reinterpret_cast<const char*>(pc) : "";
+				const unsigned char* oc = sqlite3_column_text(stmt, 5);
+				m.officer_comment = oc ? reinterpret_cast<const char*>(oc) : "";
+				m.profile_id      = (uint32_t)sqlite3_column_int(stmt, 6);
+				info.members.push_back(std::move(m));
+			}
+			sqlite3_finalize(stmt);
+		}
+	}
+
+	return info;
+}
+
+bool Database::AddAgencyMember(int64_t agency_id, int64_t user_id,
+                               int64_t character_id,
+                               const std::string& player_name,
+                               int rank_id) {
+	if (agency_id <= 0 || user_id <= 0) return false;
+	if (GetAgencyIdForUser(user_id) != 0) {
+		Logger::Log("agency", "[DB] AddAgencyMember: user %lld already in an agency\n",
+			(long long)user_id);
+		return false;
+	}
+	sqlite3* db = GetConnection();
+	sqlite3_stmt* stmt = nullptr;
+	if (sqlite3_prepare_v2(db,
+			"INSERT INTO ga_agency_members "
+			"(user_id, agency_id, character_id, player_name, rank_id, joined_at) "
+			"VALUES (?, ?, ?, ?, ?, strftime('%s','now'))",
+			-1, &stmt, nullptr) != SQLITE_OK || !stmt) {
+		return false;
+	}
+	sqlite3_bind_int64(stmt, 1, user_id);
+	sqlite3_bind_int64(stmt, 2, agency_id);
+	sqlite3_bind_int64(stmt, 3, character_id);
+	sqlite3_bind_text(stmt, 4, player_name.c_str(), -1, SQLITE_TRANSIENT);
+	sqlite3_bind_int(stmt, 5, rank_id);
+	const bool ok = (sqlite3_step(stmt) == SQLITE_DONE);
+	sqlite3_finalize(stmt);
+	Logger::Log("agency", "[DB] AddAgencyMember agency=%lld user=%lld '%s' rank=%d ok=%d\n",
+		(long long)agency_id, (long long)user_id, player_name.c_str(), rank_id, (int)ok);
+	return ok;
+}
+
+bool Database::SetAgencyMemberRank(int64_t agency_id, int64_t character_id,
+                                   int rank_id) {
+	if (agency_id <= 0 || character_id <= 0) return false;
+	sqlite3* db = GetConnection();
+	sqlite3_stmt* stmt = nullptr;
+	if (sqlite3_prepare_v2(db,
+			"UPDATE ga_agency_members SET rank_id = ? "
+			"WHERE agency_id = ? AND character_id = ?",
+			-1, &stmt, nullptr) != SQLITE_OK || !stmt) {
+		return false;
+	}
+	sqlite3_bind_int(stmt, 1, rank_id);
+	sqlite3_bind_int64(stmt, 2, agency_id);
+	sqlite3_bind_int64(stmt, 3, character_id);
+	sqlite3_step(stmt);
+	sqlite3_finalize(stmt);
+	const bool ok = sqlite3_changes(db) > 0;
+	Logger::Log("agency", "[DB] SetAgencyMemberRank agency=%lld char=%lld rank=%d ok=%d\n",
+		(long long)agency_id, (long long)character_id, rank_id, (int)ok);
+	return ok;
+}
+
+bool Database::RemoveAgencyMember(int64_t agency_id, int64_t character_id) {
+	if (agency_id <= 0 || character_id <= 0) return false;
+	sqlite3* db = GetConnection();
+	sqlite3_stmt* stmt = nullptr;
+	if (sqlite3_prepare_v2(db,
+			"DELETE FROM ga_agency_members WHERE agency_id = ? AND character_id = ?",
+			-1, &stmt, nullptr) != SQLITE_OK || !stmt) {
+		return false;
+	}
+	sqlite3_bind_int64(stmt, 1, agency_id);
+	sqlite3_bind_int64(stmt, 2, character_id);
+	sqlite3_step(stmt);
+	sqlite3_finalize(stmt);
+	const bool ok = sqlite3_changes(db) > 0;
+	Logger::Log("agency", "[DB] RemoveAgencyMember agency=%lld char=%lld ok=%d\n",
+		(long long)agency_id, (long long)character_id, (int)ok);
+	return ok;
+}
+
+void Database::DisbandAgency(int64_t agency_id) {
+	if (agency_id <= 0) return;
+	sqlite3* db = GetConnection();
+	int64_t owned_alliance = 0;
+	{
+		sqlite3_stmt* st = nullptr;
+		if (sqlite3_prepare_v2(db, "SELECT id FROM ga_alliances WHERE owner_agency_id = ? LIMIT 1",
+				-1, &st, nullptr) == SQLITE_OK && st) {
+			sqlite3_bind_int64(st, 1, agency_id);
+			if (sqlite3_step(st) == SQLITE_ROW) owned_alliance = sqlite3_column_int64(st, 0);
+			sqlite3_finalize(st);
+		}
+	}
+	auto exec_bind = [&](const char* sql, int64_t v) {
+		sqlite3_stmt* st = nullptr;
+		if (sqlite3_prepare_v2(db, sql, -1, &st, nullptr) == SQLITE_OK && st) {
+			sqlite3_bind_int64(st, 1, v);
+			sqlite3_step(st);
+			sqlite3_finalize(st);
+		}
+	};
+	exec_bind("DELETE FROM ga_agency_members WHERE agency_id = ?", agency_id);
+	exec_bind("DELETE FROM ga_agency_ranks   WHERE agency_id = ?", agency_id);
+	exec_bind("DELETE FROM ga_alliance_members WHERE agency_id = ?", agency_id);
+	exec_bind("DELETE FROM ga_agencies WHERE id = ?", agency_id);
+	if (owned_alliance != 0) {
+		exec_bind("DELETE FROM ga_alliance_members WHERE alliance_id = ?", owned_alliance);
+		exec_bind("DELETE FROM ga_alliances WHERE id = ?", owned_alliance);
+	}
+	Logger::Log("agency", "[DB] DisbandAgency id=%lld (owned_alliance=%lld)\n",
+		(long long)agency_id, (long long)owned_alliance);
+}
+
+// ---- Alliances (design 2026-07-18) -----------------------------------------
+
+int64_t Database::GetAllianceIdForAgency(int64_t agency_id) {
+	if (agency_id <= 0) return 0;
+	sqlite3* db = GetConnection();
+	sqlite3_stmt* stmt = nullptr;
+	if (sqlite3_prepare_v2(db,
+			"SELECT alliance_id FROM ga_alliance_members WHERE agency_id = ? LIMIT 1",
+			-1, &stmt, nullptr) != SQLITE_OK || !stmt) {
+		return 0;
+	}
+	sqlite3_bind_int64(stmt, 1, agency_id);
+	int64_t id = 0;
+	if (sqlite3_step(stmt) == SQLITE_ROW) id = sqlite3_column_int64(stmt, 0);
+	sqlite3_finalize(stmt);
+	return id;
+}
+
+bool Database::AddAgencyToAlliance(int64_t alliance_id, int64_t agency_id) {
+	if (alliance_id <= 0 || agency_id <= 0) return false;
+	if (GetAllianceIdForAgency(agency_id) != 0) return false;  // one alliance per agency
+	sqlite3* db = GetConnection();
+	sqlite3_stmt* stmt = nullptr;
+	if (sqlite3_prepare_v2(db,
+			"INSERT INTO ga_alliance_members (agency_id, alliance_id, joined_at) "
+			"VALUES (?, ?, strftime('%s','now'))",
+			-1, &stmt, nullptr) != SQLITE_OK || !stmt) {
+		return false;
+	}
+	sqlite3_bind_int64(stmt, 1, agency_id);
+	sqlite3_bind_int64(stmt, 2, alliance_id);
+	bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+	sqlite3_finalize(stmt);
+	return ok;
+}
+
+int64_t Database::CreateAlliance(const std::string& name, int64_t owner_agency_id) {
+	if (name.empty() || owner_agency_id <= 0) return 0;
+	if (GetAllianceIdForAgency(owner_agency_id) != 0) {
+		Logger::Log("agency", "[DB] CreateAlliance: agency %lld already in an alliance\n",
+			(long long)owner_agency_id);
+		return 0;
+	}
+
+	sqlite3* db = GetConnection();
+	char* err = nullptr;
+	if (sqlite3_exec(db, "BEGIN IMMEDIATE", nullptr, nullptr, &err) != SQLITE_OK) {
+		if (err) sqlite3_free(err);
+		return 0;
+	}
+
+	int64_t alliance_id = 0;
+	bool ok = true;
+	{
+		sqlite3_stmt* stmt = nullptr;
+		if (sqlite3_prepare_v2(db,
+				"INSERT INTO ga_alliances (name, owner_agency_id, created_at) "
+				"VALUES (?, ?, strftime('%s','now'))",
+				-1, &stmt, nullptr) != SQLITE_OK || !stmt) {
+			ok = false;
+		} else {
+			sqlite3_bind_text(stmt, 1, name.c_str(), -1, SQLITE_TRANSIENT);
+			sqlite3_bind_int64(stmt, 2, owner_agency_id);
+			if (sqlite3_step(stmt) != SQLITE_DONE) ok = false;  // name UNIQUE
+			sqlite3_finalize(stmt);
+		}
+		if (ok) alliance_id = sqlite3_last_insert_rowid(db);
+	}
+	if (ok) {
+		sqlite3_stmt* stmt = nullptr;
+		if (sqlite3_prepare_v2(db,
+				"INSERT INTO ga_alliance_members (agency_id, alliance_id, joined_at) "
+				"VALUES (?, ?, strftime('%s','now'))",
+				-1, &stmt, nullptr) != SQLITE_OK || !stmt) {
+			ok = false;
+		} else {
+			sqlite3_bind_int64(stmt, 1, owner_agency_id);
+			sqlite3_bind_int64(stmt, 2, alliance_id);
+			if (sqlite3_step(stmt) != SQLITE_DONE) ok = false;
+			sqlite3_finalize(stmt);
+		}
+	}
+
+	if (ok) {
+		sqlite3_exec(db, "COMMIT", nullptr, nullptr, nullptr);
+		Logger::Log("agency", "[DB] CreateAlliance '%s' id=%lld owner_agency=%lld\n",
+			name.c_str(), (long long)alliance_id, (long long)owner_agency_id);
+		return alliance_id;
+	}
+	sqlite3_exec(db, "ROLLBACK", nullptr, nullptr, nullptr);
+	Logger::Log("agency", "[DB] CreateAlliance '%s' failed (name taken?)\n", name.c_str());
+	return 0;
+}
+
+std::optional<Database::AllianceInfo> Database::GetAllianceInfo(int64_t alliance_id) {
+	if (alliance_id <= 0) return std::nullopt;
+	sqlite3* db = GetConnection();
+
+	AllianceInfo info;
+	{
+		sqlite3_stmt* stmt = nullptr;
+		if (sqlite3_prepare_v2(db,
+				"SELECT al.id, al.name, al.motd, al.information, al.owner_agency_id, "
+				"       COALESCE(ag.name,''), al.created_at "
+				"FROM ga_alliances al "
+				"LEFT JOIN ga_agencies ag ON ag.id = al.owner_agency_id "
+				"WHERE al.id = ? LIMIT 1",
+				-1, &stmt, nullptr) != SQLITE_OK || !stmt) {
+			return std::nullopt;
+		}
+		sqlite3_bind_int64(stmt, 1, alliance_id);
+		if (sqlite3_step(stmt) != SQLITE_ROW) {
+			sqlite3_finalize(stmt);
+			return std::nullopt;
+		}
+		auto txt = [&](int c) {
+			const unsigned char* t = sqlite3_column_text(stmt, c);
+			return t ? std::string(reinterpret_cast<const char*>(t)) : std::string();
+		};
+		info.id                = sqlite3_column_int64(stmt, 0);
+		info.name              = txt(1);
+		info.motd              = txt(2);
+		info.information       = txt(3);
+		info.owner_agency_id   = sqlite3_column_int64(stmt, 4);
+		info.owner_agency_name = txt(5);
+		info.created_at        = sqlite3_column_int64(stmt, 6);
+		sqlite3_finalize(stmt);
+	}
+
+	{
+		sqlite3_stmt* stmt = nullptr;
+		if (sqlite3_prepare_v2(db,
+				"SELECT ag.id, ag.name, "
+				"       (SELECT COUNT(*) FROM ga_agency_members m WHERE m.agency_id = ag.id) "
+				"FROM ga_alliance_members am "
+				"JOIN ga_agencies ag ON ag.id = am.agency_id "
+				"WHERE am.alliance_id = ?",
+				-1, &stmt, nullptr) == SQLITE_OK && stmt) {
+			sqlite3_bind_int64(stmt, 1, alliance_id);
+			while (sqlite3_step(stmt) == SQLITE_ROW) {
+				AllianceMemberRow m;
+				m.agency_id    = sqlite3_column_int64(stmt, 0);
+				const unsigned char* nm = sqlite3_column_text(stmt, 1);
+				m.agency_name  = nm ? reinterpret_cast<const char*>(nm) : "";
+				m.member_count = sqlite3_column_int(stmt, 2);
+				info.members.push_back(std::move(m));
+			}
+			sqlite3_finalize(stmt);
+		}
+	}
+
+	return info;
+}
+
+void Database::DisbandAlliance(int64_t alliance_id) {
+	if (alliance_id <= 0) return;
+	sqlite3* db = GetConnection();
+	auto exec_bind = [&](const char* sql, int64_t v) {
+		sqlite3_stmt* st = nullptr;
+		if (sqlite3_prepare_v2(db, sql, -1, &st, nullptr) == SQLITE_OK && st) {
+			sqlite3_bind_int64(st, 1, v);
+			sqlite3_step(st);
+			sqlite3_finalize(st);
+		}
+	};
+	exec_bind("DELETE FROM ga_alliance_members WHERE alliance_id = ?", alliance_id);
+	exec_bind("DELETE FROM ga_alliances WHERE id = ?", alliance_id);
+	Logger::Log("agency", "[DB] DisbandAlliance id=%lld\n", (long long)alliance_id);
+}
+
+bool Database::SetAgencyText(int64_t agency_id, bool is_motd,
+                             const std::string& text) {
+	if (agency_id <= 0) return false;
+	sqlite3* db = GetConnection();
+	sqlite3_stmt* stmt = nullptr;
+	const char* sql = is_motd ? "UPDATE ga_agencies SET motd = ? WHERE id = ?"
+	                          : "UPDATE ga_agencies SET information = ? WHERE id = ?";
+	if (sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr) != SQLITE_OK || !stmt) return false;
+	sqlite3_bind_text(stmt, 1, text.c_str(), -1, SQLITE_TRANSIENT);
+	sqlite3_bind_int64(stmt, 2, agency_id);
+	sqlite3_step(stmt);
+	sqlite3_finalize(stmt);
+	const bool ok = sqlite3_changes(db) > 0;
+	Logger::Log("agency", "[DB] SetAgencyText agency=%lld motd=%d len=%d ok=%d\n",
+		(long long)agency_id, (int)is_motd, (int)text.size(), (int)ok);
+	return ok;
+}
+
+bool Database::SetAgencyMemberComment(int64_t agency_id, int64_t character_id,
+                                      bool officer, const std::string& text) {
+	if (agency_id <= 0 || character_id <= 0) return false;
+	sqlite3* db = GetConnection();
+	sqlite3_stmt* stmt = nullptr;
+	const char* sql = officer
+		? "UPDATE ga_agency_members SET officer_comment = ? "
+		  "WHERE agency_id = ? AND character_id = ?"
+		: "UPDATE ga_agency_members SET public_comment = ? "
+		  "WHERE agency_id = ? AND character_id = ?";
+	if (sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr) != SQLITE_OK || !stmt) return false;
+	sqlite3_bind_text(stmt, 1, text.c_str(), -1, SQLITE_TRANSIENT);
+	sqlite3_bind_int64(stmt, 2, agency_id);
+	sqlite3_bind_int64(stmt, 3, character_id);
+	sqlite3_step(stmt);
+	sqlite3_finalize(stmt);
+	const bool ok = sqlite3_changes(db) > 0;
+	Logger::Log("agency", "[DB] SetAgencyMemberComment agency=%lld char=%lld officer=%d ok=%d\n",
+		(long long)agency_id, (long long)character_id, (int)officer, (int)ok);
+	return ok;
+}
+
+bool Database::ReplaceAgencyRanks(int64_t agency_id,
+                                  const std::vector<AgencyRankRow>& ranks) {
+	if (agency_id <= 0 || ranks.empty()) return false;
+	// The client identifies the leader by rank_level 0 — refuse a set that
+	// would leave the agency without one.
+	bool has_leader_rank = false;
+	for (const auto& rk : ranks) if (rk.rank_level == 0) has_leader_rank = true;
+	if (!has_leader_rank) {
+		Logger::Log("agency", "[DB] ReplaceAgencyRanks: rejected, no rank_level 0 row\n");
+		return false;
+	}
+
+	sqlite3* db = GetConnection();
+	if (sqlite3_exec(db, "BEGIN IMMEDIATE", nullptr, nullptr, nullptr) != SQLITE_OK) return false;
+
+	bool ok = true;
+	{
+		sqlite3_stmt* st = nullptr;
+		if (sqlite3_prepare_v2(db, "DELETE FROM ga_agency_ranks WHERE agency_id = ?",
+				-1, &st, nullptr) == SQLITE_OK && st) {
+			sqlite3_bind_int64(st, 1, agency_id);
+			if (sqlite3_step(st) != SQLITE_DONE) ok = false;
+			sqlite3_finalize(st);
+		} else {
+			ok = false;
+		}
+	}
+	if (ok) {
+		sqlite3_stmt* st = nullptr;
+		if (sqlite3_prepare_v2(db,
+				"INSERT INTO ga_agency_ranks "
+				"(agency_id, rank_id, rank_level, permissions, rank_name) "
+				"VALUES (?, ?, ?, ?, ?)",
+				-1, &st, nullptr) == SQLITE_OK && st) {
+			for (const auto& rk : ranks) {
+				sqlite3_reset(st);
+				sqlite3_bind_int64(st, 1, agency_id);
+				sqlite3_bind_int(st, 2, rk.rank_id);
+				sqlite3_bind_int(st, 3, rk.rank_level);
+				sqlite3_bind_int(st, 4, rk.permissions);
+				sqlite3_bind_text(st, 5, rk.rank_name.c_str(), -1, SQLITE_TRANSIENT);
+				if (sqlite3_step(st) != SQLITE_DONE) { ok = false; break; }
+			}
+			sqlite3_finalize(st);
+		} else {
+			ok = false;
+		}
+	}
+	// Anyone on a rank that no longer exists lands on the bottom rank.
+	if (ok) {
+		int bottom_rank = ranks.front().rank_id;
+		int bottom_level = ranks.front().rank_level;
+		for (const auto& rk : ranks) {
+			if (rk.rank_level > bottom_level) { bottom_level = rk.rank_level; bottom_rank = rk.rank_id; }
+		}
+		sqlite3_stmt* st = nullptr;
+		if (sqlite3_prepare_v2(db,
+				"UPDATE ga_agency_members SET rank_id = ? WHERE agency_id = ? AND rank_id NOT IN "
+				"(SELECT rank_id FROM ga_agency_ranks WHERE agency_id = ?)",
+				-1, &st, nullptr) == SQLITE_OK && st) {
+			sqlite3_bind_int(st, 1, bottom_rank);
+			sqlite3_bind_int64(st, 2, agency_id);
+			sqlite3_bind_int64(st, 3, agency_id);
+			sqlite3_step(st);
+			sqlite3_finalize(st);
+		}
+	}
+
+	sqlite3_exec(db, ok ? "COMMIT" : "ROLLBACK", nullptr, nullptr, nullptr);
+	Logger::Log("agency", "[DB] ReplaceAgencyRanks agency=%lld rows=%d ok=%d\n",
+		(long long)agency_id, (int)ranks.size(), (int)ok);
+	return ok;
+}
+
+std::map<int64_t, std::string> Database::GetOnlineAgencyMemberMaps(int64_t agency_id) {
+	std::map<int64_t, std::string> out;
+	if (agency_id <= 0) return out;
+	sqlite3_stmt* stmt = nullptr;
+	if (sqlite3_prepare_v2(GetConnection(),
+			"SELECT ip.character_id, i.map_name "
+			"FROM ga_instance_players ip "
+			"JOIN ga_instances i ON i.instance_id = ip.instance_id AND i.state != 'STOPPED' "
+			"JOIN ga_agency_members m ON m.character_id = ip.character_id "
+			"WHERE m.agency_id = ? AND ip.left_at IS NULL",
+			-1, &stmt, nullptr) != SQLITE_OK || !stmt) {
+		return out;
+	}
+	sqlite3_bind_int64(stmt, 1, agency_id);
+	while (sqlite3_step(stmt) == SQLITE_ROW) {
+		const unsigned char* mp = sqlite3_column_text(stmt, 1);
+		out[sqlite3_column_int64(stmt, 0)] = mp ? reinterpret_cast<const char*>(mp) : "";
+	}
+	sqlite3_finalize(stmt);
+	return out;
+}
+
+bool Database::SetAgencyRecruiting(int64_t agency_id, const std::string& text,
+                                   bool recruiting, bool sub_only) {
+	if (agency_id <= 0) return false;
+	sqlite3* db = GetConnection();
+	sqlite3_stmt* stmt = nullptr;
+	if (sqlite3_prepare_v2(db,
+			"UPDATE ga_agencies SET recruiting_text = ?, recruiting = ?, sub_only = ? "
+			"WHERE id = ?",
+			-1, &stmt, nullptr) != SQLITE_OK || !stmt) {
+		return false;
+	}
+	sqlite3_bind_text(stmt, 1, text.c_str(), -1, SQLITE_TRANSIENT);
+	sqlite3_bind_int(stmt, 2, recruiting ? 1 : 0);
+	sqlite3_bind_int(stmt, 3, sub_only ? 1 : 0);
+	sqlite3_bind_int64(stmt, 4, agency_id);
+	sqlite3_step(stmt);
+	sqlite3_finalize(stmt);
+	const bool ok = sqlite3_changes(db) > 0;
+	Logger::Log("agency", "[DB] SetAgencyRecruiting agency=%lld recruiting=%d sub_only=%d ok=%d\n",
+		(long long)agency_id, (int)recruiting, (int)sub_only, (int)ok);
+	return ok;
+}
+
+bool Database::SetAgencyLeader(int64_t agency_id, int64_t user_id) {
+	if (agency_id <= 0 || user_id <= 0) return false;
+	sqlite3* db = GetConnection();
+	sqlite3_stmt* stmt = nullptr;
+	if (sqlite3_prepare_v2(db, "UPDATE ga_agencies SET leader_user_id = ? WHERE id = ?",
+			-1, &stmt, nullptr) != SQLITE_OK || !stmt) {
+		return false;
+	}
+	sqlite3_bind_int64(stmt, 1, user_id);
+	sqlite3_bind_int64(stmt, 2, agency_id);
+	sqlite3_step(stmt);
+	sqlite3_finalize(stmt);
+	const bool ok = sqlite3_changes(db) > 0;
+	Logger::Log("agency", "[DB] SetAgencyLeader agency=%lld user=%lld ok=%d\n",
+		(long long)agency_id, (long long)user_id, (int)ok);
+	return ok;
+}
+
+static std::vector<int64_t> query_user_ids(const char* sql, int64_t bind_value) {
+	std::vector<int64_t> out;
+	if (bind_value <= 0) return out;
+	sqlite3_stmt* stmt = nullptr;
+	if (sqlite3_prepare_v2(Database::GetConnection(), sql, -1, &stmt, nullptr) != SQLITE_OK
+	    || !stmt) {
+		return out;
+	}
+	sqlite3_bind_int64(stmt, 1, bind_value);
+	while (sqlite3_step(stmt) == SQLITE_ROW) out.push_back(sqlite3_column_int64(stmt, 0));
+	sqlite3_finalize(stmt);
+	return out;
+}
+
+std::vector<int64_t> Database::GetAllianceMemberUserIds(int64_t alliance_id) {
+	return query_user_ids(
+		"SELECT m.user_id FROM ga_agency_members m "
+		"JOIN ga_alliance_members am ON am.agency_id = m.agency_id "
+		"WHERE am.alliance_id = ?", alliance_id);
+}
+
+std::vector<int64_t> Database::GetAgencyMemberUserIds(int64_t agency_id) {
+	return query_user_ids("SELECT user_id FROM ga_agency_members WHERE agency_id = ?",
+	                      agency_id);
+}
+
+int64_t Database::GetAgencyIdByLeaderName(const std::string& leader_name) {
+	if (leader_name.empty()) return 0;
+	sqlite3* db = GetConnection();
+	sqlite3_stmt* stmt = nullptr;
+	if (sqlite3_prepare_v2(db,
+			"SELECT agency_id FROM ga_agency_members "
+			"WHERE rank_id = 0 AND player_name = ? LIMIT 1",
+			-1, &stmt, nullptr) != SQLITE_OK || !stmt) {
+		return 0;
+	}
+	sqlite3_bind_text(stmt, 1, leader_name.c_str(), -1, SQLITE_TRANSIENT);
+	int64_t id = 0;
+	if (sqlite3_step(stmt) == SQLITE_ROW) id = sqlite3_column_int64(stmt, 0);
+	sqlite3_finalize(stmt);
+	return id;
+}
+
+void Database::RemoveAgencyFromAlliance(int64_t agency_id) {
+	if (agency_id <= 0) return;
+	sqlite3* db = GetConnection();
+	sqlite3_stmt* st = nullptr;
+	if (sqlite3_prepare_v2(db, "DELETE FROM ga_alliance_members WHERE agency_id = ?",
+			-1, &st, nullptr) == SQLITE_OK && st) {
+		sqlite3_bind_int64(st, 1, agency_id);
+		sqlite3_step(st);
+		sqlite3_finalize(st);
+	}
+	Logger::Log("agency", "[DB] RemoveAgencyFromAlliance agency=%lld\n", (long long)agency_id);
 }

--- a/src/ControlServer/Database/Database.hpp
+++ b/src/ControlServer/Database/Database.hpp
@@ -295,4 +295,13 @@ public:
     // Agency led by the account whose leader player_name matches (rank_id 0 =
     // leader). Used to resolve ALLIANCE_INVITE (invite by leader name). 0 if none.
     static int64_t GetAgencyIdByLeaderName(const std::string& leader_name);
+
+    // character_id -> {agency name, alliance name} for every agency member.
+    // Whole table in one query — the Team window and player search need the two
+    // name columns for a list of characters at once.
+    struct AffiliationRow {
+        std::string agency_name;
+        std::string alliance_name;   // "" when the agency is in no alliance
+    };
+    static std::map<int64_t, AffiliationRow> GetAffiliationsByCharacter();
 };

--- a/src/ControlServer/Database/Database.hpp
+++ b/src/ControlServer/Database/Database.hpp
@@ -135,4 +135,164 @@ public:
     static void SetInstanceDeathCounts(int64_t instance_id,
                                        int count_deaths_attackers,
                                        int count_deaths_defenders);
+
+    // ---- Agencies (design 2026-07-18) --------------------------------------
+    struct AgencyMemberRow {
+        int64_t     user_id      = 0;
+        int64_t     character_id = 0;
+        std::string player_name;
+        int         rank_id      = 0;
+        std::string public_comment;
+        std::string officer_comment;
+        uint32_t    profile_id = 0;   // ga_characters.profile_id (class), joined in
+    };
+    // PERMISSION_FLAGS (0x3B0) bits, read off single-checkbox AGENCY_UPDATE_RANKS
+    // submits from the Management tab's "Rank Abilities" panel. Bits 0-3 (0x0F)
+    // ride along on every submit but map to no visible checkbox.
+    enum AgencyPerm : uint32_t {
+        AGENCY_PERM_PROMOTE            = 0x00000040,
+        AGENCY_PERM_DEMOTE             = 0x00000080,
+        AGENCY_PERM_INVITE             = 0x00000100,
+        AGENCY_PERM_KICK               = 0x00000200,
+        AGENCY_PERM_EDIT_DESCRIPTION   = 0x00000400,
+        AGENCY_PERM_EDIT_PUBLIC_MSG    = 0x00000800,
+        AGENCY_PERM_EDIT_OFFICER_MSG   = 0x00001000,
+        AGENCY_PERM_VIEW_OFFICER_MSG   = 0x00002000,
+        AGENCY_PERM_EDIT_MOTD          = 0x00008000,
+        AGENCY_PERM_FACILITY_MGMT      = 0x00020000,
+        AGENCY_PERM_INVENTORY_REMOVAL  = 0x00040000,
+    };
+
+    struct AgencyRankRow {
+        int         rank_id     = 0;
+        int         rank_level  = 0;
+        int         permissions = 0;
+        std::string rank_name;
+    };
+    struct AgencyInfo {
+        int64_t     id = 0;
+        std::string name;
+        std::string motd;
+        std::string information;
+        float       color_r = 0, color_g = 0, color_b = 0;
+        bool        recruiting = false;
+        std::string recruiting_text;
+        bool        sub_only = false;
+        int64_t     leader_user_id = 0;
+        std::vector<AgencyMemberRow> members;
+        std::vector<AgencyRankRow>   ranks;
+    };
+
+    // Create an agency owned by leader_user_id. Seeds the 3 default ranks and
+    // adds the leader as a member at the top rank, atomically. Returns the new
+    // agency id, or 0 on failure (name already taken, or the account is already
+    // in an agency).
+    static int64_t CreateAgency(const std::string& name,
+                                float r, float g, float b,
+                                int64_t leader_user_id,
+                                int64_t leader_character_id,
+                                const std::string& leader_name);
+
+    // Agency id the account currently belongs to, or 0 if none.
+    static int64_t GetAgencyIdForUser(int64_t user_id);
+
+    // Full agency record (meta + members + ranks), or nullopt if not found.
+    static std::optional<AgencyInfo> GetAgencyInfo(int64_t agency_id);
+
+    // Delete an agency and everything attached: its members, ranks, any alliance
+    // it owns (+ that alliance's memberships), and its own alliance membership.
+    static void DisbandAgency(int64_t agency_id);
+
+    // Add an account to an agency (invite-accept). rank_id 2 = default Member.
+    // Returns false if the account is already in an agency or the insert failed.
+    static bool AddAgencyMember(int64_t agency_id, int64_t user_id,
+                                int64_t character_id,
+                                const std::string& player_name,
+                                int rank_id);
+
+    // Change a member's rank (promote / demote). Member keyed by character_id —
+    // that's what the client sends back as PLAYER_ID. False if no such member.
+    static bool SetAgencyMemberRank(int64_t agency_id, int64_t character_id,
+                                    int rank_id);
+
+    // Drop a member from an agency (kick / leave). Keyed by character_id.
+    static bool RemoveAgencyMember(int64_t agency_id, int64_t character_id);
+
+    // ---- Alliances (groups of agencies) ------------------------------------
+    struct AllianceMemberRow {
+        int64_t     agency_id       = 0;
+        std::string agency_name;
+        int         member_count    = 0;  // agents in that agency
+        int         territory_count = 0;
+    };
+    struct AllianceInfo {
+        int64_t     id = 0;
+        std::string name;
+        std::string motd;
+        std::string information;
+        int64_t     owner_agency_id = 0;
+        std::string owner_agency_name;
+        int64_t     created_at = 0;   // unix seconds
+        std::vector<AllianceMemberRow> members;
+    };
+
+    // Alliance id the agency currently belongs to, or 0 if none.
+    static int64_t GetAllianceIdForAgency(int64_t agency_id);
+
+    // Create an alliance owned by owner_agency_id and add it as the first
+    // member, atomically. Returns the new alliance id, or 0 on failure (name
+    // taken, or the agency is already in an alliance).
+    static int64_t CreateAlliance(const std::string& name, int64_t owner_agency_id);
+
+    // Add an agency to an alliance (invite-accept / join). Returns false if the
+    // agency is already in an alliance or the insert failed.
+    static bool AddAgencyToAlliance(int64_t alliance_id, int64_t agency_id);
+
+    // Full alliance record (meta + member agencies), or nullopt if not found.
+    static std::optional<AllianceInfo> GetAllianceInfo(int64_t alliance_id);
+
+    // Delete an alliance + all its agency memberships.
+    static void DisbandAlliance(int64_t alliance_id);
+
+    // Remove one agency from its alliance (member leave / owner kick).
+    static void RemoveAgencyFromAlliance(int64_t agency_id);
+
+    // Agency MOTD (is_motd) or description/information text.
+    static bool SetAgencyText(int64_t agency_id, bool is_motd,
+                              const std::string& text);
+
+    // A member's public or officer note. Member keyed by character_id.
+    static bool SetAgencyMemberComment(int64_t agency_id, int64_t character_id,
+                                       bool officer, const std::string& text);
+
+    // Replace an agency's whole rank table (AGENCY_UPDATE_RANKS sends every row,
+    // so adds / renames / permission edits / deletes all arrive together).
+    // Members sitting on a deleted rank fall to the lowest-authority rank left.
+    static bool ReplaceAgencyRanks(int64_t agency_id,
+                                   const std::vector<AgencyRankRow>& ranks);
+
+    // Recruiting listing: text + the two flags (Recruiting Members / AvA Only).
+    static bool SetAgencyRecruiting(int64_t agency_id, const std::string& text,
+                                    bool recruiting, bool sub_only);
+
+    // Hand the agency to another account (Transfer Leader). Rank rows are moved
+    // by the caller; this only updates ga_agencies.leader_user_id.
+    static bool SetAgencyLeader(int64_t agency_id, int64_t user_id);
+
+    // character_id -> map name, for the agency's members currently in a running
+    // instance. One query per roster poll; deliberately narrower than
+    // InstanceRegistry::GetActiveSearchablePlayers (which joins users/players
+    // for the name columns the roster already has).
+    static std::map<int64_t, std::string> GetOnlineAgencyMemberMaps(int64_t agency_id);
+
+    // Every account in every agency of an alliance. Used to push alliance-state
+    // changes to the players affected, so their panels don't need a relog.
+    static std::vector<int64_t> GetAllianceMemberUserIds(int64_t alliance_id);
+
+    // Every account in one agency.
+    static std::vector<int64_t> GetAgencyMemberUserIds(int64_t agency_id);
+
+    // Agency led by the account whose leader player_name matches (rank_id 0 =
+    // leader). Used to resolve ALLIANCE_INVITE (invite by leader name). 0 if none.
+    static int64_t GetAgencyIdByLeaderName(const std::string& leader_name);
 };

--- a/src/ControlServer/TcpSession/TcpSession.cpp
+++ b/src/ControlServer/TcpSession/TcpSession.cpp
@@ -4121,16 +4121,21 @@ void TcpSession::send_query_players_response(const PacketView& pkt)
 	constexpr size_t   kMaxRows = 50;
 
 	const auto players = InstanceRegistry::GetActiveSearchablePlayers();
+	const auto affiliations = Database::GetAffiliationsByCharacter();
 
 	std::vector<uint8_t> rows;
 	size_t row_count = 0;
 	for (const auto& p : players) {
 		if (row_count >= kMaxRows) break;
 		const bool teamed = TeamService::IsTeamed(p.session_guid);
+		Database::AffiliationRow aff;
+		if (auto a = affiliations.find(p.character_id); a != affiliations.end())
+			aff = a->second;
 		if (name_filter && !contains_ci(p.player_name, *name_filter)) continue;
-		// No agency/alliance system yet — a non-empty filter matches nobody.
-		if (agency_filter && !agency_filter->empty()) continue;
-		if (alliance_filter && !alliance_filter->empty()) continue;
+		if (agency_filter && !agency_filter->empty() &&
+			!contains_ci(aff.agency_name, *agency_filter)) continue;
+		if (alliance_filter && !alliance_filter->empty() &&
+			!contains_ci(aff.alliance_name, *alliance_filter)) continue;
 		if (level_min && kLevel < *level_min) continue;
 		if (level_max && kLevel > *level_max) continue;
 		if (profile_filter && p.profile_id != *profile_filter) continue;
@@ -4144,8 +4149,8 @@ void TcpSession::send_query_players_response(const PacketView& pkt)
 		append(rows, 0x0A, 0x00);  // 10 fields per row
 		Write4B(rows, GA_T::PLAYER_ID, (uint32_t)p.character_id);
 		WriteString(rows, GA_T::PLAYER_NAME, p.player_name);
-		WriteString(rows, GA_T::AGENCY_NAME, "");
-		WriteString(rows, GA_T::ALLIANCE_NAME, "");
+		WriteString(rows, GA_T::AGENCY_NAME, aff.agency_name);
+		WriteString(rows, GA_T::ALLIANCE_NAME, aff.alliance_name);
 		Write4B(rows, GA_T::LEVEL, kLevel);
 		Write4B(rows, GA_T::PROFILE_ID, p.profile_id);
 		Write4B(rows, GA_T::MAP_NAME_MSG_ID, map_msg_id);

--- a/src/ControlServer/TcpSession/TcpSession.cpp
+++ b/src/ControlServer/TcpSession/TcpSession.cpp
@@ -29,6 +29,10 @@
 
 std::mutex TcpSession::sessions_mutex_;
 std::map<std::string, std::weak_ptr<TcpSession>> TcpSession::g_sessions_;
+std::mutex TcpSession::pending_alliance_mutex_;
+std::map<int64_t, int64_t> TcpSession::pending_alliance_invites_;
+std::mutex TcpSession::pending_agency_mutex_;
+std::map<int64_t, int64_t> TcpSession::pending_agency_invites_;
 std::function<void()> TcpSession::on_need_home_map_;
 std::string TcpSession::s_host_ = "127.0.0.1";
 uint16_t    TcpSession::s_chat_port_ = 9001;
@@ -1785,6 +1789,122 @@ void TcpSession::handle_packet(const uint8_t* data, size_t length) {
 			Logger::Log("tcp", "[%s] Received: AGENCY_GET_ROSTER [0x%04X], item count: %d\n", Logger::GetTime(), packet_type, item_count);
 			send_agency_get_roster_response();
 			break;
+		case GA_U::AGENCY_CREATE: {
+			Logger::Log("tcp", "[%s] Received: AGENCY_CREATE [0x%04X], item count: %d\n", Logger::GetTime(), packet_type, item_count);
+			PacketView pkt(data + 6, length - 6);
+			handle_agency_create(pkt);
+			break;
+		}
+		// Solo leader disband: "remove" on the last member confirms as a disband.
+		// The client may send DISBAND, LEAVE, or a self-targeted REMOVE — all mean
+		// "delete my agency" for a solo leader, so route them together.
+		case GA_U::AGENCY_DISBAND:
+		case GA_U::AGENCY_LEAVE:
+		case GA_U::AGENCY_REMOVE:
+		case GA_U::AGENCY_PLAYER_REMOVE: {
+			Logger::Log("tcp", "[%s] Received: AGENCY disband/leave/remove [0x%04X], item count: %d\n", Logger::GetTime(), packet_type, item_count);
+			PacketView pkt(data + 6, length - 6);
+			// A PLAYER_ID that isn't mine = kicking that member; anything else
+			// (no target, or myself) is the leave/disband path.
+			const int64_t target = (int64_t)pkt.Read4B(GA_T::PLAYER_ID).value_or(0);
+			if (target != 0 && target != selected_character_id_) {
+				handle_agency_kick(target);
+				break;
+			}
+			handle_agency_disband();
+			break;
+		}
+		case GA_U::AGENCY_SET_NOTE: {
+			Logger::Log("tcp", "[%s] Received: AGENCY_SET_NOTE [0x%04X], item count: %d\n", Logger::GetTime(), packet_type, item_count);
+			PacketView pkt(data + 6, length - 6);
+			handle_agency_set_note(pkt);
+			break;
+		}
+		case GA_U::AGENCY_UPDATE_RECRUITING: {
+			Logger::Log("tcp", "[%s] Received: AGENCY_UPDATE_RECRUITING [0x%04X], item count: %d\n", Logger::GetTime(), packet_type, item_count);
+			PacketView pkt(data + 6, length - 6);
+			handle_agency_update_recruiting(pkt);
+			break;
+		}
+		case GA_U::AGENCY_SET_OWNER: {
+			Logger::Log("tcp", "[%s] Received: AGENCY_SET_OWNER [0x%04X], item count: %d\n", Logger::GetTime(), packet_type, item_count);
+			PacketView pkt(data + 6, length - 6);
+			handle_agency_set_owner(pkt);
+			break;
+		}
+		case GA_U::AGENCY_UPDATE_RANKS: {
+			Logger::Log("tcp", "[%s] Received: AGENCY_UPDATE_RANKS [0x%04X], item count: %d\n", Logger::GetTime(), packet_type, item_count);
+			PacketView pkt(data + 6, length - 6);
+			handle_agency_update_ranks(pkt);
+			break;
+		}
+		case GA_U::AGENCY_PROMOTE:
+		case GA_U::AGENCY_DEMOTE: {
+			Logger::Log("tcp", "[%s] Received: AGENCY_PROMOTE/DEMOTE [0x%04X], item count: %d\n", Logger::GetTime(), packet_type, item_count);
+			PacketView pkt(data + 6, length - 6);
+			handle_agency_rank_change(pkt, packet_type == GA_U::AGENCY_PROMOTE);
+			break;
+		}
+		case GA_U::AGENCY_INVITE: {
+			Logger::Log("tcp", "[%s] Received: AGENCY_INVITE [0x%04X], item count: %d\n", Logger::GetTime(), packet_type, item_count);
+			PacketView pkt(data + 6, length - 6);
+			handle_agency_invite(pkt);
+			break;
+		}
+		// UC has ONE native for both answers — ATgPlayerController::AgencyAccept(bool
+		// bAccepted) (TgPlayerController.uc) — so the accept/decline split is assumed
+		// to be 0xB7 vs 0xB8 (both opcodes exist). LogData confirms on first test; if
+		// decline arrives as 0xB7 + a flag field, gate the join on that flag here.
+		case GA_U::AGENCY_ACCEPT_INVITE:
+			Logger::Log("tcp", "[%s] Received: AGENCY_ACCEPT_INVITE [0x%04X], item count: %d\n", Logger::GetTime(), packet_type, item_count);
+			handle_agency_accept();
+			break;
+		case GA_U::AGENCY_REJECT_INVITE: {
+			Logger::Log("tcp", "[%s] Received: AGENCY_REJECT_INVITE [0x%04X]\n", Logger::GetTime(), packet_type);
+			std::lock_guard<std::mutex> lock(pending_agency_mutex_);
+			pending_agency_invites_.erase(user_id_);
+			break;
+		}
+		case GA_U::ALLIANCE_GET_MEMBER_LIST:
+			Logger::Log("tcp", "[%s] Received: ALLIANCE_GET_MEMBER_LIST [0x%04X], item count: %d\n", Logger::GetTime(), packet_type, item_count);
+			send_alliance_member_list_response();
+			break;
+		case GA_U::ALLIANCE_CREATE: {
+			Logger::Log("tcp", "[%s] Received: ALLIANCE_CREATE [0x%04X], item count: %d\n", Logger::GetTime(), packet_type, item_count);
+			PacketView pkt(data + 6, length - 6);
+			handle_alliance_create(pkt);
+			break;
+		}
+		case GA_U::ALLIANCE_DISBAND:
+			Logger::Log("tcp", "[%s] Received: ALLIANCE_DISBAND [0x%04X]\n", Logger::GetTime(), packet_type);
+			handle_alliance_disband();
+			break;
+		case GA_U::ALLIANCE_REMOVE: {
+			Logger::Log("tcp", "[%s] Received: ALLIANCE_REMOVE [0x%04X], item count: %d\n", Logger::GetTime(), packet_type, item_count);
+			PacketView pkt(data + 6, length - 6);
+			handle_alliance_remove(pkt);
+			break;
+		}
+		case GA_U::ALLIANCE_INVITE: {
+			Logger::Log("tcp", "[%s] Received: ALLIANCE_INVITE [0x%04X], item count: %d\n", Logger::GetTime(), packet_type, item_count);
+			PacketView pkt(data + 6, length - 6);
+			handle_alliance_invite(pkt);
+			break;
+		}
+		case GA_U::ALLIANCE_ACCEPT_INVITE: {
+			Logger::Log("tcp", "[%s] Received: ALLIANCE_ACCEPT_INVITE [0x%04X], item count: %d\n", Logger::GetTime(), packet_type, item_count);
+			handle_alliance_accept();
+			break;
+		}
+		case GA_U::ALLIANCE_REJECT_INVITE: {
+			Logger::Log("tcp", "[%s] Received: ALLIANCE_REJECT_INVITE [0x%04X]\n", Logger::GetTime(), packet_type);
+			int64_t my_agency = Database::GetAgencyIdForUser(user_id_);
+			if (my_agency != 0) {
+				std::lock_guard<std::mutex> lock(pending_alliance_mutex_);
+				pending_alliance_invites_.erase(my_agency);
+			}
+			break;
+		}
 		case GA_U::QUERY_PLAYERS: {
 			Logger::Log("tcp", "[%s] Received: QUERY_PLAYERS [0x%04X], item count: %d\n", Logger::GetTime(), packet_type, item_count);
 			PacketView pkt(data + 6, length - 6);
@@ -3059,18 +3179,909 @@ void TcpSession::send_player_skills_response()
 	send_response(response);
 }
 
+// Rank helpers. Ranks are ordered rank_level ASC; level 0 = Leader, who always
+// passes every permission check regardless of the stored bits.
+namespace {
+int agency_rank_level(const Database::AgencyInfo& info, int rank_id) {
+	for (const auto& rk : info.ranks) if (rk.rank_id == rank_id) return rk.rank_level;
+	return 9999;
+}
+
+const Database::AgencyMemberRow* agency_member_by_user(const Database::AgencyInfo& info,
+                                                       int64_t user_id) {
+	for (const auto& m : info.members) if (m.user_id == user_id) return &m;
+	return nullptr;
+}
+
+bool agency_has_perm(const Database::AgencyInfo& info, int64_t user_id, uint32_t bit) {
+	const auto* me = agency_member_by_user(info, user_id);
+	if (!me) return false;
+	for (const auto& rk : info.ranks) {
+		if (rk.rank_id != me->rank_id) continue;
+		return rk.rank_level == 0 || ((uint32_t)rk.permissions & bit) != 0;
+	}
+	return false;
+}
+}  // namespace
+
+// Append the caller's agency as top-level TLV fields, in the exact shape the
+// client's receive handler (TgAgencyData, reversed at client FUN_113cd3d0)
+// consumes. The gate is ROSTER_FLAGS bit0 — WITHOUT it the client leaves
+// m_bNoAgency=true and ignores the whole block. Agency/rank name is tag NAME
+// (0x370), NOT AGENCY_NAME/RANK_NAME. Returns the top-level field count (0 if
+// the caller has no agency).
+int TcpSession::append_agency_payload(std::vector<uint8_t>& response)
+{
+	int64_t agency_id = Database::GetAgencyIdForUser(user_id_);
+	if (agency_id == 0) return 0;
+
+	auto info = Database::GetAgencyInfo(agency_id);
+	if (!info) return 0;
+
+	// bit0 = "core agency data present" → clears m_bNoAgency. (bit4 = inventory.)
+	Write4B(response,     GA_T::ROSTER_FLAGS,             0x1);
+	WriteString(response, GA_T::NAME,                     info->name);        // 0x370
+	WriteString(response, GA_T::AGENCY_MOTD,              info->motd);
+	WriteString(response, GA_T::AGENCY_INFORMATION,       info->information);
+	WriteString(response, GA_T::RECRUITING_LISTING_TEXT,  info->recruiting_text);
+	// Flags are WCHAR_STR on the wire; client GetFlag reads first char (y/Y/t/T=true).
+	WriteString(response, GA_T::RECRUITING_FLAG,          info->recruiting ? "y" : "n");
+	WriteString(response, GA_T::RECRUITING_SUB_ONLY_FLAG, info->sub_only ? "y" : "n");
+	Write4B(response,     GA_T::AGENCY_ID,                (uint32_t)info->id);
+	// PLAYER_ID at top level = the local player's member id (→ m_nLocalPlayerId,
+	// drives LocalPlayerIsLeader). Must match this member's PLAYER_ID row below.
+	Write4B(response,     GA_T::PLAYER_ID,                (uint32_t)selected_character_id_);
+	Write4B(response,     GA_T::COUNT,                    (uint32_t)info->members.size());
+
+	// DATA_SET_RANKS — rows: RANK_ID, RANK_LEVEL, PERMISSION_FLAGS, NAME(0x370).
+	append(response, GA_T::DATA_SET_RANKS & 0xFF, GA_T::DATA_SET_RANKS >> 8);
+	append(response, info->ranks.size() & 0xFF, (info->ranks.size() >> 8) & 0xFF);
+	for (const auto& rk : info->ranks) {
+		append(response, 0x04, 0x00);  // 4 fields
+		Write4B(response,     GA_T::RANK_ID,          (uint32_t)rk.rank_id);
+		Write4B(response,     GA_T::RANK_LEVEL,       (uint32_t)rk.rank_level);
+		Write4B(response,     GA_T::PERMISSION_FLAGS, (uint32_t)rk.permissions);
+		WriteString(response, GA_T::NAME,             rk.rank_name);
+	}
+
+	// Online members (character_id -> map name) in ONE query scoped to this
+	// agency. The roster is polled every 2s per client, so this path stays at a
+	// fixed 5 queries regardless of member count: agency id, meta, ranks,
+	// members (profile_id joined in), online map.
+	const std::map<int64_t, std::string> online =
+		Database::GetOnlineAgencyMemberMaps(agency_id);
+
+	// DATA_SET_MEMBERS — the row parser (client FUN_113ccbe0) reads, in order:
+	// PLAYER_NAME 0x3C5, PLAYER_ID 0x3C3, RANK_ID 0x417, LEVEL 0x303,
+	// PROFILE_ID 0x3DF, ACTIVE_FLAG 0x16, MAP_NAME_MSG_ID 0x327 (the Location
+	// column), PUBLIC_COMMENT 0x3F3, OFFICER_COMMENT 0x386. It stores
+	// ACTIVE_FLAG inverted (absent/false => "offline"), so online must send "y".
+	append(response, GA_T::DATA_SET_MEMBERS & 0xFF, GA_T::DATA_SET_MEMBERS >> 8);
+	append(response, info->members.size() & 0xFF, (info->members.size() >> 8) & 0xFF);
+	for (const auto& m : info->members) {
+		auto it = online.find(m.character_id);
+		const bool is_online = (it != online.end());
+
+		uint32_t map_msg_id = 0;
+		if (is_online) {
+			if (auto rec = MapGameInfo::LookupByName(it->second))
+				map_msg_id = rec->friendly_name_msg_id;
+		}
+		// A map with no friendly-name msg id would localize to "Unknown" too.
+		const bool send_location = (map_msg_id != 0);
+
+		// Offline members OMIT MAP_NAME_MSG_ID: the parser only localizes the id
+		// when the field is present, so leaving it out keeps
+		// sMemberLocationString at its "" default (a 0 id localizes to
+		// "Unknown"). Field count is per-row, so 8 vs 9 is fine.
+		append(response, send_location ? 0x09 : 0x08, 0x00);
+		WriteString(response, GA_T::PLAYER_NAME,     m.player_name);
+		Write4B(response,     GA_T::PLAYER_ID,       (uint32_t)m.character_id);
+		Write4B(response,     GA_T::RANK_ID,         (uint32_t)m.rank_id);
+		// Levels aren't tracked anywhere on this server — 50 everywhere, same
+		// constant GSC_CHARACTER_LIST and QUERY_PLAYERS use.
+		Write4B(response,     GA_T::LEVEL,           50);
+		Write4B(response,     GA_T::PROFILE_ID,      m.profile_id);
+		WriteString(response, GA_T::ACTIVE_FLAG,     is_online ? "y" : "n");
+		if (send_location) Write4B(response, GA_T::MAP_NAME_MSG_ID, map_msg_id);
+		WriteString(response, GA_T::PUBLIC_COMMENT,  m.public_comment);
+		// Officer notes only go out to ranks allowed to read them — the client
+		// hides the box, but don't ship the text to a client that can't show it.
+		WriteString(response, GA_T::OFFICER_COMMENT,
+			agency_has_perm(*info, user_id_, Database::AGENCY_PERM_VIEW_OFFICER_MSG)
+				? m.officer_comment : std::string());
+	}
+
+	// ROSTER_FLAGS, NAME, MOTD, INFORMATION, RECRUITING_TEXT, RECRUITING_FLAG,
+	// SUB_ONLY, AGENCY_ID, PLAYER_ID, COUNT, DATA_SET_RANKS, DATA_SET_MEMBERS.
+	return 12;
+}
+
 void TcpSession::send_agency_get_roster_response()
 {
+	std::vector<uint8_t> payload;
+	int fields = append_agency_payload(payload);
+
 	std::vector<uint8_t> response;
-
 	uint16_t packet_type = GA_U::AGENCY_GET_ROSTER;
-	uint16_t item_count = 1;
 
+	if (fields == 0) {
+		// "You are not in an agency." MSG_ID==0x37B9 makes the receiver set
+		// m_bNoAgency + ClearData — needed to reset the UI after a disband
+		// (the creation menu shows again). Harmless before first create too.
+		uint16_t item_count = 1;
+		append(response, packet_type & 0xFF, packet_type >> 8);
+		append(response, item_count & 0xFF, item_count >> 8);
+		Write4B(response, GA_T::MSG_ID, 0x37B9);
+		send_response(response);
+		return;
+	}
+
+	uint16_t item_count = (uint16_t)fields;
 	append(response, packet_type & 0xFF, packet_type >> 8);
 	append(response, item_count & 0xFF, item_count >> 8);
+	WriteNBytesRaw(response, payload);
 
-	Write4B(response, GA_T::AGENCY_ID, 0x1);
+	send_response(response);
+}
 
+void TcpSession::handle_agency_disband()
+{
+	int64_t agency_id = Database::GetAgencyIdForUser(user_id_);
+	if (agency_id == 0) { send_agency_get_roster_response(); return; }
+
+	auto agency = Database::GetAgencyInfo(agency_id);
+	if (!agency) return;
+	// Non-leader: this is a plain LEAVE — drop just my member row. (Only the
+	// leader's "remove last member" confirms as a disband.)
+	if (agency->leader_user_id != user_id_) {
+		Logger::Log("agency", "[TCP] AGENCY leave: user %lld leaving agency %lld\n",
+			(long long)user_id_, (long long)agency_id);
+		Database::RemoveAgencyMember(agency_id, selected_character_id_);
+		// Alliance tab needs the explicit reset too — it only refreshes while open.
+		send_agency_get_roster_response();
+		send_alliance_member_list_response();
+		return;
+	}
+
+	// Everyone else loses their agency too — collect them before the delete so
+	// their panels can be reset without waiting for a relog.
+	std::vector<int64_t> others;
+	for (const auto& m : agency->members) {
+		if (m.user_id != user_id_) others.push_back(m.user_id);
+	}
+
+	Database::DisbandAgency(agency_id);
+	// Reset both panels: no-agency roster + no-alliance member list.
+	send_agency_get_roster_response();
+	send_alliance_member_list_response();
+	for (int64_t uid : others) DeliverAgencyRefresh(uid);
+}
+
+void TcpSession::handle_agency_create(const PacketView& pkt)
+{
+	std::string name = pkt.ReadString(GA_T::AGENCY_NAME).value_or("");
+	float r = pkt.ReadFloat(GA_T::LINEAR_COLOR_R).value_or(0.0f);
+	float g = pkt.ReadFloat(GA_T::LINEAR_COLOR_G).value_or(0.0f);
+	float b = pkt.ReadFloat(GA_T::LINEAR_COLOR_B).value_or(0.0f);
+
+	Logger::Log("agency", "[TCP] AGENCY_CREATE name='%s' color=(%.3f,%.3f,%.3f) user=%lld\n",
+		name.c_str(), r, g, b, (long long)user_id_);
+
+	if (name.empty() || user_id_ <= 0) return;
+
+	int64_t agency_id = Database::CreateAgency(
+		name, r, g, b, user_id_, selected_character_id_, player_name);
+	if (agency_id == 0) {
+		Logger::Log("agency", "[TCP] AGENCY_CREATE rejected (dup name or already in agency)\n");
+		return;  // ponytail: no error-reply reversed yet; client stays on the
+		         // creation panel. Add AGENCY_CREATE error path when observed.
+	}
+
+	// Push the agency data as a roster response so the client's TgAgencyData
+	// receiver clears m_bNoAgency and the UI leaves the creation panel. The
+	// menu's own 2s roster poll is the backup path.
+	send_agency_get_roster_response();
+}
+
+// AGENCY_INVITE (0xB5) — invite a player by name, same shape as ALLIANCE_INVITE.
+// Target must be online (the popup is a live push); pending state drives accept.
+void TcpSession::handle_agency_invite(const PacketView& pkt)
+{
+	std::string target_name = pkt.ReadString(GA_T::PLAYER_NAME).value_or("");
+	Logger::Log("agency", "[TCP] AGENCY_INVITE target='%s' user=%lld\n",
+		target_name.c_str(), (long long)user_id_);
+	if (target_name.empty() || user_id_ <= 0) return;
+
+	int64_t my_agency = Database::GetAgencyIdForUser(user_id_);
+	if (my_agency == 0) { send_agency_message(14265, target_name); return; }
+	auto agency = Database::GetAgencyInfo(my_agency);
+	if (!agency) return;
+	if (!agency_has_perm(*agency, user_id_, Database::AGENCY_PERM_INVITE)) {
+		Logger::Log("agency", "[TCP] AGENCY_INVITE denied: user %lld lacks the invite permission\n",
+			(long long)user_id_);
+		send_agency_message(14258, target_name);  // "Your rank does not allow..."
+		return;
+	}
+
+	int64_t target_user = 0;
+	std::shared_ptr<TcpSession> target_session;
+	{
+		std::lock_guard<std::mutex> lock(sessions_mutex_);
+		for (auto& kv : g_sessions_) {
+			auto s = kv.second.lock();
+			if (s && s->player_name == target_name && s->user_id_ > 0) {
+				target_session = s;
+				target_user = s->user_id_;
+				break;
+			}
+		}
+	}
+	if (!target_session) {
+		// Offline players can't be invited (the popup is a live push), and the
+		// client's own message for that case is "character was not found".
+		Logger::Log("agency", "[TCP] AGENCY_INVITE: '%s' not online\n", target_name.c_str());
+		send_agency_message(14259, target_name);
+		return;
+	}
+	if (target_user == user_id_) return;
+	const int64_t their_agency = Database::GetAgencyIdForUser(target_user);
+	if (their_agency != 0) {
+		Logger::Log("agency", "[TCP] AGENCY_INVITE: '%s' already in an agency\n",
+			target_name.c_str());
+		// 14260 "is already a member." / 14262 "is a member of another agency."
+		send_agency_message(their_agency == my_agency ? 14260 : 14262, target_name);
+		return;
+	}
+
+	{
+		std::lock_guard<std::mutex> lock(pending_agency_mutex_);
+		if (pending_agency_invites_.count(target_user)) {
+			send_agency_message(14267, target_name);  // "has a pending invite."
+			return;
+		}
+		pending_agency_invites_[target_user] = my_agency;
+	}
+	target_session->send_agency_invitation(agency->name, player_name);
+	send_agency_message(14261, target_name);  // "Invite to join agency was sent to..."
+}
+
+void TcpSession::handle_agency_accept()
+{
+	int64_t agency_id = 0;
+	{
+		std::lock_guard<std::mutex> lock(pending_agency_mutex_);
+		auto it = pending_agency_invites_.find(user_id_);
+		if (it == pending_agency_invites_.end()) {
+			Logger::Log("agency", "[TCP] AGENCY_ACCEPT: no pending invite for user %lld\n",
+				(long long)user_id_);
+			return;
+		}
+		agency_id = it->second;
+		pending_agency_invites_.erase(it);
+	}
+
+	// rank_id 2 = the seeded "Member" rank (see CreateAgency).
+	if (!Database::AddAgencyMember(agency_id, user_id_, selected_character_id_,
+	                               player_name, 2)) {
+		return;
+	}
+	Logger::Log("agency", "[TCP] AGENCY_ACCEPT: user %lld joined agency %lld\n",
+		(long long)user_id_, (long long)agency_id);
+	// Roster + alliance both: the agency I just joined may already be in an
+	// alliance, and the Alliance tab won't refresh on its own until opened.
+	send_agency_get_roster_response();
+	send_alliance_member_list_response();
+}
+
+// AGENCY_PROMOTE (0xBB) / AGENCY_DEMOTE (0xBC). Client sends the member's
+// PLAYER_ID, which is the character_id we put in the DATA_SET_MEMBERS rows
+// (UC: TgAgencyData::Promote/Demote(int nPlayerId)). Ranks are ordered by
+// rank_level ASC (0 = Leader), so promote = previous rank in that list.
+void TcpSession::handle_agency_rank_change(const PacketView& pkt, bool promote)
+{
+	const int64_t target_char = (int64_t)pkt.Read4B(GA_T::PLAYER_ID).value_or(0);
+	int64_t my_agency = Database::GetAgencyIdForUser(user_id_);
+	Logger::Log("agency", "[TCP] AGENCY_%s target_char=%lld user=%lld agency=%lld\n",
+		promote ? "PROMOTE" : "DEMOTE", (long long)target_char,
+		(long long)user_id_, (long long)my_agency);
+	if (target_char == 0 || my_agency == 0) return;
+
+	auto info = Database::GetAgencyInfo(my_agency);
+	if (!info) return;
+
+	const Database::AgencyMemberRow* me = nullptr;
+	const Database::AgencyMemberRow* target = nullptr;
+	for (const auto& m : info->members) {
+		if (m.user_id == user_id_)          me = &m;
+		if (m.character_id == target_char)  target = &m;
+	}
+	if (!me || !target) return;
+
+	auto level_of = [&](int rank_id) {
+		for (const auto& rk : info->ranks) if (rk.rank_id == rank_id) return rk.rank_level;
+		return 9999;
+	};
+	// info->ranks comes back ordered by rank_level ASC.
+	size_t idx = info->ranks.size();
+	for (size_t i = 0; i < info->ranks.size(); ++i) {
+		if (info->ranks[i].rank_id == target->rank_id) { idx = i; break; }
+	}
+	if (idx >= info->ranks.size()) return;
+	// idx 0 = the rank_level 0 Leader rank — promoting INTO it is TransferLeader
+	// (a separate native), so promote stops one below.
+	if (promote && idx <= 1) return;
+	if (!promote && idx + 1 >= info->ranks.size()) return; // already bottom rank
+	const auto& new_rank = info->ranks[promote ? idx - 1 : idx + 1];
+
+	if (!agency_has_perm(*info, user_id_, promote ? Database::AGENCY_PERM_PROMOTE
+	                                              : Database::AGENCY_PERM_DEMOTE)) {
+		Logger::Log("agency", "[TCP] AGENCY rank change denied: no permission\n");
+		return;
+	}
+	// Only outrank-ers may act, and never onto/above your own rank.
+	const int my_level = level_of(me->rank_id);
+	if (my_level >= level_of(target->rank_id) || my_level >= new_rank.rank_level) {
+		Logger::Log("agency", "[TCP] AGENCY rank change denied: my_level=%d target_level=%d new_level=%d\n",
+			my_level, level_of(target->rank_id), new_rank.rank_level);
+		return;
+	}
+
+	if (!Database::SetAgencyMemberRank(my_agency, target_char, new_rank.rank_id)) return;
+	// The affected member (and everyone else) picks this up on the 2s roster poll.
+	send_agency_get_roster_response();
+}
+
+// AGENCY_UPDATE_RANKS (0xCB) — the Management tab's rank editor Submit. Sends
+// DATA_SET_RANKS (0x193) with EVERY rank row: RANK_ID(0x417), NAME(0x370),
+// PERMISSION_FLAGS(0x3B0), RANK_LEVEL(0x418) — so add / rename / delete /
+// permission edits all arrive as one replacement set. Leader only.
+void TcpSession::handle_agency_update_ranks(const PacketView& pkt)
+{
+	int64_t my_agency = Database::GetAgencyIdForUser(user_id_);
+	if (my_agency == 0) return;
+	auto info = Database::GetAgencyInfo(my_agency);
+	if (!info) return;
+
+	const auto* me = agency_member_by_user(*info, user_id_);
+	if (!me || agency_rank_level(*info, me->rank_id) != 0) {
+		Logger::Log("agency", "[TCP] AGENCY_UPDATE_RANKS rejected: user %lld is not the leader\n",
+			(long long)user_id_);
+		return;
+	}
+
+	std::vector<Database::AgencyRankRow> ranks;
+	for (const auto& row : pkt.GetDataSet(GA_T::DATA_SET_RANKS)) {
+		Database::AgencyRankRow rk;
+		rk.rank_id     = (int)row.Read4B(GA_T::RANK_ID).value_or(0);
+		rk.rank_level  = (int)row.Read4B(GA_T::RANK_LEVEL).value_or(0);
+		rk.permissions = (int)row.Read4B(GA_T::PERMISSION_FLAGS).value_or(0);
+		rk.rank_name   = row.ReadString(GA_T::NAME).value_or("");
+		ranks.push_back(std::move(rk));
+	}
+	Logger::Log("agency", "[TCP] AGENCY_UPDATE_RANKS user=%lld rows=%d\n",
+		(long long)user_id_, (int)ranks.size());
+	if (ranks.empty()) return;
+
+	if (!Database::ReplaceAgencyRanks(my_agency, ranks)) return;
+	send_agency_get_roster_response();
+	for (int64_t uid : Database::GetAgencyMemberUserIds(my_agency)) {
+		if (uid != user_id_) DeliverAgencyRefresh(uid);
+	}
+}
+
+// AGENCY_SET_NOTE (0xC4) — the four text edits share this opcode; which one is
+// meant is told by the tag present (UC: TgAgencyData::SetMOTD(string),
+// SetDescription(string), SetPublicComment/SetOfficerComment(int nPlayerId,
+// string)). A PLAYER_ID alongside the text = a per-member note.
+void TcpSession::handle_agency_set_note(const PacketView& pkt)
+{
+	int64_t my_agency = Database::GetAgencyIdForUser(user_id_);
+	if (my_agency == 0) return;
+	auto info = Database::GetAgencyInfo(my_agency);
+	if (!info) return;
+
+	const auto* me = agency_member_by_user(*info, user_id_);
+	if (!me) return;
+
+	auto motd        = pkt.ReadString(GA_T::AGENCY_MOTD);
+	auto information = pkt.ReadString(GA_T::AGENCY_INFORMATION);
+	auto public_note = pkt.ReadString(GA_T::PUBLIC_COMMENT);
+	auto officer_note= pkt.ReadString(GA_T::OFFICER_COMMENT);
+	const int64_t target_char = (int64_t)pkt.Read4B(GA_T::PLAYER_ID)
+		.value_or((uint32_t)selected_character_id_);
+
+	Logger::Log("agency", "[TCP] AGENCY_SET_NOTE user=%lld motd=%d info=%d pub=%d off=%d target=%lld\n",
+		(long long)user_id_, (int)motd.has_value(), (int)information.has_value(),
+		(int)public_note.has_value(), (int)officer_note.has_value(), (long long)target_char);
+
+	bool changed = false;
+	if (motd && agency_has_perm(*info, user_id_, Database::AGENCY_PERM_EDIT_MOTD))
+		changed |= Database::SetAgencyText(my_agency, true, *motd);
+	if (information && agency_has_perm(*info, user_id_, Database::AGENCY_PERM_EDIT_DESCRIPTION))
+		changed |= Database::SetAgencyText(my_agency, false, *information);
+	if (public_note && agency_has_perm(*info, user_id_, Database::AGENCY_PERM_EDIT_PUBLIC_MSG))
+		changed |= Database::SetAgencyMemberComment(my_agency, target_char, false, *public_note);
+	if (officer_note && agency_has_perm(*info, user_id_, Database::AGENCY_PERM_EDIT_OFFICER_MSG))
+		changed |= Database::SetAgencyMemberComment(my_agency, target_char, true, *officer_note);
+	if (!changed) return;
+
+	send_agency_get_roster_response();
+	// MOTD/description are agency-wide — everyone else's panel shows them too.
+	for (int64_t uid : Database::GetAgencyMemberUserIds(my_agency)) {
+		if (uid != user_id_) DeliverAgencyRefresh(uid);
+	}
+}
+
+// AGENCY_UPDATE_RECRUITING (0xCA) — the Recruiting tab's Submit. Observed:
+// RECRUITING_LISTING_TEXT(0x41F) + RECRUITING_FLAG(0x41E) +
+// RECRUITING_SUB_ONLY_FLAG(0x420); both flags are "y"/"n" strings, same as the
+// roster response direction.
+void TcpSession::handle_agency_update_recruiting(const PacketView& pkt)
+{
+	int64_t my_agency = Database::GetAgencyIdForUser(user_id_);
+	if (my_agency == 0) return;
+	auto info = Database::GetAgencyInfo(my_agency);
+	if (!info) return;
+
+	auto flag_of = [&](uint16_t tag, bool fallback) {
+		auto s = pkt.ReadString(tag);
+		if (!s || s->empty()) return fallback;
+		const char c = (*s)[0];
+		return c == 'y' || c == 'Y' || c == 't' || c == 'T';
+	};
+	const std::string text = pkt.ReadString(GA_T::RECRUITING_LISTING_TEXT)
+		.value_or(info->recruiting_text);
+	const bool recruiting = flag_of(GA_T::RECRUITING_FLAG,          info->recruiting);
+	const bool sub_only   = flag_of(GA_T::RECRUITING_SUB_ONLY_FLAG, info->sub_only);
+
+	Logger::Log("agency", "[TCP] AGENCY_UPDATE_RECRUITING user=%lld recruiting=%d sub_only=%d text='%s'\n",
+		(long long)user_id_, (int)recruiting, (int)sub_only, text.c_str());
+
+	if (!Database::SetAgencyRecruiting(my_agency, text, recruiting, sub_only)) return;
+	send_agency_get_roster_response();
+	for (int64_t uid : Database::GetAgencyMemberUserIds(my_agency)) {
+		if (uid != user_id_) DeliverAgencyRefresh(uid);
+	}
+}
+
+// AGENCY_SET_OWNER (0xC6) — Management tab's "Transfer Leader". The client
+// resolves the typed name itself and sends the target's PLAYER_ID
+// (= character_id). Leader takes the target's old rank; target takes rank 0.
+void TcpSession::handle_agency_set_owner(const PacketView& pkt)
+{
+	const int64_t target_char = (int64_t)pkt.Read4B(GA_T::PLAYER_ID).value_or(0);
+	int64_t my_agency = Database::GetAgencyIdForUser(user_id_);
+	Logger::Log("agency", "[TCP] AGENCY_SET_OWNER target_char=%lld user=%lld agency=%lld\n",
+		(long long)target_char, (long long)user_id_, (long long)my_agency);
+	if (target_char == 0 || my_agency == 0) return;
+
+	auto info = Database::GetAgencyInfo(my_agency);
+	if (!info || info->leader_user_id != user_id_) {
+		Logger::Log("agency", "[TCP] AGENCY_SET_OWNER rejected: user %lld is not the leader\n",
+			(long long)user_id_);
+		return;
+	}
+	const Database::AgencyMemberRow* target = nullptr;
+	for (const auto& m : info->members) if (m.character_id == target_char) target = &m;
+	if (!target || target->user_id == user_id_) return;
+
+	// Leader drops to the rank just below rank_level 0 (ranks are level-ASC).
+	const int demoted_rank = info->ranks.size() > 1 ? info->ranks[1].rank_id : 0;
+	const int64_t new_leader_user = target->user_id;
+
+	Database::SetAgencyMemberRank(my_agency, target_char, 0);
+	Database::SetAgencyMemberRank(my_agency, selected_character_id_, demoted_rank);
+	Database::SetAgencyLeader(my_agency, new_leader_user);
+
+	send_agency_get_roster_response();
+	for (int64_t uid : Database::GetAgencyMemberUserIds(my_agency)) {
+		if (uid != user_id_) DeliverAgencyRefresh(uid);
+	}
+}
+
+// Kick a member: AGENCY_PLAYER_REMOVE (0xBF), or AGENCY_REMOVE (0xBD) carrying
+// someone else's PLAYER_ID. Self-targeted / no target = leave-or-disband.
+void TcpSession::handle_agency_kick(int64_t target_char)
+{
+	int64_t my_agency = Database::GetAgencyIdForUser(user_id_);
+	Logger::Log("agency", "[TCP] AGENCY kick target_char=%lld user=%lld agency=%lld\n",
+		(long long)target_char, (long long)user_id_, (long long)my_agency);
+	if (target_char == 0 || my_agency == 0) return;
+
+	auto info = Database::GetAgencyInfo(my_agency);
+	if (!info) return;
+
+	const Database::AgencyMemberRow* me = nullptr;
+	const Database::AgencyMemberRow* target = nullptr;
+	for (const auto& m : info->members) {
+		if (m.user_id == user_id_)         me = &m;
+		if (m.character_id == target_char) target = &m;
+	}
+	if (!me || !target) return;
+
+	auto level_of = [&](int rank_id) {
+		for (const auto& rk : info->ranks) if (rk.rank_id == rank_id) return rk.rank_level;
+		return 9999;
+	};
+	if (!agency_has_perm(*info, user_id_, Database::AGENCY_PERM_KICK)) {
+		Logger::Log("agency", "[TCP] AGENCY kick denied: no permission\n");
+		return;
+	}
+	if (level_of(me->rank_id) >= level_of(target->rank_id)) {
+		Logger::Log("agency", "[TCP] AGENCY kick denied: target outranks or equals kicker\n");
+		return;
+	}
+
+	const int64_t kicked_user = target->user_id;
+	if (!Database::RemoveAgencyMember(my_agency, target_char)) return;
+	send_agency_get_roster_response();
+	// Push the reset to the kicked player too: their agency panel would clear on
+	// its own roster poll, but the Alliance tab only refreshes while that tab is
+	// open, so without this it stays stale until relog.
+	DeliverAgencyRefresh(kicked_user);
+}
+
+// Push the caller's CURRENT agency + alliance state to whichever live session
+// owns target_user_id (so it doubles as the "no agency"/"no alliance" reset).
+// Needed whenever a player's agency or alliance changes without them asking —
+// the roster poll self-heals the AgentInfo panel, but the Alliance tab only
+// refreshes while it's open, so it stays stale until relog otherwise.
+void TcpSession::DeliverAgencyRefresh(int64_t target_user_id)
+{
+	if (target_user_id <= 0) return;
+	std::shared_ptr<TcpSession> s;
+	{
+		std::lock_guard<std::mutex> lock(sessions_mutex_);
+		for (auto& kv : g_sessions_) {
+			auto cand = kv.second.lock();
+			if (cand && cand->user_id_ == target_user_id) { s = cand; break; }
+		}
+	}
+	if (!s) return;
+	s->send_agency_get_roster_response();
+	s->send_alliance_member_list_response();
+}
+
+// Agency status/error line (the Invite tab's message label). The full set of
+// templates exists in asm_data_set_msg_translations: 14258 no permission, 14259
+// character not found, 14260 already a member, 14261 invite sent, 14262 member
+// of another agency, 14265 you have no agency, 14267 has a pending invite.
+// Carrier: echoed on AGENCY_INVITE (0xB5) — the request opcode — with MSG_ID +
+// the @@player_name@@ token. Tested: renders in the Invite tab's label, an OK
+// dialog, and the chat log. Do NOT reuse 0xB6, that one raises the HUD dialog.
+void TcpSession::send_agency_message(uint32_t msg_id, const std::string& player_name_token)
+{
+	std::vector<uint8_t> response;
+	uint16_t packet_type = GA_U::AGENCY_INVITE;
+	uint16_t item_count = 2;
+	append(response, packet_type & 0xFF, packet_type >> 8);
+	append(response, item_count & 0xFF, item_count >> 8);
+	Write4B(response,     GA_T::MSG_ID,      msg_id);
+	WriteString(response, GA_T::PLAYER_NAME, player_name_token);
+	Logger::Log("agency", "[TCP] send agency message msg_id=%u token='%s' to user=%lld\n",
+		msg_id, player_name_token.c_str(), (long long)user_id_);
+	send_response(response);
+}
+
+void TcpSession::send_agency_invitation(const std::string& agency_name,
+                                        const std::string& inviter_leader_name)
+{
+	// MSG_ID 14266 = "@@leader_name@@ has invited you to join agency
+	// \"@@agency_name@@\"." — tokens substitute by field name.
+	// NOT reversed at the client yet (unlike the roster/alliance receivers): the
+	// client shows this as a HUD dialog — TgUIPrimaryHUD_DialogQuery.HUDDialogType
+	// DialogInviteToAgency, the same widget the team invite (0x4B) drives — so the
+	// shape mirrors send_team_invitation_popup (MSG_ID + LEADER_NAME), plus
+	// AGENCY_NAME for the second token. Confirm on first test.
+	std::vector<uint8_t> response;
+	uint16_t packet_type = GA_U::AGENCY_INVITATION;
+	uint16_t item_count = 3;
+	append(response, packet_type & 0xFF, packet_type >> 8);
+	append(response, item_count & 0xFF, item_count >> 8);
+	Write4B(response,     GA_T::MSG_ID,      14266);
+	WriteString(response, GA_T::LEADER_NAME, inviter_leader_name);
+	WriteString(response, GA_T::AGENCY_NAME, agency_name);
+	Logger::Log("agency", "[TCP] send AGENCY_INVITATION agency='%s' from '%s' to user=%lld\n",
+		agency_name.c_str(), inviter_leader_name.c_str(), (long long)user_id_);
+	send_response(response);
+}
+
+// Alliance member-list payload, matching the client TgAllianceData receiver
+// (reversed at client FUN_113ce850). Gate is ROSTER_FLAGS bit0 (clears
+// m_bNoAlliance). Alliance name = NAME(0x370); owner agency name = AGENCY_NAME.
+// Returns top-level field count (0 if the caller's agency has no alliance).
+int TcpSession::append_alliance_payload(std::vector<uint8_t>& response)
+{
+	int64_t agency_id = Database::GetAgencyIdForUser(user_id_);
+	if (agency_id == 0) return 0;
+	int64_t alliance_id = Database::GetAllianceIdForAgency(agency_id);
+	if (alliance_id == 0) return 0;
+
+	auto info = Database::GetAllianceInfo(alliance_id);
+	if (!info) return 0;
+
+	// bit0 = core present (clears m_bNoAlliance); bit2 = member-agency data set
+	// present (the receiver gates DATA_SET_AGENCIES on it). Client requests flags=5.
+	Write4B(response,     GA_T::ROSTER_FLAGS,     0x5);
+	WriteString(response, GA_T::NAME,             info->name);              // 0x370
+	WriteString(response, GA_T::AGENCY_NAME,      info->owner_agency_name); // 0x24
+	Write4B(response,     GA_T::ALLIANCE_ID,      (uint32_t)info->id);
+	Write4B(response,     GA_T::OWNER_AGENCY_ID,  (uint32_t)info->owner_agency_id);
+	Write4B(response,     GA_T::COUNT,            (uint32_t)info->members.size());
+	// "Formed <date>" line. The client's DATETIME formatter (FUN_10955ab0) reads
+	// this double as DAYS SINCE 1900-01-01 (input 0 -> 01/01/1900). Convert from
+	// unix seconds: days = (unix + 2208988800) / 86400  (offset = 1900->1970 secs).
+	const double kSecs1900to1970 = 2208988800.0;
+	double days_since_1900 = ((double)info->created_at + kSecs1900to1970) / 86400.0;
+	WriteDouble(response, GA_T::CREATED_DATETIME, days_since_1900);
+
+	// DATA_SET_AGENCIES — rows: AGENCY_NAME, AGENCY_ID, PLAYER_COUNT, TERRITORY_COUNT.
+	append(response, GA_T::DATA_SET_AGENCIES & 0xFF, GA_T::DATA_SET_AGENCIES >> 8);
+	append(response, info->members.size() & 0xFF, (info->members.size() >> 8) & 0xFF);
+	for (const auto& m : info->members) {
+		append(response, 0x04, 0x00);  // 4 fields
+		WriteString(response, GA_T::AGENCY_NAME,     m.agency_name);
+		Write4B(response,     GA_T::AGENCY_ID,       (uint32_t)m.agency_id);
+		Write4B(response,     GA_T::PLAYER_COUNT,    (uint32_t)m.member_count);
+		Write4B(response,     GA_T::TERRITORY_COUNT, (uint32_t)m.territory_count);
+	}
+
+	// ROSTER_FLAGS, NAME, AGENCY_NAME, ALLIANCE_ID, OWNER_AGENCY_ID, COUNT,
+	// CREATED_DATETIME, DATA_SET_AGENCIES.
+	return 8;
+}
+
+// The client's alliance receiver needs a DEFINITIVE answer to show the Alliance
+// tab: either the alliance data, or the explicit "no alliance" signal
+// MSG_ID==0x624F (which sets m_bNoAlliance + runs ClearData, unlocking the
+// in-tab Create panel). An empty response is ignored and leaves the tab blank.
+void TcpSession::send_alliance_member_list_response()
+{
+	std::vector<uint8_t> payload;
+	int fields = append_alliance_payload(payload);
+
+	std::vector<uint8_t> response;
+	uint16_t packet_type = GA_U::ALLIANCE_GET_MEMBER_LIST;
+
+	if (fields == 0) {
+		// "You are not in an alliance."
+		uint16_t item_count = 1;
+		append(response, packet_type & 0xFF, packet_type >> 8);
+		append(response, item_count & 0xFF, item_count >> 8);
+		Write4B(response, GA_T::MSG_ID, 0x624F);
+		send_response(response);
+		return;
+	}
+
+	uint16_t item_count = (uint16_t)fields;
+	append(response, packet_type & 0xFF, packet_type >> 8);
+	append(response, item_count & 0xFF, item_count >> 8);
+	WriteNBytesRaw(response, payload);
+
+	send_response(response);
+}
+
+void TcpSession::handle_alliance_create(const PacketView& pkt)
+{
+	// Observed tag is NAME (0x370); the other two are harmless fallbacks.
+	std::string name = pkt.ReadString(GA_T::ALLIANCE_NAME)
+		.value_or(pkt.ReadString(GA_T::NAME)
+		.value_or(pkt.ReadString(GA_T::AGENCY_NAME).value_or("")));
+
+	Logger::Log("agency", "[TCP] ALLIANCE_CREATE name='%s' user=%lld\n",
+		name.c_str(), (long long)user_id_);
+
+	if (name.empty() || user_id_ <= 0) return;
+
+	// Must be in an agency AND be its leader to found an alliance.
+	int64_t agency_id = Database::GetAgencyIdForUser(user_id_);
+	if (agency_id == 0) {
+		Logger::Log("agency", "[TCP] ALLIANCE_CREATE rejected: user %lld not in an agency\n",
+			(long long)user_id_);
+		return;
+	}
+	auto agency = Database::GetAgencyInfo(agency_id);
+	if (!agency || agency->leader_user_id != user_id_) {
+		Logger::Log("agency", "[TCP] ALLIANCE_CREATE rejected: user %lld not agency leader\n",
+			(long long)user_id_);
+		return;
+	}
+
+	int64_t alliance_id = Database::CreateAlliance(name, agency_id);
+	if (alliance_id == 0) {
+		Logger::Log("agency", "[TCP] ALLIANCE_CREATE rejected (dup name or agency already allied)\n");
+		return;
+	}
+
+	// Push the member list so the client's TgAllianceData clears m_bNoAlliance.
+	send_alliance_member_list_response();
+	// My agency-mates just gained an alliance too.
+	for (int64_t uid : Database::GetAgencyMemberUserIds(agency_id)) {
+		if (uid != user_id_) DeliverAgencyRefresh(uid);
+	}
+}
+
+
+void TcpSession::handle_alliance_disband()
+{
+	int64_t agency_id = Database::GetAgencyIdForUser(user_id_);
+	int64_t alliance_id = agency_id ? Database::GetAllianceIdForAgency(agency_id) : 0;
+	if (alliance_id == 0) { send_alliance_member_list_response(); return; }
+
+	auto info = Database::GetAllianceInfo(alliance_id);
+	if (!info || info->owner_agency_id != agency_id) {
+		Logger::Log("agency", "[TCP] ALLIANCE_DISBAND rejected: agency %lld does not own alliance %lld\n",
+			(long long)agency_id, (long long)alliance_id);
+		return;  // only the owning agency can disband
+	}
+
+	// Collect everyone in the alliance BEFORE the delete — after it, the
+	// membership rows are gone and there's no way to find them.
+	auto affected = Database::GetAllianceMemberUserIds(alliance_id);
+	Database::DisbandAlliance(alliance_id);
+	send_alliance_member_list_response();
+	// Push the reset to every other member agency's players: their Alliance tab
+	// (and the AgentInfo line) would otherwise stay stale until relog.
+	for (int64_t uid : affected) {
+		if (uid != user_id_) DeliverAgencyRefresh(uid);
+	}
+}
+
+// ALLIANCE_REMOVE (0xD3) handles both "owner kicks a member agency" and "member
+// agency leaves" — both send AGENCY_ID of the agency to drop.
+void TcpSession::handle_alliance_remove(const PacketView& pkt)
+{
+	uint32_t target_agency = pkt.Read4B(GA_T::AGENCY_ID).value_or(0);
+	int64_t my_agency = Database::GetAgencyIdForUser(user_id_);
+	int64_t alliance_id = my_agency ? Database::GetAllianceIdForAgency(my_agency) : 0;
+	Logger::Log("agency", "[TCP] ALLIANCE_REMOVE target_agency=%u my_agency=%lld alliance=%lld\n",
+		target_agency, (long long)my_agency, (long long)alliance_id);
+	if (target_agency == 0 || alliance_id == 0) return;
+
+	auto info = Database::GetAllianceInfo(alliance_id);
+	if (!info) return;
+
+	const bool leaving = ((int64_t)target_agency == my_agency);
+	const bool is_owner = (info->owner_agency_id == my_agency);
+	if (!leaving && !is_owner) {
+		Logger::Log("agency", "[TCP] ALLIANCE_REMOVE rejected: not owner and not self-leave\n");
+		return;
+	}
+	if ((int64_t)target_agency == info->owner_agency_id) {
+		// The owner agency can't be removed from its own alliance — that's a disband.
+		Logger::Log("agency", "[TCP] ALLIANCE_REMOVE: target is owner agency; use disband\n");
+		return;
+	}
+	// Target must actually be in THIS alliance.
+	if (Database::GetAllianceIdForAgency((int64_t)target_agency) != alliance_id) {
+		Logger::Log("agency", "[TCP] ALLIANCE_REMOVE: agency %u not in alliance %lld\n",
+			target_agency, (long long)alliance_id);
+		return;
+	}
+
+	// Both sides change: the dropped agency loses the alliance, the remaining
+	// ones lose a row. Collect before the delete so the dropped agency's players
+	// are still reachable through the alliance join.
+	auto affected = Database::GetAllianceMemberUserIds(alliance_id);
+	Database::RemoveAgencyFromAlliance((int64_t)target_agency);
+	send_alliance_member_list_response();
+	for (int64_t uid : affected) {
+		if (uid != user_id_) DeliverAgencyRefresh(uid);
+	}
+}
+
+void TcpSession::handle_alliance_invite(const PacketView& pkt)
+{
+	std::string leader_name = pkt.ReadString(GA_T::PLAYER_NAME).value_or("");
+	Logger::Log("agency", "[TCP] ALLIANCE_INVITE target-leader='%s' user=%lld\n",
+		leader_name.c_str(), (long long)user_id_);
+	if (leader_name.empty() || user_id_ <= 0) return;
+
+	// I must own an alliance.
+	int64_t my_agency = Database::GetAgencyIdForUser(user_id_);
+	int64_t alliance_id = my_agency ? Database::GetAllianceIdForAgency(my_agency) : 0;
+	if (alliance_id == 0) return;
+	auto alliance = Database::GetAllianceInfo(alliance_id);
+	if (!alliance || alliance->owner_agency_id != my_agency) {
+		Logger::Log("agency", "[TCP] ALLIANCE_INVITE rejected: user %lld not alliance owner\n",
+			(long long)user_id_);
+		return;
+	}
+
+	// Resolve the target agency by its leader's player name.
+	int64_t target_agency = Database::GetAgencyIdByLeaderName(leader_name);
+	if (target_agency == 0 || target_agency == my_agency) {
+		Logger::Log("agency", "[TCP] ALLIANCE_INVITE: no other agency led by '%s'\n",
+			leader_name.c_str());
+		return;
+	}
+	if (Database::GetAllianceIdForAgency(target_agency) != 0) {
+		Logger::Log("agency", "[TCP] ALLIANCE_INVITE: target agency %lld already in an alliance\n",
+			(long long)target_agency);
+		return;
+	}
+
+	{
+		std::lock_guard<std::mutex> lock(pending_alliance_mutex_);
+		pending_alliance_invites_[target_agency] = alliance_id;
+	}
+	auto target = Database::GetAgencyInfo(target_agency);
+	int64_t target_user = target ? target->leader_user_id : 0;
+	// @@leader_name@@ in the popup = the inviting leader (me).
+	DeliverAllianceInvitation(target_user, alliance->name, player_name, alliance_id);
+}
+
+void TcpSession::handle_alliance_accept()
+{
+	int64_t my_agency = Database::GetAgencyIdForUser(user_id_);
+	if (my_agency == 0) return;
+
+	int64_t alliance_id = 0;
+	{
+		std::lock_guard<std::mutex> lock(pending_alliance_mutex_);
+		auto it = pending_alliance_invites_.find(my_agency);
+		if (it == pending_alliance_invites_.end()) {
+			Logger::Log("agency", "[TCP] ALLIANCE_ACCEPT: no pending invite for agency %lld\n",
+				(long long)my_agency);
+			return;
+		}
+		alliance_id = it->second;
+		pending_alliance_invites_.erase(it);
+	}
+
+	if (!Database::AddAgencyToAlliance(alliance_id, my_agency)) {
+		Logger::Log("agency", "[TCP] ALLIANCE_ACCEPT: AddAgencyToAlliance(%lld,%lld) failed\n",
+			(long long)alliance_id, (long long)my_agency);
+		return;
+	}
+	Logger::Log("agency", "[TCP] ALLIANCE_ACCEPT: agency %lld joined alliance %lld\n",
+		(long long)my_agency, (long long)alliance_id);
+	send_alliance_member_list_response();
+	// Everyone already in the alliance gains a member row — push it to them too.
+	for (int64_t uid : Database::GetAllianceMemberUserIds(alliance_id)) {
+		if (uid != user_id_) DeliverAgencyRefresh(uid);
+	}
+}
+
+bool TcpSession::DeliverAllianceInvitation(int64_t target_user_id,
+                                           const std::string& alliance_name,
+                                           const std::string& inviter_leader_name,
+                                           int64_t alliance_id)
+{
+	if (target_user_id <= 0) return false;
+	std::lock_guard<std::mutex> lock(sessions_mutex_);
+	for (auto& kv : g_sessions_) {
+		auto s = kv.second.lock();
+		if (s && s->user_id_ == target_user_id) {
+			s->send_alliance_invitation(alliance_name, inviter_leader_name, alliance_id);
+			return true;
+		}
+	}
+	Logger::Log("agency", "[TCP] DeliverAllianceInvitation: target user %lld not online\n",
+		(long long)target_user_id);
+	return false;
+}
+
+void TcpSession::send_alliance_invitation(const std::string& alliance_name,
+                                          const std::string& inviter_leader_name,
+                                          int64_t alliance_id)
+{
+	// The popup is a MSG_ID template + @@token@@ substitution (like team invites).
+	// MSG_ID 25111 = "Invitation from @@leader_name@@ to join alliance
+	// @@alliance_name@@" (asm_data_set_msg_translations). Tokens map by name:
+	// @@leader_name@@ -> LEADER_NAME, @@alliance_name@@ -> ALLIANCE_NAME.
+	std::vector<uint8_t> response;
+	uint16_t packet_type = GA_U::ALLIANCE_INVITATION;
+	uint16_t item_count = 4;
+	append(response, packet_type & 0xFF, packet_type >> 8);
+	append(response, item_count & 0xFF, item_count >> 8);
+	Write4B(response,     GA_T::MSG_ID,        25111);
+	WriteString(response, GA_T::LEADER_NAME,   inviter_leader_name);
+	WriteString(response, GA_T::ALLIANCE_NAME, alliance_name);
+	Write4B(response,     GA_T::ALLIANCE_ID,   (uint32_t)alliance_id);
+	Logger::Log("agency", "[TCP] send ALLIANCE_INVITATION alliance='%s' from '%s' to user=%lld\n",
+		alliance_name.c_str(), inviter_leader_name.c_str(), (long long)user_id_);
 	send_response(response);
 }
 

--- a/src/ControlServer/TcpSession/TcpSession.hpp
+++ b/src/ControlServer/TcpSession/TcpSession.hpp
@@ -546,6 +546,61 @@ private:
     void send_player_skills_response();
 
     void send_agency_get_roster_response();
+    void handle_agency_create(const PacketView& pkt);
+    // Leader disbands the agency (delete it + push the "no agency" reset).
+    void handle_agency_disband();
+    // Append the caller's agency (meta + DATA_SET_RANKS + DATA_SET_MEMBERS) to
+    // `response` as top-level fields. Returns the number of fields appended (0
+    // if the caller is not in an agency). Shared by roster + create responses.
+    int append_agency_payload(std::vector<uint8_t>& response);
+
+    void handle_agency_invite(const PacketView& pkt);
+    // AGENCY_PROMOTE / AGENCY_DEMOTE — target member by PLAYER_ID (= character_id).
+    void handle_agency_rank_change(const PacketView& pkt, bool promote);
+    // Kick a member (AGENCY_PLAYER_REMOVE, or AGENCY_REMOVE with someone else's id).
+    void handle_agency_kick(int64_t target_char);
+    // AGENCY_SET_NOTE — MOTD / description / per-member public+officer notes.
+    void handle_agency_set_note(const PacketView& pkt);
+    // AGENCY_UPDATE_RANKS — full rank-table replacement from the rank editor.
+    void handle_agency_update_ranks(const PacketView& pkt);
+    // AGENCY_UPDATE_RECRUITING — Recruiting tab listing text + the two flags.
+    void handle_agency_update_recruiting(const PacketView& pkt);
+    // AGENCY_SET_OWNER — Management tab "Transfer Leader".
+    void handle_agency_set_owner(const PacketView& pkt);
+    // Push "no agency" + "no alliance" to a live session that just lost its
+    // agency without asking (kick / someone else's disband).
+    static void DeliverAgencyRefresh(int64_t target_user_id);
+    void handle_agency_accept();
+    // Push an AGENCY_INVITATION popup to this session.
+    // Status/error line for agency actions (MSG_ID template + @@player_name@@).
+    void send_agency_message(uint32_t msg_id, const std::string& player_name_token);
+    void send_agency_invitation(const std::string& agency_name,
+                                const std::string& inviter_leader_name);
+    // Pending agency invites: invited user_id -> agency_id it was invited to.
+    static std::mutex pending_agency_mutex_;
+    static std::map<int64_t, int64_t> pending_agency_invites_;
+
+    void send_alliance_member_list_response();
+    void handle_alliance_create(const PacketView& pkt);
+    // Append the caller's alliance (meta + DATA_SET_AGENCIES) as top-level
+    // fields. Returns field count (0 if the caller's agency has no alliance).
+    int append_alliance_payload(std::vector<uint8_t>& response);
+    void handle_alliance_disband();
+    void handle_alliance_invite(const PacketView& pkt);
+    void handle_alliance_accept();
+    void handle_alliance_remove(const PacketView& pkt);
+    // Push an ALLIANCE_INVITATION popup to this session.
+    void send_alliance_invitation(const std::string& alliance_name,
+                                  const std::string& inviter_leader_name,
+                                  int64_t alliance_id);
+    // Deliver an alliance invitation to whichever live session owns target_user_id.
+    static bool DeliverAllianceInvitation(int64_t target_user_id,
+                                          const std::string& alliance_name,
+                                          const std::string& inviter_leader_name,
+                                          int64_t alliance_id);
+    // Pending alliance invites: target agency_id -> alliance_id it was invited to.
+    static std::mutex pending_alliance_mutex_;
+    static std::map<int64_t, int64_t> pending_alliance_invites_;
 
     // QUERY_PLAYERS (0x0152) — player search from the Team menu / player
     // search scene. Echoes CALLER_ID (the client TgDataSet's GObjObjects

--- a/src/ControlServer/TeamService/TeamService.cpp
+++ b/src/ControlServer/TeamService/TeamService.cpp
@@ -6,6 +6,7 @@
 #include "src/ControlServer/MatchmakingService/MatchmakingService.hpp"
 #include "src/ControlServer/TcpSession/TcpSession.hpp"
 #include "src/ControlServer/Constants/GameTypes.h"
+#include "src/ControlServer/Database/Database.hpp"
 #include "src/ControlServer/Logger.hpp"
 
 #include <algorithm>
@@ -77,6 +78,7 @@ TeamRoster TeamService::BuildRosterLocked(const Team& team) {
     TeamRoster roster;
     roster.team_id = team.id;
     roster.team_mode = 1;
+    const auto affiliations = Database::GetAffiliationsByCharacter();
     for (const auto& m : team.members) {
         if (m.session_guid == team.leader_guid)
             roster.leader_character_id = m.character_id;
@@ -88,6 +90,10 @@ TeamRoster TeamService::BuildRosterLocked(const Team& team) {
         row.class_msg_id    = ClassMsgIdFor(m.profile_id);
         row.map_name_msg_id = MapMsgIdForSession(m.session_guid);
         row.offline         = m.offline;
+        if (auto a = affiliations.find(m.character_id); a != affiliations.end()) {
+            row.agency_name   = a->second.agency_name;
+            row.alliance_name = a->second.alliance_name;
+        }
         roster.rows.push_back(std::move(row));
     }
     return roster;


### PR DESCRIPTION
Agency & Alliance management: invites, ranks, permissions, presence

Background

Agencies (guilds) and alliances (groups of agencies) are a persistent subsystem the retail client drives over the ControlServer TCP connection — the same transport as login, team and whisper. The client natives were never stubbed: it genuinely emits every opcode when you press O. The server simply had no handlers and no schema, so most of the Agency panel silently did nothing.

Earlier work landed the foundations (create/disband agency, create/disband alliance, alliance invite/accept/kick/leave, the affiliated-agencies list). This PR finishes the agency side and fixes several bugs that only became visible once agencies could hold more than one member.

All of it is server-side. The client is unmodified retail.

What was broken

Most of the Agency panel was inert. Invite, promote, demote, kick, transfer leader, the rank editor, the recruiting tab and the notes boxes all sent packets into the void — no handler existed. Three of those opcodes weren't even identified: they showed up in logs as Received unknown packet type: 00CA / 00C6 / 0194.

Notes looked broken, but the writes were fine all along. AGENCY_SET_NOTE persisted public and officer messages correctly from the first attempt — the roster response just never sent them back down, so the boxes stayed empty and the feature looked dead. The bug was in the reply, not the write.

A non-leader could not leave their agency. handle_agency_disband rejected anyone who wasn't the leader outright, so a member pressing Leave stayed put. This was invisible before this PR because there was no way to get a second member into an agency.

Panels went stale until relog. Every mutation pushed an update only to the acting session. The agency panel happened to self-heal because its roster poll always runs, but the Alliance tab only refreshes while it's open — so a kicked player kept seeing an alliance they were no longer in, and members of a disbanded alliance kept seeing it until they restarted the client.

Offline members showed "Location: Unknown" once presence was wired, because a 0 map id gets localized to that string.

Fixes

Membership — invite (0xB5 → 0xB6 popup → accept 0xB7 / decline 0xB8), promote (0xBB), demote (0xBC), kick (0xBF), leave, and transfer leader. The invite popup turned out not to be a data receiver like the roster: it's the HUD dialog (TgUIPrimaryHUD_DialogQuery, type DialogInviteToAgency), the same widget team invites use. Transfer leader was the unidentified 0x00C6 = AGENCY_SET_OWNER, which sends the target's id rather than the typed name.

Ranks and permissions — the rank editor (0xCB) sends every rank row as one replacement set, so rename, add, delete and permission edits all arrive together. ReplaceAgencyRanks applies it in a single transaction, refuses any set that would leave the agency without a rank_level 0 rank, and moves members off deleted ranks to the bottom rank.

PERMISSION_FLAGS bits, recovered by submitting one checkbox at a time and diffing the payloads:

- `0x40` — Promote Players
- `0x80` — Demote Players
- `0x100` — Invite Players
- `0x200` — Remove/Kick Players
- `0x400` — Edit Description
- `0x800` — Edit Public Message
- `0x1000` — Edit Officer Message
- `0x2000` — View Officer Message
- `0x8000` — Edit MOTD
- `0x20000` — Allow Facility Management
- `0x40000` — Allow Inventory Removal

These are now enforced server-side on every action, not merely reflected in a hidden button. Officer message text is also withheld from the wire for ranks lacking View Officer Message, so it's a real permission rather than a client-side hide.

Content — MOTD, description and per-member public/officer notes (0xC4, one opcode carrying four different edits distinguished by tag), plus the recruiting listing and its two flags (0xCA).

Status and error messages — the six invite-flow templates the client already ships ("is already a member", "is a member of another agency", "the character was not found", etc.) are now sent. The carrier is an echo on the request opcode itself, which renders in the Invite tab label, a modal dialog, and the chat log from a single send.

Presence — member rows now carry real class, online status and location. Two client details mattered: the online flag is stored inverted (eMemberStatus = (flag == 0), where ONLINE = 0), and the location field must be omitted entirely when offline — an absent field leaves the string empty, while a 0 value localizes to "Unknown".

Live push fan-out — the stale-panel bug is fixed at its root with DeliverAgencyRefresh(user_id), which pushes both the roster and the alliance list to another live session. It's wired into every mutation: agency kick, disband, leave, invite-accept, and alliance create/accept/disband/remove. For deletes, the affected user ids are collected before the DELETE — afterwards the membership rows are gone and those players are unreachable.

Verified as not fixable

Two UI gaps were investigated at the binary and confirmed to have no server-side path, rather than being left as open questions:

- "Leader: Unknown" in the alliance detail. The struct has an sLeaderName field, but the row parser reads exactly four tags and none is a name, and the enclosing receiver reads no name tag either — so the field keeps its empty default.
- Joined / Win-Loss / Last Online in the member detail. The labels exist as widgets, but the client's per-member struct has no date or win-loss field at all, so no payload could ever reach them. ga_agency_members.joined_at is populated and has nowhere to go.

LEVEL remains 50 because no level is tracked anywhere on this server — GSC_CHARACTER_LIST and the player search both hardcode it. Making the agency panel differ would just be a third place telling the same lie.

Testing

Everything was exercised live with two accounts: invite, accept, decline, promote, demote, kick, leave, disband, transfer leader, MOTD, description, public and officer notes, recruiting submit, rank checkbox edits, rank add and delete. Permission enforcement was confirmed both ways — an Officer holding Invite could invite, and was correctly refused on Edit Description. Presence was checked with a member online in a different map and again after logout. The error lines were confirmed for already-a-member, member-of-another-agency and character-not-found. The stale-panel fixes were verified with the Alliance tab open on the affected client at the moment of the kick and disband.

DB query rate

The roster is polled every 2 seconds per online client, so anything per-member in that path multiplies fast. Wiring presence initially introduced exactly that, and a review caught two problems:

- GetAgencyInfo looked up each member's class with its own query — O(N) round trips per poll. A 40-member agency meant 40 extra queries every 2 seconds, per online member. This is now a LEFT JOIN ga_characters inside the existing members query.
- Online detection used InstanceRegistry::GetActiveSearchablePlayers(), a five-table join that also pulls user and player names the roster already has. Replaced with GetOnlineAgencyMemberMaps(agency_id): one query, scoped to that agency, returning character_id → map_name.

The result is a flat 5 queries per roster poll regardless of member count — agency id, meta, ranks, members, online map.

No cache layer was added, deliberately. A cache would buy nothing measured here and would reintroduce precisely the stale-data class of bug this PR spent most of its effort eliminating. Instead there's a new dbperf log channel: a sqlite3_trace_v2 hook reporting statements per second across the whole server, including code we didn't write. That way the next optimisation starts from a number rather than a hunch. It's worth pointing at the friends/ignore path too.

Also removed: the per-poll log lines in the roster and alliance responses, which fired every 2 and 5 seconds per client and would have buried everything else in the log, plus the raw packet dumps used during protocol discovery.

Documentation: agencies-alliances.md and the CLAUDE.md index

This PR adds agencies-alliances.md at the repo root. It began as a working handoff and has been rewritten as a permanent reference, because most of its content is expensive to obtain and impossible to recover from the code alone:

- The reversed wire protocol — framing, per-tag encodings, every agency and alliance opcode, and the exact field shape each client receiver expects. Several of these are counter-intuitive traps that already cost test cycles: the mandatory ROSTER_FLAGS gate bit without which the client silently ignores an entire payload; agency and rank names travelling as NAME rather than the obvious AGENCY_NAME/RANK_NAME; leader identity being rank level 0 rather than rank id 0; the affiliated-agencies list being gated by a flag bit while the agency member list is not; and date fields whose representation differs per client formatter.
- The permission bit table, which took a dozen single-checkbox submits to derive and cannot be inferred from anything in the repo.
- The negative findings — "Leader: Unknown" and the empty detail-panel labels — with the specific function addresses proving it. Without this, the next developer reasonably assumes it's a server gap and spends a day rediscovering that it isn't.
- The Ghidra-over-HTTP method used throughout, so the next investigation can pick up the same tooling immediately.

The file was renamed from handoff.md and stripped of session framing (status dates, resume points, and a build/test section duplicating CLAUDE.md) so it reads as durable documentation rather than a snapshot. The name now matches its siblings — bots.md, deployables.md, equip-slots.md.

CLAUDE.md was updated to add the file to its list of technical docs. That list is the mechanism by which anyone (human or AI assistant) is told to read the relevant document before working in an area — a doc that isn't in the index effectively doesn't exist. One line there is what makes the rest of the file discoverable when agency and alliance chat gets picked up on its own branch.

Related to:  https://discord.com/channels/994691794627461211/1528060092908441680