### PR TITLE
Destroy a deployable / pet when it is swapped off the loadout

### DIFF
--- a/src/GameServer/IpDrv/NetConnection/Cleanup/NetConnection__Cleanup.cpp
+++ b/src/GameServer/IpDrv/NetConnection/Cleanup/NetConnection__Cleanup.cpp
@@ -9,6 +9,7 @@
 #include "lib/nlohmann/json.hpp"
 #include "src/GameServer/Storage/PlayerRegistry/PlayerRegistry.hpp"
 #include "src/GameServer/Stats/MatchStats.hpp"
+#include "src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.hpp"
 #include "src/Utils/Logger/Logger.hpp"
 
 void __fastcall NetConnection__Cleanup::Call(UNetConnection* Connection) {
@@ -84,6 +85,13 @@ void __fastcall NetConnection__Cleanup::Call(UNetConnection* Connection) {
 	// leaving a dangling key would cause those routes to hit free'd memory
 	// on the next inventory change.
 	if (pawn) {
+		// Leaving the mission takes your live deployables/pets with you —
+		// otherwise a player parks a power/med station in a PvE boss room,
+		// disconnects or swaps character, and the station keeps working for
+		// the team. Same teardown team-change and profile-switch already do.
+		if (!pawn->bDeleteMe) {
+			TgPawn__KillDeployables::KillAllOwned((ATgPawn*)pawn);
+		}
 		GPawnSessions.erase((ATgPawn*)pawn);
 	}
 

--- a/src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.cpp
+++ b/src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.cpp
@@ -139,3 +139,35 @@ void TgPawn__KillDeployables::KillAllOwned(ATgPawn* Pawn) {
 
 	Pawn->s_SelfDeployableList.Count = 0;
 }
+
+// Swapping a device off the loadout must take its live output with it — a
+// power station left standing after its device is gone has no owner device to
+// govern it. Same teardown as KillAllOwned, scoped to one device.
+void TgPawn__KillDeployables::KillFromDevice(ATgPawn* Pawn, ATgDevice* Device) {
+	if (!Pawn || !Device) return;
+
+	AWorldInfo* wi = Pawn->WorldInfo;
+	if (!wi || !wi->GRI) return;
+	ATgRepInfo_Game* gri = (ATgRepInfo_Game*)wi->GRI;
+	const int invId = Device->r_nDeviceInstanceId;
+
+	for (int i = gri->m_Deployables.Count - 1; i >= 0; --i) {
+		ATgDeployable* dep = gri->m_Deployables.Data[i];
+		if (!dep || dep->m_bInDestroyedState) continue;
+		if (dep->r_nDeployableId == 36) continue; // beacon: team resource
+		// invId also matches deployables placed by an earlier actor for the same
+		// inventory item (device actors are respawned on death / profile switch).
+		if (dep->r_Owner != Device &&
+		    !(dep->r_Owner && dep->r_Owner->r_nDeviceInstanceId == invId)) continue;
+		DeployableClassify::DispatchDestroyIt(dep, 0);
+	}
+
+	// Pet pawns (turrets, drones) carry their spawning device's instance id.
+	for (APawn* p = wi->PawnList; p != nullptr; p = p->NextPawn) {
+		if (p == (APawn*)Pawn || p->Health <= 0 || p->bDeleteMe) continue;
+		ATgPawn* pet = (ATgPawn*)p;
+		if (pet->r_Owner != Pawn) continue;
+		if (pet->s_nSpawnerDeviceInstId != invId) continue;
+		p->eventKilledBy((APawn*)Pawn);
+	}
+}

--- a/src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.hpp
+++ b/src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.hpp
@@ -18,4 +18,9 @@ public:
 	// (catches deployed bot pawns like the Grizzly drone). Use this instead of
 	// Call(bAll=1) on team-change / profile-switch paths.
 	static void KillAllOwned(ATgPawn* Pawn);
+
+	// Destroy only what one equipped device produced — its live deployables
+	// (dep->r_Owner == Device) and its pet pawns (s_nSpawnerDeviceInstId ==
+	// device invId). Call BEFORE Inventory::Unequip destroys the device actor.
+	static void KillFromDevice(ATgPawn* Pawn, ATgDevice* Device);
 };

--- a/src/GameServer/TgGame/TgPlayerController/ServerAcceptNewProfileFromEquipScreen/TgPlayerController__ServerAcceptNewProfileFromEquipScreen.cpp
+++ b/src/GameServer/TgGame/TgPlayerController/ServerAcceptNewProfileFromEquipScreen/TgPlayerController__ServerAcceptNewProfileFromEquipScreen.cpp
@@ -4,6 +4,7 @@
 #include "src/GameServer/Storage/PlayerRegistry/PlayerRegistry.hpp"
 #include "src/GameServer/Inventory/Inventory.hpp"
 #include "src/GameServer/Cosmetics/CosmeticEquip.hpp"
+#include "src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.hpp"
 #include "src/Database/Database.hpp"
 #include "src/IpcClient/IpcClient.hpp"
 #include "src/Shared/IpcProtocol.hpp"
@@ -227,6 +228,7 @@ void __fastcall TgPlayerController__ServerAcceptNewProfileFromEquipScreen::Call(
 			-1, &delDev, nullptr);
 		for (int slot : kClearableDeviceSlots) {
 			if (DeviceArray.SlotIndices[slot] != 0) continue;
+			TgPawn__KillDeployables::KillFromDevice(Pawn, Pawn->m_EquippedDevices[slot]);
 			Inventory::Unequip(Pawn, slot);
 			if (delDev) {
 				sqlite3_reset(delDev);
@@ -275,6 +277,8 @@ void __fastcall TgPlayerController__ServerAcceptNewProfileFromEquipScreen::Call(
 		ATgDevice* cur = Pawn->m_EquippedDevices[slot];
 		if (cur == nullptr) continue;
 		if (cur->r_nDeviceInstanceId == r.newInvId) continue;  // same item, leave alone (Equip will short-circuit)
+		// The outgoing device's live turrets/stations/drones go with it.
+		TgPawn__KillDeployables::KillFromDevice(Pawn, cur);
 		Inventory::Unequip(Pawn, slot);
 	}
 


### PR DESCRIPTION
### Bug

Team change and profile switch already destroy a player's live deployables (`KillAllOwned`), but swapping a single device off the loadout in the equip screen did not. Equipping a sensor over a deployed power station left the station standing with no owning device — same for turrets, drones and deconstructors.

### Fix

New `TgPawn__KillDeployables::KillFromDevice(Pawn, Device)`: the per-device counterpart to `KillAllOwned`. It destroys

- deployables in `gri->m_Deployables` whose `r_Owner` is that device (or an earlier device actor with the same `r_nDeviceInstanceId`, since device actors are respawned on death/profile switch), skipping beacons (id 36 — team resource), via `DeployableClassify::DispatchDestroyIt`;
- pet pawns in `WorldInfo->PawnList` with `r_Owner == Pawn && s_nSpawnerDeviceInstId == invId`, via `eventKilledBy` — same teardown `KillAllOwned` uses.

Called from both unequip sites in `ServerAcceptNewProfileFromEquipScreen` (explicit slot clear and the swap pre-pass), before `Inventory::Unequip` destroys the dev *not* hooked into `Inventory::Unequip`itself: `NonPersistRemoveDevice` also routes there on beacon placement and would destroy the beacon that was just placed.

### Testing

Deployed a turret, a station and a drone, went into spawn room and swapped them off 1 by 1 - Destroyed 1 by 1
Same while taking them away and not replacing with other off hand, they get killed when inventory window is closed.


Related to: https://discord.com/channels/994691794627461211/1528580030526132304