### PR TITLE
Show agency name on the in-match scoreboard (populate PRI r_sAgencyName)

### DIFF
--- a/src/Database/Database.cpp
+++ b/src/Database/Database.cpp
@@ -10658,6 +10658,27 @@ void Database::Init() {
 	PlayerRegistry::Init();
 }
 
+std::string Database::GetAgencyName(int64_t character_id) {
+	if (character_id <= 0) return "";
+	sqlite3* db = GetConnection();
+	sqlite3_stmt* stmt = nullptr;
+	if (sqlite3_prepare_v2(db,
+			"SELECT ag.name FROM ga_agency_members m "
+			"JOIN ga_agencies ag ON ag.id = m.agency_id "
+			"WHERE m.character_id = ?",
+			-1, &stmt, nullptr) != SQLITE_OK || !stmt) {
+		return "";
+	}
+	sqlite3_bind_int64(stmt, 1, character_id);
+	std::string name;
+	if (sqlite3_step(stmt) == SQLITE_ROW) {
+		const char* a = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
+		if (a) name = a;
+	}
+	sqlite3_finalize(stmt);
+	return name;
+}
+
 std::string Database::GetQuestStatus(int64_t character_id, int quest_id) {
 	sqlite3* db = GetConnection();
 	sqlite3_stmt* stmt = nullptr;

--- a/src/Database/Database.hpp
+++ b/src/Database/Database.hpp
@@ -13,6 +13,10 @@ public:
 	static void CloseConnection();
 	static void Init();
 
+	// Agency name for a character, "" when unaffiliated. Feeds the in-match
+	// scoreboard's Agency column (ATgRepInfo_Player::r_sAgencyName).
+	static std::string GetAgencyName(int64_t character_id);
+
 	// Returns "" (not found), "active", or "complete"
 	static std::string GetQuestStatus(int64_t character_id, int quest_id);
 	static void AcceptQuest(int64_t character_id, int quest_id);

--- a/src/GameServer/TgGame/TgGame/SpawnPlayerCharacter/TgGame__SpawnPlayerCharacter.cpp
+++ b/src/GameServer/TgGame/TgGame/SpawnPlayerCharacter/TgGame__SpawnPlayerCharacter.cpp
@@ -47,6 +47,26 @@ static void LogAssemblySnapshot(const char* where, void* obj, const FCustomChara
 		a.DyeList[0], a.DyeList[1], a.DyeList[2], a.DyeList[3], a.DyeList[4]);
 }
 
+// Persistently assign a replicated FString field on a UObject. The field is
+// replicated over many frames and later freed by the engine via GAllocator, so
+// Data must come from GAllocator (not C++ new[] — mixing allocators corrupts
+// the heap, see the eventSetPlayerName note below). Frees any prior
+// GAllocator-owned buffer first so respawns don't leak.
+static void SetReplicatedFString(FString& field, const std::string& utf8) {
+	if (field.Data) {
+		GAllocator::Free(field.Data);
+		field.Data = nullptr;
+		field.Count = field.Max = 0;
+	}
+	if (utf8.empty()) return;
+	int wlen = MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, nullptr, 0);
+	if (wlen <= 0) return;  // includes the null terminator
+	wchar_t* buf = (wchar_t*)GAllocator::Malloc(sizeof(wchar_t) * wlen);
+	MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, buf, wlen);
+	field.Data = buf;
+	field.Count = field.Max = wlen;  // FString Count includes the terminator
+}
+
 static bool AddTouchingIfMissing(AActor* Actor, AActor* Other) {
 	if (!Actor || !Other) return false;
 	for (int i = 0; i < Actor->Touching.Count; ++i) {
@@ -485,6 +505,9 @@ ATgPawn_Character* __fastcall TgGame__SpawnPlayerCharacter::Call(ATgGame* Game, 
 	SyncPawnHealth::Apply(newpawn, hp, hp);
 	newrepplayer->r_nCharacterId = newpawn->s_nCharacterId;
 	newrepplayer->r_nLevel = 50;
+	// Scoreboard Agency column — replicated FString on the PRI.
+	SetReplicatedFString(newrepplayer->r_sAgencyName,
+	                     Database::GetAgencyName(newpawn->s_nCharacterId));
 	// newrepplayer->r_sOrigPlayerName = FString(L"Zaxik");
 	newrepplayer->r_PawnOwner = newpawn;
 	newrepplayer->r_ApproxLocation = newpawn->Location;


### PR DESCRIPTION
Fix the blank Agency column on the Mission Stats scoreboard.

The scoreboard's Agency column reads ATgRepInfo_Player::r_sAgencyName, a replicated FString the rep-list already ships (Actor__GetOptimizedRepListV2 DO_REP) — but nothing on the server ever wrote it, so it stayed empty. Team search showed agencies because that's a separate ControlServer TCP path (GetAffiliationsByCharacter); the in-match scoreboard is game-server PRI state and was never populated.

Changes:
- src/Database/Database.{hpp,cpp} — new GetAgencyName(character_id): single indexed lookup joining ga_agency_members → ga_agencies. Game server's Database points at the same server.db the agency system writes.
- TgGame__SpawnPlayerCharacter.cpp — after r_nCharacterId is set, write r_sAgencyName via a new SetReplicatedFString helper that allocates through GAllocator (the engine frees the field later, so mixing allocators would corrupt the heap) and frees any prior buffer so respawns don't leak.

How it works / DB query concern:
The lookup runs on pawn load in SpawnPlayerCharacter — the same place cosmetics, devices, and skills are already loaded from the DB — so it fires once per spawn (join + each respawn), not per-frame. Spawn already issues several DB queries; this is one more indexed lookup, negligible. Left uncached deliberately: caching it in PlayerInfo would save one lookup per respawn but go stale if a player's agency changes mid-session, and there's no measured load to justify it (enable the dbperf channel if that ever changes).

Alliance intentionally not touched — the scoreboard has no alliance column.

Scope: human players only (bots spawn through a different path and have no agency).

Related to: https://discord.com/channels/994691794627461211/1528060092908441680 
and https://discord.com/channels/994691794627461211/1530185607760973926