### PR TITLE
Fix stealth breaking the PainGun beam

### DIFF
--- a/src/GameServer/TgGame/TgPawn/TickMakeVisibleCalculation/TgPawn__TickMakeVisibleCalculation.cpp
+++ b/src/GameServer/TgGame/TgPawn/TickMakeVisibleCalculation/TgPawn__TickMakeVisibleCalculation.cpp
@@ -1,5 +1,6 @@
 #include "src/GameServer/TgGame/TgPawn/TickMakeVisibleCalculation/TgPawn__TickMakeVisibleCalculation.hpp"
 #include <unordered_map>
+#include <unordered_set>
 
 // Server-side native stripped to `RET 0x4`; reimplemented as the reveal driver.
 // m_fMakeVisibleCurrent is the client-local "MakeVisible" MIC scalar (0..100);
@@ -11,6 +12,7 @@
 // Keyed by r_nPawnId, not pointer, to survive UE3 address reuse.
 
 static std::unordered_map<int, float> g_revealRemaining;  // seconds of reveal left, by r_nPawnId
+static std::unordered_set<int> g_stealthDisabledBumped;   // pawnIds we've +1'd r_nStealthDisabled on
 
 void TgPawn__TickMakeVisibleCalculation::QueueRevealPulse(int pawnId, float durationSeconds) {
 	float& r = g_revealRemaining[pawnId];
@@ -37,10 +39,30 @@ void __fastcall TgPawn__TickMakeVisibleCalculation::Call(ATgPawn* Pawn, void* /*
 		// schemes drift. A fat constant crushes decay and the engine's own tick
 		// clamp at 100 pins m there — delivery-rate-insensitive.
 		Pawn->r_fMakeVisibleIncreased = 10.0f;  // DO_REP_FORCED ships while != 0
+
+		// Lock gate: the m_fMakeVisibleCurrent path above only reveals via the
+		// rate-fragile r_fMakeVisibleIncreased fold, so on an observer's client
+		// IsStealthed() can still flip true for a frame — enough for the medic's
+		// auto-lock (CheckTargetActor, TgPawn.uc:6672 `r_Target.IsStealthed()`)
+		// to drop r_Target and break the PainGun beam. r_nStealthDisabled is a
+		// replicated int and one of IsStealthed()'s three clauses; bumping it
+		// closes the gate directly on every client. Faithful: taking damage
+		// disables stealth for the reveal window (see IsStealthed decomp note).
+		if (g_stealthDisabledBumped.insert(Pawn->r_nPawnId).second) {
+			Pawn->r_nStealthDisabled++;
+		}
 		Pawn->bNetDirty = 1;
 		Pawn->bForceNetUpdate = 1;
 		if (windowActive && it->second <= 0.0f) g_revealRemaining.erase(it);
 		return;
+	}
+
+	// Reveal ended: undo our one-time stealth-disable bump (symmetric decrement).
+	auto b = g_stealthDisabledBumped.find(Pawn->r_nPawnId);
+	if (b != g_stealthDisabledBumped.end()) {
+		if (Pawn->r_nStealthDisabled > 0) Pawn->r_nStealthDisabled--;
+		Pawn->bNetDirty = 1;
+		g_stealthDisabledBumped.erase(b);
 	}
 
 	// No active reveal: restore the cloaked sentinel server-side and stop streaming


### PR DESCRIPTION
Bug:

A Recon who stealthed while a Medic's PainGun beam was on them broke the beam and escaped the slow. The medic's auto-lock beam drops its target every tick in CheckTargetActor when r_Target.IsStealthed() is true (TgPawn.uc:6672). IsStealthed() = r_bIsStealthed && r_nStealthDisabled == 0 && m_fMakeVisibleCurrent == KSN. The existing reveal-on-damage only drove m_fMakeVisibleCurrent, and that reaches observers only through the delivery-rate-fragile r_fMakeVisibleIncreased fold — so on the medic's client IsStealthed() could still flip true for a frame, dropping the lock, breaking the beam, and stopping the slow from re-applying. (UTgDeviceFire::IsValidTarget has no stealth gate, so the auto-lock drop is the sole cause.)

Fix: 
During the active reveal window in TgPawn__TickMakeVisibleCalculation, also bump the replicated int r_nStealthDisabled (one of IsStealthed()'s three clauses, CPF_Net). This closes the gate directly on every client, independent of the fold race, and matches the intended "taking damage disables stealth for the reveal window" behavior. The bump is tracked per pawn and decremented symmetrically (underflow-guarded) when the window ends, so it can't corrupt legitimate stealth-disable effects. One file changed.

Scope: This is not PainGun-specific. The reveal is driven by TrackDamageTaken, which fires on any incoming damage (projectile, melee, DOT, beam), so any damage to a stealthing Recon reveals and fully exposes them for the reveal window (~1s, refreshed by sustained damage), after which they re-cloak when left alone. All lock-on/IsStealthed()-gated targeting benefits, not just the medic beam. The PainGun was simply the clearest case to reproduce it. Reveal duration is the hardcoded 1.0s window in TrackDamageTaken.

Test: Two-PC LAN, Medic vs. Recon on opposing teams. Held the PainGun beam on the Recon while they attempted to stealth — the beam stayed locked, the Recon remained revealed (purple) and continued to be slowed for the duration of the beam. After fire stopped, the Recon re-cloaked fully with no lingering reveal or broken stealth. Confirmed from both the medic and recon clients. Tested specifically with the PainGun, but the mechanism applies to any source of damage.

Related to:  https://discord.com/channels/994691794627461211/1529822725550641274