### PR TITLE
Fix: face spawning players the way their chosen player start points

### DIFF
--- a/src/GameServer/TgGame/TgGame/SpawnPlayerCharacter/TgGame__SpawnPlayerCharacter.cpp
+++ b/src/GameServer/TgGame/TgGame/SpawnPlayerCharacter/TgGame__SpawnPlayerCharacter.cpp
@@ -1,5 +1,6 @@
 #include "src/GameServer/TgGame/TgGame/SpawnPlayerCharacter/TgGame__SpawnPlayerCharacter.hpp"
 #include "src/GameServer/TgGame/TgGame/SpawnBotById/TgGame__SpawnBotById.hpp"
+#include "src/GameServer/TgGame/TgGame/TgFindPlayerStart/TgGame__TgFindPlayerStart.hpp"
 #include "src/GameServer/Inventory/Inventory.hpp"
 #include "src/GameServer/Cosmetics/CosmeticEquip.hpp"
 #include "src/GameServer/Constants/EquipSlot.hpp"
@@ -252,7 +253,22 @@ ATgPawn_Character* __fastcall TgGame__SpawnPlayerCharacter::Call(ATgGame* Game, 
 	// nPendingBotId = profileId so InitializeDefaultProps loads the correct class stats from DB.
 	// For player classes, bot_id == profile_id in asm_data_set_bots.
 	TgPawn__InitializeDefaultProps::nPendingBotId = profileId;
-	ATgPawn_Character* newpawn = (ATgPawn_Character*)Game->Spawn(ClassPreloader::GetTgPawnCharacterClass(), PlayerController, FName(), SpawnLocation, PlayerController->Rotation, nullptr, 1);
+	// Face the pawn the way the chosen TgTeamPlayerStart points. Retail
+	// RestartPlayer does Pawn.SetRotation(StartSpot.Rotation); we were reusing
+	// the controller's stale rotation (0 on join, last death view on respawn),
+	// which spawned players looking backwards on any start whose yaw isn't ~0.
+	// Yaw only, mirroring TgTeleporter.UsePlayerStart (see ReturnHomeArea.cpp).
+	FRotator SpawnRotation = PlayerController->Rotation;
+	SpawnRotation.Pitch = 0;
+	SpawnRotation.Roll  = 0;
+	{
+		auto it = TgGame__TgFindPlayerStart::s_ChosenYaw.find((AController*)PlayerController);
+		if (it != TgGame__TgFindPlayerStart::s_ChosenYaw.end()) {
+			SpawnRotation.Yaw = it->second;
+		}
+	}
+
+	ATgPawn_Character* newpawn = (ATgPawn_Character*)Game->Spawn(ClassPreloader::GetTgPawnCharacterClass(), PlayerController, FName(), SpawnLocation, SpawnRotation, nullptr, 1);
 	// nPendingBotId cleared inside InitializeDefaultProps::Call
 
 	// r_nPawnId is assigned by UC TgPawn.PostBeginPlay via TgGame.GetNextPawnId()
@@ -881,7 +897,13 @@ ATgPawn_Character* __fastcall TgGame__SpawnPlayerCharacter::Call(ATgGame* Game, 
 	// Refresh against the pawn's actual spawned transform. The native
 	// vLocation argument can be unavailable on some hook paths after Spawn().
 	newpawn->SetLocation(newpawn->Location);
-	newpawn->SetRotation(PlayerController ? PlayerController->Rotation : newpawn->Rotation);
+	newpawn->SetRotation(SpawnRotation);
+	newpawn->SetViewRotation(SpawnRotation);
+	newpawn->ClientSetRotation(SpawnRotation);
+	if (PlayerController) {
+		PlayerController->Rotation = SpawnRotation;
+		PlayerController->ClientSetRotation(SpawnRotation, 1);
+	}
 	RepairSpawnVolumeState(newpawn);
 
 	// scope-zoom investigation baseline — snapshot the aim-mode fields right

--- a/src/GameServer/TgGame/TgGame/TgFindPlayerStart/TgGame__TgFindPlayerStart.cpp
+++ b/src/GameServer/TgGame/TgGame/TgFindPlayerStart/TgGame__TgFindPlayerStart.cpp
@@ -99,11 +99,15 @@ ANavigationPoint* __fastcall TgGame__TgFindPlayerStart::Call(ATgGame* Game, void
 		}
 	}
 
+	if (Controller != nullptr) {
+		s_ChosenYaw[Controller] = best->Rotation.Yaw;
+	}
+
 	if (logEnabled) {
 		Logger::Log("spawn",
-			"TgFindPlayerStart: chose %s mapObjId=%d tf=%d prio=%d rating=%.1f\n",
+			"TgFindPlayerStart: chose %s mapObjId=%d tf=%d prio=%d rating=%.1f yaw=%d\n",
 			((UObject*)best)->GetName(), best->m_nMapObjectId,
-			(int)best->m_nTaskForce, best->m_nPriority, bestRating);
+			(int)best->m_nTaskForce, best->m_nPriority, bestRating, best->Rotation.Yaw);
 	}
 
 	LogCallEnd();

