### PR TITLE
Populate r_DeviceStats so the Device Stats tab isn't empty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ SOURCE_FILES= \
 			  $(SRC_DIR)/GameServer/Storage/UserPreferences/UserPreferences.cpp \
 			  $(SRC_DIR)/GameServer/Stats/StatsCore.cpp \
 			  $(SRC_DIR)/GameServer/Stats/MatchStats.cpp \
+			  $(SRC_DIR)/GameServer/Stats/DeviceStats.cpp \
 			  $(SRC_DIR)/GameServer/IpDrv/ClientConnection/SendMarshal/ClientConnection__SendMarshal.cpp \
 			  $(SRC_DIR)/GameServer/IpDrv/NetConnection/LowLevelSend/NetConnection__LowLevelSend.cpp \
 			  $(SRC_DIR)/GameServer/Engine/NetConnection/SendPackageMap/NetConnection__SendPackageMap.cpp \

--- a/src/GameServer/Stats/DeviceStats.cpp
+++ b/src/GameServer/Stats/DeviceStats.cpp
@@ -1,0 +1,133 @@
+#include "src/GameServer/Stats/DeviceStats.hpp"
+#include "src/GameServer/Engine/World/GetWorldInfo/World__GetWorldInfo.hpp"
+#include "src/GameServer/Globals.hpp"
+#include "src/Database/Database.hpp"
+
+#include "sqlite3.h"
+
+#include <unordered_map>
+
+namespace {
+
+constexpr int kNumRows   = 9;   // ATgRepInfo_Player::r_DeviceStats[9]
+constexpr int kFieldDPM  = 5;
+constexpr int kFieldHPM  = 6;
+
+// Seconds since the mission timer started. Falls back to level time when the
+// timer hasn't been armed (warmup, home maps) so DPM never divides by zero.
+float MissionElapsedSeconds() {
+	if (Globals::Get().GWorld == nullptr) return 1.0f;
+	AWorldInfo* WI = World__GetWorldInfo::CallOriginal((UWorld*)Globals::Get().GWorld, nullptr, 0);
+	if (WI == nullptr) return 1.0f;
+
+	float elapsed = WI->TimeSeconds;
+	ATgGame* Game = (ATgGame*)Globals::Get().GGameInfo;
+	if (Game != nullptr && Game->s_fMissionTimerStartedAt > 0.0f) {
+		elapsed = WI->TimeSeconds - Game->s_fMissionTimerStartedAt;
+	}
+	return elapsed < 1.0f ? 1.0f : elapsed;
+}
+
+std::unordered_map<int, int> g_modeToDevice;
+bool g_modeMapLoaded = false;
+
+std::unordered_map<int, int> g_deployableToDevice;
+bool g_deployableMapLoaded = false;
+
+}  // namespace
+
+int DeviceStats::DeviceIdFromModeId(int deviceModeId) {
+	if (deviceModeId <= 0) return 0;
+
+	if (!g_modeMapLoaded) {
+		g_modeMapLoaded = true;
+		sqlite3* db = Database::GetConnection();
+		if (db != nullptr) {
+			sqlite3_stmt* stmt = nullptr;
+			const char* sql =
+				"SELECT device_mode_id, device_id "
+				"FROM asm_data_set_devices_data_set_device_modes";
+			if (sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr) == SQLITE_OK) {
+				while (sqlite3_step(stmt) == SQLITE_ROW) {
+					g_modeToDevice[sqlite3_column_int(stmt, 0)] =
+						sqlite3_column_int(stmt, 1);
+				}
+			}
+			sqlite3_finalize(stmt);
+		}
+	}
+
+	auto it = g_modeToDevice.find(deviceModeId);
+	return it == g_modeToDevice.end() ? 0 : it->second;
+}
+
+int DeviceStats::DeviceIdFromDeployableId(int deployableId) {
+	if (deployableId <= 0) return 0;
+
+	if (!g_deployableMapLoaded) {
+		g_deployableMapLoaded = true;
+		sqlite3* db = Database::GetConnection();
+		if (db != nullptr) {
+			// Both spawn routes: the mode's own deployable_id, and the
+			// deployable its projectile spawns (mines, spider grenades). The
+			// projectile join must exclude device_projectile_id = 0 or every
+			// projectile-less mode matches every projectile-less row.
+			// slot_used_value_id filter keeps bot/test devices out, so the
+			// counts below only see player-equippable spawners.
+			const char* sql =
+				"SELECT dep.deployable_id, MIN(m.device_id), COUNT(DISTINCT m.device_id) "
+				"FROM asm_data_set_devices_data_set_device_modes m "
+				"JOIN asm_data_set_devices d ON d.device_id = m.device_id "
+				"LEFT JOIN asm_data_set_projectiles p "
+				"  ON p.device_projectile_id = m.device_projectile_id "
+				"  AND m.device_projectile_id != 0 "
+				"JOIN asm_data_set_deployables dep "
+				"  ON (m.deployable_id != 0 AND dep.deployable_id = m.deployable_id) "
+				"  OR (p.spawn_deployable_id != 0 AND dep.deployable_id = p.spawn_deployable_id) "
+				"WHERE d.slot_used_value_id IN (388,389,390,393,394,476,741,806,981,1482) "
+				"GROUP BY dep.deployable_id";
+			sqlite3_stmt* stmt = nullptr;
+			if (sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr) == SQLITE_OK) {
+				while (sqlite3_step(stmt) == SQLITE_ROW) {
+					if (sqlite3_column_int(stmt, 2) != 1) continue;  // ambiguous
+					g_deployableToDevice[sqlite3_column_int(stmt, 0)] =
+						sqlite3_column_int(stmt, 1);
+				}
+			}
+			sqlite3_finalize(stmt);
+		}
+	}
+
+	auto it = g_deployableToDevice.find(deployableId);
+	return it == g_deployableToDevice.end() ? 0 : it->second;
+}
+
+void DeviceStats::Credit(ATgPawn* CreditPawn, int deviceId, int field, int amount) {
+	if (CreditPawn == nullptr || deviceId <= 0 || amount <= 0) return;
+
+	ATgRepInfo_Player* PRI = (ATgRepInfo_Player*)CreditPawn->PlayerReplicationInfo;
+	if (PRI == nullptr) return;
+
+	FDeviceStatInfo* row = nullptr;
+	for (int i = 0; i < kNumRows; i++) {
+		if (PRI->r_DeviceStats[i].Stats[kId] == deviceId) { row = &PRI->r_DeviceStats[i]; break; }
+	}
+	if (row == nullptr) {
+		for (int i = 0; i < kNumRows; i++) {
+			if (PRI->r_DeviceStats[i].Stats[kId] == 0) {
+				row = &PRI->r_DeviceStats[i];
+				row->Stats[kId] = deviceId;
+				break;
+			}
+		}
+	}
+	// ponytail: 10th+ distinct device in one match is dropped, not evicted —
+	// the client only renders 8 rows anyway. Add LRU eviction if it matters.
+	if (row == nullptr) return;
+
+	row->Stats[field] += amount;
+
+	const float minutes = MissionElapsedSeconds() / 60.0f;
+	row->Stats[kFieldDPM] = (int)(row->Stats[kDamage]  / minutes);
+	row->Stats[kFieldHPM] = (int)(row->Stats[kHealing] / minutes);
+}