--- a/src/GameServer/TgGame/TgGame/TgFindPlayerStart/TgGame__TgFindPlayerStart.hpp
+++ b/src/GameServer/TgGame/TgGame/TgFindPlayerStart/TgGame__TgFindPlayerStart.hpp
@@ -8,6 +8,11 @@ class TgGame__TgFindPlayerStart : public HookBase<
 	0x10a744b0,
 	TgGame__TgFindPlayerStart> {
 public:
+	// Yaw of the start last chosen for each controller. SpawnPlayerCharacter
+	// consumes it so the pawn faces out of the spawn room instead of keeping
+	// the controller's stale rotation.
+	static inline std::unordered_map<AController*, int> s_ChosenYaw;
+
 	static ANavigationPoint* __fastcall Call(ATgGame* Game, void* edx, AController* Controller, FName IncomingName);
 	static inline ANavigationPoint* __fastcall CallOriginal(ATgGame* Game, void* edx, AController* Controller, FName IncomingName) {
 		return m_original(Game, edx, Controller, IncomingName);


### PR DESCRIPTION
Bug

Players sometimes spawned facing backwards instead of toward the spawn room's exit/door. Reproduced on every map with a spawn start whose yaw isn't near zero; never reproduced in the VR Arena.

Cause

TgGame::SpawnPlayerCharacter passed PlayerController->Rotation as the spawn rotation and re-asserted it in the post-spawn transform refresh. The TgTeamPlayerStart chosen by TgFindPlayerStart was only ever used for its Location — its Rotation was discarded. Facing therefore came from whatever rotation the controller was already carrying (zero on a fresh join, the last death-view direction on a respawn). Retail RestartPlayer does Pawn.SetRotation(StartSpot.Rotation); that step was missing.

VR Arena was unaffected because it never calls TgFindPlayerStart at all — confirmed in the logs (no picker lines on that instance).

Fix

- TgFindPlayerStart records the chosen start's Rotation.Yaw per controller (s_ChosenYaw) and logs it on the existing chose ... line.
- SpawnPlayerCharacter builds the spawn rotation from that yaw (pitch/roll zeroed) and uses it both for Spawn() and the post-spawn refresh, then applies the same sequence already proven in ReturnHomeArea.cpp: SetRotation + SetViewRotation + Pawn.ClientSetRotation + Controller.ClientSetRotation(…, true), so the camera follows instead of keeping the stale view.
- Falls back to the previous controller-rotation behaviour when no start was recorded, which keeps the VR Arena path unchanged.

Testing

Five instances captured on the spawn channel:

- VR Arena — initial spawn and -changeteam respawn: correct; log confirms this map bypasses the picker entirely, so the fallback path is exercised.
- PvE, SUMAX single attacker start — 3–4 respawns, all facing the dropship exit. -changeteam to the SUMAX boss-room start: correct, facing the exit door.
- PvP 1v1, Control map — two accounts, attacker and defender, opposite starts: both facing the dropship door.
- PvP 1v1, Payload map — same, correct.
- PvE, UMAX — two players on the same team: correct.

Logs verified: on every non-VR spawn the applied yaw matched the yaw of the start that was picked, including across the priority handoff (start 8140 prio=1 → 8139 prio=2) and both task forces. No no eligible start fallbacks occurred.

Still needs to be tested on: Raids / DDR /  PvE defense missions / DA but should be working as expected.

Related to:  https://discord.com/channels/994691794627461211/1528792467502272624