--- a/src/GameServer/Stats/DeviceStats.hpp
+++ b/src/GameServer/Stats/DeviceStats.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "src/pch.hpp"
+
+// Per-device stats for the end-of-mission "Device Stats" tab.
+//
+// The tab reads ATgRepInfo_Player::r_DeviceStats[9] (owner-only replication,
+// already wired in GetOptimizedRepListV2). Client row builder
+// (UTgUIDeviceStats vtable +0x130 → 0x11463870) walks the first 8 entries,
+// hides any whose Stats[DS_ID] <= 0, resolves Stats[DS_ID] against the asm
+// device table for the name + icon, and prints Stats[1..6] verbatim. So the
+// server owns every number, including DPM/HPM.
+//
+// Nothing in the shipped binary writes r_DeviceStats — the crediting natives
+// are stripped, which is why the tab is empty.
+namespace DeviceStats {
+
+// Indices into FDeviceStatInfo::Stats (TgRepInfo_Player.DEVICE_STATS).
+constexpr int kId          = 0;
+constexpr int kDamage      = 1;
+constexpr int kHealing     = 2;
+constexpr int kPlayerKills = 3;
+constexpr int kBotKills    = 4;
+
+// Add `amount` to `field` on CreditPawn's row for `deviceId`, claiming a free
+// row on first use. No-ops on a null pawn/PRI, deviceId <= 0, or when all 9
+// rows are already claimed by other devices.
+void Credit(ATgPawn* CreditPawn, int deviceId, int field, int amount);
+
+// asm_data_set_devices_data_set_device_modes: device_mode_id → device_id.
+// Loaded once, cached. Returns 0 when unknown.
+int DeviceIdFromModeId(int deviceModeId);
+
+// Deployable → the player-equippable device that places it (directly or via
+// its projectile). Loaded once, cached. Returns 0 when unknown or when more
+// than one equippable device spawns the same deployable (mines: Standard Mine
+// vs Archer's Folly — no way to tell them apart from the deployable alone).
+int DeviceIdFromDeployableId(int deployableId);
+
+}  // namespace DeviceStats

--- a/src/GameServer/TgGame/TgEffect/TrackStats/TgEffect__TrackStats.cpp
+++ b/src/GameServer/TgGame/TgEffect/TrackStats/TgEffect__TrackStats.cpp
@@ -16,6 +16,7 @@
 #include "src/GameServer/TgGame/TgPawn/TrackKilledBot/TgPawn__TrackKilledBot.hpp"
 #include "src/GameServer/TgGame/Morale/MoraleCredit.hpp"
 #include "src/GameServer/Stats/MatchStats.hpp"
+#include "src/GameServer/Stats/DeviceStats.hpp"
 #include "src/Utils/Logger/Logger.hpp"
 #include <string>
 
@@ -305,6 +306,38 @@ void __fastcall TgEffect__TrackStats::Call(UTgEffect* /*Effect*/, void* /*edx*/,
 	ATgPawn* damageCreditPawn = Instigator;
 	if (Instigator->r_Owner != nullptr) damageCreditPawn = Instigator->r_Owner;
 
+	// Device that caused this event — same fire-mode reference the kill
+	// attribution below uses (FImpactInfo @ 0x54), resolved to an asm device
+	// id. Drives the end-of-mission Device Stats tab.
+	int creditDeviceId = ResolveDeviceIdFromFireMode((UObject*)Impact.dw[0x54 / 4]);
+
+	// Deployable-fired (Medical Station heal, mine blast, force wall): the
+	// fire mode's m_Owner is the ATgDeployable itself, not an ATgDevice, so
+	// the helper above returns 0 and the event would go uncredited. Map the
+	// deployable back to the device the player equipped to place it.
+	if (creditDeviceId == 0) {
+		UTgDeviceFire* fireMode = (UTgDeviceFire*)Impact.dw[0x54 / 4];
+		AActor* fmOwner = fireMode ? fireMode->m_Owner : nullptr;
+		if (fmOwner != nullptr &&
+		    ObjectClassCache::ClassNameContains(fmOwner, "TgDeployable")) {
+			creditDeviceId = DeviceStats::DeviceIdFromDeployableId(
+				((ATgDeployable*)fmOwner)->r_nDeployableId);
+		}
+	}
+
+	// Pet → spawning device, mirroring the pet → owner pawn resolution above.
+	// A pet turret shoots with its OWN internal weapon device ("Personal
+	// Turret Laser", "Flame Turret Fire"): a data row that never appears in
+	// any UI and carries icon_id = 0, so the stats tab would show the GA
+	// placeholder icon. Credit the device the player actually equipped
+	// ("Personal Turret", "Flame Turret") instead — s_nSpawnerDeviceModeId
+	// carries the fire mode that spawned the pet.
+	if (Instigator->r_Owner != nullptr && Instigator->s_nSpawnerDeviceModeId > 0) {
+		const int spawnerDeviceId =
+			DeviceStats::DeviceIdFromModeId(Instigator->s_nSpawnerDeviceModeId);
+		if (spawnerDeviceId > 0) creditDeviceId = spawnerDeviceId;
+	}
+
 	// ===== Rolling damager history for assist credit =====
 	// UC's UpdateDamagers native is stripped (no UC caller). Without
 	// rotation, m_SecondToLastDamager stays null forever and TrackKill can
@@ -467,6 +500,14 @@ void __fastcall TgEffect__TrackStats::Call(UTgEffect* /*Effect*/, void* /*edx*/,
 			if (bIsEnemy) {
 				TgPawn__TrackKill::Call(Victim, nullptr, DamagerPawn);
 
+				// creditDeviceId, not killerDeviceId: same fire mode, but
+				// pet→spawning-device resolved (see above).
+				DeviceStats::Credit(CreditPawn, creditDeviceId,
+				                    IsRealPlayer(Victim->Controller)
+				                        ? DeviceStats::kPlayerKills
+				                        : DeviceStats::kBotKills,
+				                    1);
+
 				// Match event: scoreboard-parity KILL (+assists). Team-kills
 				// stay killer-less — the victim's pending DEATH covers them.
 				MatchStats::OnKill(CreditPawn, isPetKill ? DamagerPawn : nullptr,
@@ -564,6 +605,8 @@ void __fastcall TgEffect__TrackStats::Call(UTgEffect* /*Effect*/, void* /*edx*/,
 		if (bIsEnemy && targetIsDeployable && targetDeployable->r_nHealth <= 0 &&
 		    magnitude > 0.0f) {
 			TgPawn__TrackKilledBot::Call(damageCreditPawn, nullptr, 0);
+			DeviceStats::Credit(damageCreditPawn, creditDeviceId,
+			                    DeviceStats::kBotKills, 1);
 
 			// Match event: DEPLOYABLE_DESTROYED / BEACON_DESTROYED with
 			// deployer attribution (design 2026-06-12).
@@ -646,6 +689,16 @@ void __fastcall TgEffect__TrackStats::Call(UTgEffect* /*Effect*/, void* /*edx*/,
 				TgPawn__TrackBotHealing::Call(damageCreditPawn, nullptr,
 					0, magnitude, fMissingHealth, 0);
 			}
+
+			// Same overheal exclusion the Track*Healing bodies apply to
+			// STYPE_HEALING — only actually-restored HP counts.
+			if (targetIsPawn || targetIsDeployable) {
+				const float missing = fMissingHealth < 0.0f ? 0.0f : fMissingHealth;
+				float effectiveHeal = magnitude;
+				if (effectiveHeal > missing) effectiveHeal = missing;
+				DeviceStats::Credit(damageCreditPawn, creditDeviceId,
+				                    DeviceStats::kHealing, (int)effectiveHeal);
+			}
 		}
 	}
 	// ===== end kill attribution =====
@@ -677,9 +730,13 @@ void __fastcall TgEffect__TrackStats::Call(UTgEffect* /*Effect*/, void* /*edx*/,
 				TgPawn__TrackDamagedPlayer::Call(damageCreditPawn, nullptr,
 					targetPawn, 0, (int)magnitude);
 			}
+			DeviceStats::Credit(damageCreditPawn, creditDeviceId,
+			                    DeviceStats::kDamage, (int)magnitude);
 		} else if (targetIsDeployable) {
 			TgPawn__TrackDamagedBot::Call(damageCreditPawn, nullptr,
 				nullptr, 0, (int)magnitude);
+			DeviceStats::Credit(damageCreditPawn, creditDeviceId,
+			                    DeviceStats::kDamage, (int)magnitude);
 		}
 	}
 


### PR DESCRIPTION
### Bug

The end-of-mission screen's **Device Stats** tab is always empty. Summary and Mission Stats work.

Nothing on the server ever writes `ATgRepInfo_Player::r_DeviceStats[9]` — the natives that credited it were stripped from the shipped binary, the same gap the existing `r_Scores` `Track*` hooks fill for the scoreboard. Replication for the array was already wired (`GetOptimizedRepListV2.cpp`, owner-only per the UC `bNetOwner` block), so the array simply arrived all-zero.

The client side is intact and defines the contract. `UTgUIDeviceStats::TickTgUIScene` (vtable `0x1188a580`+0x130 → row builder `0x11463870`) reads `GetMyPRI() + 0x4C8`, walks 8 rows of stride 0x2C, and **hides any row whose `Stats[DS_ID] <= 0`** — hence a blank tab. `Stats[DS_ID]` is an asm device id, looked up in the device table for the row's name (+0x1c) and icon (+0x50); `Stats[1..6]` are printed verbatim, so **DPM/HPM are server-computed**, not derived on the client.

### Fix

- New `src/GameServer/Stats/DeviceStats.{hpp,cpp}`: `Credit(pawn, deviceId, field, amount)` finds-or-claims one of the 9 rows for that device, accumulates the field, and recomputes DPM/HPM from `WorldInfo.TimeSeconds - ATgGame::s_fMissionTimerStartedAt`.
- `TgEffect__TrackStats` resolves the causing device once from the impact fire-mode reference (reusing the existing `ResolveDeviceIdFromFireMode`, the same source kill attribution already uses) and credits at the four existing stat sites: damage (pawn + deployable), healing (overheal excluded, matching STYPE_HEALING), kills (player vs bot), and deployable destroyed.
- Pet damage is attributed to the **spawning** device, not the pet's internal weapon. A pet turret/drone fires its own weapon device ("Personal Turret Laser", "Flame Turret Fire", "GRIZZLY Machine Gun") — data rows that never appear in any UI and mostly carry `icon_id = 0`, which rendered as the GA placeholder icon. `s_nSpawnerDeviceModeId` on the pet maps back through `asm_data_set_devices_data_set_device_modes` to the device the player equipped ("Personal Turret", "Flame Turret", "Grizzly Drone"), which has a real icon. This mirrors the pet→owner pawn resolution the credit path already does.

- Deployable-placed devices (Medical Station, Force Wall, Sensor, Power Station, Jockey's Friend) were credited to nothing at all: a deployable's fire mode has `m_Owner` = the `ATgDeployable`, not an `ATgDevice`, so the device resolver returned 0. `DeviceIdFromDeployableId` maps `r_nDeployableId` back to the placing device. Deployables spawned by more than one equippable device (mines: Standard Mine vs Archer's Folly) are left unmapped rather than guessed.
Rows update live, so the mid-game TAB overlay's Device Stats tab fills in during play as well as on the end screen. Owner-only replication means each player sees only their own devices — original design.


**Not covered:** rejoin/stint banking of device rows (`MatchStats` banks `r_Scores` only), and eviction past 9 distinct devices in one match (the client renders 8). DPM/HPM update on stat events rather than on a clock tick. The pet resolution keys off `s_nSpawnerDeviceModeId`, which is set on pet bots; a turret spawned as an `ATgDeployable` instead of a pet pawn would still report its internal device.


Related to:  https://discord.com/channels/994691794627461211/1528579739600818357