### PR TITLE
Implement rest of chats

### DIFF
--- a/control-server.example.json
+++ b/control-server.example.json
@@ -22,5 +22,6 @@
 	"crash_dir": "Z:\\opt\\ga\\crashes",
 	"log_dir": "Z:\\opt\\ga\\logs",
 	"enabled_channels": [],
-	"enabled_crash_channels": []
+	"enabled_crash_channels": [],
+	"announcers": []
 }

--- a/handoff.md
+++ b/handoff.md
@@ -1,9 +1,11 @@
 # Chat channels — investigation + implementation plan
 
 Branch: `implement-chats` (from `master`).
-Status: **7 of 12 channels live and tested** — Personal, Announcements (20),
-City, Local, Instance, Team, Trade, LFG. All five shared-infrastructure items
-except `PLAYER_COMMAND` (INF-2) are done. **Task checklist is §5b.**
+Status: **9 of 12 channels live and tested** — Personal, Announcements (20),
+City, Local, Instance, Team, Trade, LFG, Agency, Alliance. All five
+shared-infrastructure items except `PLAYER_COMMAND` (INF-2) are done.
+Agency (2) and Alliance (3) landed once `enable-agencies-alliances` merged
+upstream — they route on the agency-management DB backend. **Task checklist is §5b.**
 
 Today the server has exactly two working channels: a server-wide broadcast sent
 on channel 4 ("Local") and whispers on channel 8. This document records what the
@@ -263,10 +265,13 @@ holds `session_guid_`.
   stale.
 - `TeamService` is keyed by session guid but exposes no public "member guids"
   accessor. `FindTeamByMemberLocked` exists privately; needs a thin wrapper.
-- **Agency and alliance are not implemented on `master`.** The tables
-  (`ga_agencies`, `ga_agency_members`, `ga_alliances`, `ga_alliance_members`)
-  exist, but `send_agency_get_roster_response` is a stub and no code reads them.
-  Channels 2 and 3 are blocked on the `enable-agencies-alliances` branch landing.
+- **Agency and alliance chat are live** (channels 2 and 3). The management
+  backend from `enable-agencies-alliances` merged upstream, so
+  `ga_agencies` / `ga_agency_members` / `ga_alliances` / `ga_alliance_members`
+  are populated and readable. `RecipientsFor` resolves guid → `user_id` →
+  agency/alliance membership via `Database::GetAgencyIdForUser` /
+  `GetAgencyMemberUserIds` / `GetAllianceIdForAgency` / `GetAllianceMemberUserIds`,
+  then delivers to online members by walking connected sessions.
 
 ---
 
@@ -280,8 +285,8 @@ holds `session_guid_`.
 | 5 Team | `/t` | `TeamService` party members | small + one accessor |
 | 8 Personal | `/w`, `/tell` | whisper — already working | none |
 | 0 Global | `/gl` (client-side) | everyone; staff-gated or open | small |
-| 2 Agency | `/a` | agency membership | blocked on agencies branch |
-| 3 Alliance | `/al` | alliance membership | blocked on agencies branch |
+| 2 Agency | `/a` | agency membership | done |
+| 3 Alliance | `/al` | alliance membership | done |
 | 6 Raid | `/rg`, `*raid` | not implemented | — |
 | 0 GM | staff broadcast to everyone | small, needs an admin flag |
 | 12 Trade, 13 LFG, 9 Private 1, 14 Help | not implemented | — |
@@ -330,7 +335,8 @@ predicate change in one function, not a redesign.
    error replies stop masquerading as Local chat.
 5. **Add `TeamService::GetTeamMemberGuids(guid)`** — thin public wrapper over the
    existing locked member lookup.
-6. **Agency and Alliance** land after `enable-agencies-alliances` merges.
+6. **Agency and Alliance** — DONE. Landed after `enable-agencies-alliances`
+   merged upstream; route on its DB backend.
 7. **Logging and test.** Everything on the existing `chat` channel. Test matrix:
    two accounts across two instances and two sides, walking every channel, plus a
    whisper regression pass.
@@ -404,12 +410,13 @@ Status key: **DONE** = shipped and tested in game. **WIP** = someone owns it.
       whether it's open to all players or staff-gated — if staff-gated, reuse
       the `announcers` config list rather than adding a second mechanism.
       **TODO.**
-- [ ] **2 · Agency** — entry: `/a`. Scope: agency membership. **BLOCKED** on
-      `enable-agencies-alliances` landing: `ga_agencies` / `ga_agency_members`
-      exist but nothing reads them and `send_agency_get_roster_response` is a
-      stub. Needs INF-2 once unblocked.
-- [ ] **3 · Alliance** — entry: `/al`. Scope: alliance membership. **BLOCKED**,
-      same branch as Agency.
+- [x] **2 · Agency** — entry: `/a` / `/agency`. Scope: online agency members
+      (guid → `user_id` → `GetAgencyMemberUserIds`). No-agency reply:
+      "*** You are not in an agency ***". **DONE.**
+- [x] **3 · Alliance** — entry: `/al` / `/alliance`. Scope: online members of
+      every agency in the alliance (`GetAllianceIdForAgency` →
+      `GetAllianceMemberUserIds`). No-alliance reply:
+      "*** Your agency is not in an alliance ***". **DONE.**
 - [ ] **6 · Raid** — entry: `/rg`, `*raid`, `rgw`/`raidw` for raid-whisper.
       Scope: raid group. **TODO**, no raid-group concept exists server-side yet —
       scope this before starting.

--- a/handoff.md
+++ b/handoff.md
@@ -1,0 +1,450 @@
+# Chat channels — investigation + implementation plan
+
+Branch: `implement-chats` (from `master`).
+Status: **7 of 12 channels live and tested** — Personal, Announcements (20),
+City, Local, Instance, Team, Trade, LFG. All five shared-infrastructure items
+except `PLAYER_COMMAND` (INF-2) are done. **Task checklist is §5b.**
+
+Today the server has exactly two working channels: a server-wide broadcast sent
+on channel 4 ("Local") and whispers on channel 8. This document records what the
+client actually supports, verified against the binary, and the plan to build the
+real channel set on top of it.
+
+---
+
+## 1. The channel enum (confirmed)
+
+`FUN_10902990` in the client (`GlobalAgenda.exe`, image base `0x10900000`)
+initialises two parallel 22-entry tables — channel display name (as a message id
+resolved through `asm_data_set_msg_translations`) and channel colour
+(`DAT_1199eca0`). The array index **is** the value we put in the `CHAT_CH_TYPE`
+(0x00BE) wire field.
+
+| id | name | msg id | colour | visible in a default tab? |
+|----|------|--------|--------|---------------------------|
+| 0  | Global Agenda GM | 42221 | `fff400` yellow | yes — All |
+| 1  | Instance | 30348 | `277dff` royal blue | yes — All |
+| 2  | Agency | 30349 | `32cd32` lime green | yes — All, Agencies |
+| 3  | Alliance | 30361 | `ffa500` orange | yes — All, Agencies |
+| 4  | **Local** | 30350 | `f0e68c` khaki | yes — All |
+| 5  | Team | 30351 | `6495ed` cornflower blue | yes — All, Teams |
+| 6  | Raid | 30352 | `f94aff` magenta | yes — All, Teams |
+| 7  | City | 30353 | `f0e68c` khaki | yes — All |
+| 8  | **Personal** (whisper/tell) | 30354 | `ba55d3` medium orchid | yes — All, Agencies, Teams, Personal |
+| 9  | Private 1 | 30355 | `00ffaa` spring green | **no** |
+| 10 | GM | 30356 | `ffa58f` salmon | **no** |
+| 11 | System | 30357 | `fff400` yellow | yes — all four tabs |
+| 12 | **Trade** | 52905 | `c8c8c8` grey | yes — All |
+| 13 | **LFG ("Looking For Group")** | 52906 | `c8c8c8` grey | yes — All |
+| 14 | Help | 30358 | `ffffff` white | no |
+| 15 | VOIP | 30359 | `ffffff` white | no |
+| 16 | Unknown | 30360 | `ffffff` white | no |
+| 17 | VOIP | 30359 | `ffffff` white | Combat Log tab (mask bit 17) |
+| 18 | VOIP | 30359 | `ffffff` white | no |
+| 19 | Combat | 36537 | `ffffff` white | no |
+| 20 | Unknown | 30360 | `fff400` **yellow** | **always** (see below) |
+| 21 | Unknown | 30360 | `ffffff` white | no |
+
+Colours are ARGB with alpha `0xfa`, read straight out of the initialiser
+(`0x1199eca0 + id*4`). The name/colour loop bound is `iVar6 < 0x58` = 88 bytes =
+22 entries, which independently confirms the enum has exactly 22 members.
+
+> **Correction (2026-07-21).** Ids 12–21 in an earlier revision of this document
+> were guessed from msg-id ordering and were wrong. The table above is now read
+> directly out of the name-table initialiser: `FUN_10902990` stores each resolved
+> message string to `[0x1199ec28 + channelId*4]`, so the destination address *is*
+> the id. Ids 0–11 were unchanged by the correction. Colour table is the parallel
+> array at `0x1199eca0` (same indexing, `0x1199eca0 + channelId*4`).
+
+### How this was verified
+
+Three independent cross-checks, all agreeing:
+
+1. **Known-good values.** 4 = Local and 8 = Personal are what we already ship and
+   what real clients render correctly.
+2. **Tab filter bits.** `TgUIChat.uc` `defaultproperties` (and the shipped
+   `TgGame/Config/DefaultUI.ini`) define five tabs by bitmask. `FUN_113be150`
+   filters each incoming line with `filterBits & (1 << channelId)`. Decoding
+   each mask against the table above gives a coherent grouping:
+
+   | tab | mask | decodes to |
+   |-----|------|-----------|
+   | All (msg 59873) | 14847 | 0–8, System, Trade, LFG |
+   | Agencies (59874) | 2317 | GlobalGM, Agency, Alliance, Personal, System |
+   | Teams (59875) | 2401 | GlobalGM, Team, Raid, Personal, System |
+   | Personal (59876) | 2305 | GlobalGM, Personal, System |
+   | Combat Log (59877) | 131072 | Combat (bit 17) |
+
+3. **The Chat settings screen** (`TgUISettingsMenu_Chat`, see §1b) exposes exactly
+   11 channel checkboxes, and the All tab's mask 14847 is exactly
+   `{0..8, 11, 12, 13}` — 12 bits, of which id 0 (Global Agenda GM) is not
+   user-configurable. 14 − 1 mask members ... 11 checkboxes + GM + the two ids
+   the player cannot toggle. Under the *old* table the All tab would have had
+   Help and VOIP checkboxes and no Trade or LFG; the live screen shows Trade and
+   LFG and neither Help nor VOIP. This pins 12 = Trade, 13 = LFG.
+
+   (The Combat Log tab's mask is `1 << 17`, which lands on a VOIP name-table
+   entry rather than the Combat entry at 19. Combat-log lines are client-local
+   and irrelevant to us; not chased further.)
+
+### Two quirks in the filter code, both exploitable
+
+- `FUN_113be150` remaps **channel 20 → 11 before the filter test**
+  (`0x113be235: cmp ecx,0x14` / `mov ecx,0xb`, then `1 << cl` against the mask).
+  Channel 20 is an unnamed id (msg 30360), *not* Trade. Because bit 11 (System)
+  is set in all four default tab masks, **a message sent on channel 20 renders in
+  every tab regardless of the player's settings** — this is the unfilterable
+  channel, and it is free (nothing else uses id 20). It draws yellow (`fff400`,
+  same as System), and has no channel-name prefix of its own (msg 30360).
+  Trade (12) is a normal, filterable, checkbox-controlled channel.
+- The `CHAT_ANNOUNCEMENT_FLAG` wire field, when set on a channel 4 or 7 message,
+  recolours it as channel 9 (spring green). Free "announcement" styling on Local
+  and City without changing channel.
+
+### Consequence for the "GM channel as global chat" idea
+
+Channel **10 (GM) is in no default tab** — messages sent there are invisible
+unless the player hand-edits `TgUI.ini`. Do not use it.
+
+Use instead:
+- **channel 0 "Global Agenda GM"** — yellow, present in the All tab. Right choice
+  for staff announcements.
+- **channel 20** (unnamed, remapped to the System filter bit) — the only
+  unfilterable channel. Right choice if the goal is "reaches someone no matter
+  how they configured their tabs". Renders white.
+
+---
+
+## 1b. The Chat settings screen — one filter layer, not two
+
+`TgClient/Classes/TgUISettingsMenu_Chat.uc` (native impl, no UC logic):
+
+```
+const NUM_SHOWN_CONFIGURABLE_CHANNELS = 11;
+const NUM_CONFIGURABLE_CHANNELGROUPS  = 4;
+var CC_Group_Configuration m_Groups[4];   // each: m_Panel, m_GroupNameEditBox,
+                                          //       CC_ConfigElement m_Channels[11]
+```
+
+- The dropdown at the top of the screen is the **tab** selector — the four
+  configurable groups are `TgUIChat.m_ChannelGroupLogic[0..3]` (All, Agencies,
+  Teams, Personal). The Combat Log tab (index 4) is not configurable. Tabs are
+  also **renameable** (`m_GroupNameEditBox` → `m_TabName`).
+- The 11 checkboxes are the 11 user-configurable channels: **ids 1–8, 11, 12,
+  13** (Instance, Agency, Alliance, Local, Team, Raid, City, Personal, System,
+  Trade, LFG).
+- The checkboxes write `m_ChannelGroupLogic[tab].m_FilterBits` — **the same mask
+  `FUN_113be150` tests.** There is no second filter layer. `m_FilterBits` is
+  `globalconfig`, so it persists to `TgUI.ini` per player.
+
+Consequences for us:
+
+- Every channel we ship on ids 1–8/11/12/13 is individually mutable by the
+  player, and defaults to *on* in the All tab.
+- A player can also delete a channel from every tab, so no channel on that list
+  is guaranteed delivery. Only **channel 20** is (via the → 11 remap).
+- Nothing here is server-driven. We cannot change a player's filter bits; we can
+  only choose which channel id to send on.
+
+## 2. What the client lets us control
+
+### Channel list — server-*gated*, not server-driven (corrected)
+
+The send combo box is rebuilt by `FUN_113bdd20`. It walks a **hardcoded 10-entry
+candidate table** and adds an entry only when that channel is also enabled in the
+client's 16-slot table (which our `CHAT_CONFIG` 0x0072 packet fills):
+
+```
+for (i = 0; i < 10; i++)                       // loop bound 0x28 / 4
+    if (cand[i] < 0x10 && enabledTable[cand[i]] != 0)
+        addComboEntry(L"  /%s:  %s", prefix[i], channelName(cand[i]));
+```
+
+`cand[]` is at `0x1199c770`, the parallel prefix strings at `0x1199c748`:
+
+| slot | prefix | channel | slot | prefix | channel |
+|------|--------|---------|------|--------|---------|
+| 0 | `L`  | 4 Local    | 5 | `RG`  | 6 Raid |
+| 1 | `1`  | 7 City     | 6 | `TR`  | 12 Trade |
+| 2 | `A`  | 2 Agency   | 7 | `LFG` | 13 LFG |
+| 3 | `AL` | 3 Alliance | 8 | `P1`  | 9 Private 1 |
+| 4 | `T`  | 5 Team     | 9 | `P2`  | 10 GM |
+
+Consequences — these are hard client limits, not things a packet can change:
+
+- **Instance (1) and Personal (8) are not on the list and can never appear in
+  the combo box.** Instance is reachable only through the client's own `/i`;
+  Personal through the tell flow (`UserSelectedChannel` special-cases 8 before
+  the list is consulted). Confirmed in game: sending `CHAT_CONFIG {7,4,1,5,8}`
+  produced a three-entry combo — Local, City, Team.
+- **The prefixes are hardcoded.** City is `/1`, not `/C`. Nothing server-side
+  changes that.
+- **Private 1 (9) and GM (10) are selectable but sit in no default tab** — a
+  player who picks them is shouting into a void. Do not enable them.
+- Slot 6 = channel 12 labelled `TR` and slot 7 = channel 13 labelled `LFG` is a
+  third independent confirmation that 12 = Trade and 13 = LFG.
+- `UserSelectedChannel` (`0x113c17b0`) then reads `m_ChatChannelList[comboIndex]`
+  (`this+0x208`) to recover the channel byte for the entry the player picked.
+
+### Slash commands — the channel commands are real, and are server-side
+
+The client's own `/help chat` (`FUN_10912700`) prints this list, built from
+hardcoded (command string, message id) pairs:
+
+| command | help text (msg id) |
+|---------|--------------------|
+| `/w [player name] <message>` | Personal Channel (25909) |
+| `/t` | Team Channel (25903) |
+| `/l` | **Attacker/Defender Channel** (25904) |
+| `/a` | Agency Channel (25905) |
+| `/al` | Alliance Channel (25906) |
+| `/s` | Strike force (30362) |
+| `/rg` | Raid Channel (26906) |
+
+Note `/l` is literally named "Attacker/Defender Channel" — the client's own
+documentation says Local is side-scoped. That settles the Local design question.
+
+There are **two dispatch paths**, and this is the part that matters:
+
+**1. Handled inside the client** (`FUN_10917300` builds a 114-entry name→id map;
+`FUN_10915fc0` switches on the id):
+
+- `tell` (9), `warn` (10), `w` (11) — parse `<name> <message>`; `warn` sets the
+  extra GM-warn flag.
+- **`gl` (17) → `FUN_109018d0(0, text)` — sends on channel 0 (Global).**
+- **`i` (18) → `FUN_109018d0(1, text)` — sends on channel 1 (Instance).**
+- `rgw` (19), `raidw` (20), `*raid` (108) — raid / raid-group chat.
+- `who` (13), `chatwho` (33) — `CHAT_LIST_CHANNEL_MEMBERS` queries.
+- `friend` / `unfriend` / `ignore` / `unignore` (24–27).
+- `agencyinvite` (6), `agencyleave` / `aquit` (7), `agencydisband` (8),
+  `invite` (2), `kick` (3), `leave` (4), `teamsetleader` (41),
+  `setraidleader` (45).
+- ids 50–107 are emotes, consumed by `FUN_109140e0` before the switch.
+- `say` (37) and friends are UE console passthroughs.
+
+`FUN_109018d0(channel, text)` is the *same* function the normal (non-slash) send
+path calls with the combo box's current channel. It builds packet 0x0073 with
+`CHAT_CH_TYPE` (0xBE) = channel and `MESSAGE` (0x355) = text — and it **guards
+`channel < 0x10`**. So the client cannot send on channels 16–21. With the
+corrected enum, Trade (12) and LFG (13) are *below* the guard: the client can
+send on them, so they can be real player channels via the combo box. Channel 20
+(the unfilterable one) is above the guard — server-send only, which is exactly
+right for announcements.
+
+**2. Forwarded to the server as `PLAYER_COMMAND` (0x019F).** `/t`, `/l`, `/a`,
+`/al`, `/s`, `/rg` are *not* in the client's name map. A lookup miss falls to
+`default:` → `FUN_10920990`, which packs the raw text into a `PLAYER_COMMAND`
+(0x019F) packet with `TEXT_VALUE` (0x04FF) and sends it on the **main TCP
+connection** (not the chat socket).
+
+That is how these commands worked originally: the client is a dumb forwarder and
+the *server* parsed `/a hello` and fanned it out. The control server handles no
+`PLAYER_COMMAND` today, which is exactly why they appear broken now.
+
+**This is therefore not optional and not a separate branch — implementing the
+channel commands means implementing `PLAYER_COMMAND`.** It also gives us emote
+handling and a protocol-native replacement for our `-command` prefix hack for
+free.
+
+---
+
+## 3. Server-side state already available
+
+Everything needed for scoping is one lookup from `ChatSession`, which already
+holds `session_guid_`.
+
+- `InstanceRegistry::GetInstancePlayerTaskForce(guid)` → `(instance_id,
+  task_force)` for the player's current non-stopped instance.
+- `InstanceRegistry::GetActivePlayersForInstance(instance_id)` → roster rows with
+  guid, profile id and task force.
+- `ga_instance_players` is populated for the home map as well as missions
+  (`TcpSession.cpp` registers on PLAYER_REGISTER ACK for home, successor and
+  mission instances), and `left_at` is stamped on exit — the data is live, not
+  stale.
+- `TeamService` is keyed by session guid but exposes no public "member guids"
+  accessor. `FindTeamByMemberLocked` exists privately; needs a thin wrapper.
+- **Agency and alliance are not implemented on `master`.** The tables
+  (`ga_agencies`, `ga_agency_members`, `ga_alliances`, `ga_alliance_members`)
+  exist, but `send_agency_get_roster_response` is a stub and no code reads them.
+  Channels 2 and 3 are blocked on the `enable-agencies-alliances` branch landing.
+
+---
+
+## 4. Proposed channel mapping
+
+| Channel | Command | Scope | Effort |
+|---------|---------|-------|--------|
+| 7 City | combo box | every connected chat session — today's behaviour, renamed | trivial |
+| 4 Local | `/l` | same `instance_id` **and** same `task_force` ("Attacker/Defender"); on home map / VR, side ignored | small |
+| 1 Instance | `/i` (client-side) | same `instance_id`, both sides | small |
+| 5 Team | `/t` | `TeamService` party members | small + one accessor |
+| 8 Personal | `/w`, `/tell` | whisper — already working | none |
+| 0 Global | `/gl` (client-side) | everyone; staff-gated or open | small |
+| 2 Agency | `/a` | agency membership | blocked on agencies branch |
+| 3 Alliance | `/al` | alliance membership | blocked on agencies branch |
+| 6 Raid | `/rg`, `*raid` | not implemented | — |
+| 0 GM | staff broadcast to everyone | small, needs an admin flag |
+| 12 Trade, 13 LFG, 9 Private 1, 14 Help | not implemented | — |
+
+This matches both the community expectation and the client's own design: Local is
+instance + side, Instance is the both-sides instance-wide channel, City is the
+cross-instance social channel.
+
+### The one open decision: does City reach players inside missions?
+
+- **Simple (recommended to ship first):** yes. City is exactly today's global
+  broadcast with a different channel id — a one-constant change.
+- **Insulated:** scope City to non-mission instances (home map + VR) and use
+  channel 0 for cross-server pings to people mid-mission.
+
+Ship the simple version, gather feedback, revisit. The insulated variant is a
+predicate change in one function, not a redesign.
+
+---
+
+## 5. Implementation plan
+
+1. **Recipient filtering in `ChatSession::broadcast`.** Add one
+   `RecipientsFor(channel)` helper returning the peer set. The existing ignore
+   gate, frame construction and whisper path stay untouched.
+2. **One roster query per message.** Resolve the sender's `(instance_id,
+   task_force)` once, fetch the instance roster once, then match peers by
+   `session_guid_`. Do not query per peer. Add per-session caching against an
+   epoch only if profiling shows it matters.
+3. **Widen `CHAT_CONFIG`.** `AnnounceJoinIfNeeded` currently sends `{4, 8}`;
+   send `{7, 4, 1, 5, 8}` instead. Channels the player cannot currently use
+   (Team with no party, Local outside an instance) reply with a system message
+   rather than being dynamically added and removed — far less state to keep in
+   sync than re-sending `CHAT_CONFIG` on every instance or party transition.
+3b. **Handle `PLAYER_COMMAND` (0x019F) in `TcpSession`.** Read `TEXT_VALUE`
+   (0x04FF), split the leading token, and map `t`/`l`/`a`/`al`/`s`/`rg` to the
+   channel ids above, routing the remainder through the same
+   `RecipientsFor(channel)` path as step 1. Unknown tokens get a system reply.
+   Without this, `/t` and `/l` stay dead no matter what `CHAT_CONFIG` says —
+   only `/gl`, `/i`, `/w` and the combo box reach the chat socket on their own.
+   The command arrives on the main TCP session, so delivery needs a
+   send-by-guid entry point alongside the existing
+   `ChatSession::SystemMessageTo`.
+4. **Move `kSystemChannelId` from 4 to 11 (System).** Channel 11 is present in
+   all four default tabs and is correctly yellow-tinted. Join/leave notices and
+   error replies stop masquerading as Local chat.
+5. **Add `TeamService::GetTeamMemberGuids(guid)`** — thin public wrapper over the
+   existing locked member lookup.
+6. **Agency and Alliance** land after `enable-agencies-alliances` merges.
+7. **Logging and test.** Everything on the existing `chat` channel. Test matrix:
+   two accounts across two instances and two sides, walking every channel, plus a
+   whisper regression pass.
+
+---
+
+## 5b. Checklist — one item per channel
+
+Status key: **DONE** = shipped and tested in game. **WIP** = someone owns it.
+**TODO** = unclaimed. **BLOCKED** = waiting on something named.
+
+### Shared infrastructure (do these first — most channels depend on them)
+
+- [x] **INF-1 · `RecipientsFor(channel)` in `ChatSession::broadcast`** — one
+      helper returning the peer set for a channel; the existing ignore gate,
+      frame construction and whisper path stay untouched. Resolve the sender's
+      `(instance_id, task_force)` once and fetch the instance roster once per
+      message, then match peers by `session_guid_` — do not query per peer.
+      *Blocks: Local, Instance, Team, City-insulated.*
+- [x] **INF-2 · `PLAYER_COMMAND` (0x019F) handler in `TcpSession`** —
+      **DONE + tested** (`/c`, `/city`, `/l`, `/local`, `/t`, `/i` all verified
+      in a live merc mission; unknown-token reply still unconfirmed).
+      `handle_player_command` reads `TEXT_VALUE`,
+      strips an optional leading `/`, maps the token via
+      `ChatCommand::ChannelForCommandToken`, and routes through
+      `ChatSession::SendChannelMessageFrom` (guid-addressed, shares
+      `SendOnChannel` with the chat socket). Unknown token → system reply.
+      Aliases we define ourselves: `/c` and `/city` (the combo box hardcodes
+      City's label as `/1`), `/i`, `/tr`, `/lfg`, plus long forms.
+      Original description below.
+      *Unblocks `/t` and `/l`; `/a`, `/al`, `/rg` stay unmapped until the
+      features behind them exist (unknown-token reply instead).*
+- [x] **INF-3 · Widen `CHAT_CONFIG`** — `AnnounceJoinIfNeeded` currently sends
+      `{4, 8}`; send `{7, 4, 1, 5, 8}`. Populates the send combo box. Channels
+      the player can't currently use (Team with no party, Local outside an
+      instance) reply with a system message rather than being added/removed
+      dynamically — far less state to keep in sync.
+- [x] **INF-4 · Move `kSystemChannelId` 4 → 11** — channel 11 is in all four
+      default tabs and is correctly yellow. Join/leave notices and error replies
+      stop masquerading as Local chat. One-constant change, no dependencies.
+- [x] **INF-5 · `TeamService::GetTeamMemberGuids(guid)`** — thin public wrapper
+      over the existing private `FindTeamByMemberLocked`. *Blocks: Team.*
+
+### Channels
+
+- [x] **8 · Personal** (whisper/tell) — `/w`, `/tell`, reply keybind. **DONE**,
+      shipped before this workstream.
+- [x] **20 · Announcements** — `-announce <text>`, gated on the `announcers`
+      list in `control-server.json`. Unfilterable (remaps to the System filter
+      bit), yellow, no name prefix. **DONE + tested**: permitted sender sees
+      yellow line, non-permitted sender gets the refusal.
+- [x] **7 · City** — entry: combo box. Scope: every connected chat session, i.e.
+      exactly today's global broadcast with the channel id changed.
+      **DONE + tested.** Shipped the simple version per §4 (reaches
+      players inside missions); the insulated variant is a predicate change in
+      `RecipientsFor`, not a redesign.
+- [x] **4 · Local** — combo box + `/l` / `/local`. Scope: same `instance_id`
+      **and** same `task_force`; on home map / VR the registry reports no task
+      force, so it falls back to instance-wide. **DONE + tested** in a live merc
+      mission, including across an autobalance that moved all three players.
+      Note for testers: autobalance can leave a player alone on a side, where
+      "only I can see my Local message" is correct, not a bug. The `[Scope]`
+      log line reports `recipients=` for exactly this reason.
+- [x] **1 · Instance** — entry: **`/i` only** — the combo box cannot offer it
+      (not in the client's candidate table, see §2). Scope: same `instance_id`,
+      both sides. **DONE + tested.**
+- [x] **5 · Team** — combo box + `/t` / `/team`. Scope: `TeamService` party
+      members. **DONE + tested**, including the no-party system reply.
+- [ ] **0 · Global Agenda GM** — entry: `/gl` (client-side) or a staff command.
+      Scope: everyone. Yellow, in the All tab, not user-toggleable. Decide
+      whether it's open to all players or staff-gated — if staff-gated, reuse
+      the `announcers` config list rather than adding a second mechanism.
+      **TODO.**
+- [ ] **2 · Agency** — entry: `/a`. Scope: agency membership. **BLOCKED** on
+      `enable-agencies-alliances` landing: `ga_agencies` / `ga_agency_members`
+      exist but nothing reads them and `send_agency_get_roster_response` is a
+      stub. Needs INF-2 once unblocked.
+- [ ] **3 · Alliance** — entry: `/al`. Scope: alliance membership. **BLOCKED**,
+      same branch as Agency.
+- [ ] **6 · Raid** — entry: `/rg`, `*raid`, `rgw`/`raidw` for raid-whisper.
+      Scope: raid group. **TODO**, no raid-group concept exists server-side yet —
+      scope this before starting.
+- [x] **12 · Trade** and **13 · LFG** — combo box (`/TR`, `/LFG`), global scope,
+      same recipient set as City. **DONE + tested** — free once City worked,
+      both are on the client's combo candidate table.
+- [ ] *9 Private 1, 10 GM, 14 Help, 15–19 VOIP/Combat* — **not planned.** 9, 10
+      and 14+ are in no default tab, so messages sent there are invisible unless
+      the player hand-edits `TgUI.ini`. Do not use them.
+
+### Test matrix (run once the instance-scoped channels are in)
+
+Two accounts, two instances, two sides. Walk every channel and confirm both
+that it reaches who it should and that it does **not** reach who it shouldn't —
+the second half is the one that catches a broken `RecipientsFor`. Plus a whisper
+regression pass, since `broadcast` is shared. Everything logs to the existing
+`chat` channel.
+
+## 6. Reference — how to re-derive this
+
+- Client binary: `D:\SteamLibrary\steamapps\common\Global Agenda Live\Binaries\GlobalAgenda.exe`,
+  image base `0x10900000` (matches Ghidra and our hook addresses).
+- Channel name/colour table init: `FUN_10902990` — decompiles cleanly, and its
+  store addresses give the id mapping directly. Read this, don't infer ids from
+  msg-id ordering.
+- Chat settings screen: `TgUISettingsMenu_Chat` (UC declares the layout; natives
+  registered at `0x1199c4c0..0x1199c4f0`, name/fn pairs).
+- Per-channel colour fetch: `FUN_10901b00`, table at `DAT_1199eca0` (BSS, filled
+  at runtime — reading the file gives zeroes, read the initialiser instead).
+- Incoming message render + tab filter: `FUN_113be150`.
+- Combo box selection: `FUN_113c17b0` (`UserSelectedChannel`).
+- Chat entry submit: TgUIChat vtable `0x11877690`, slot `0x1e0` → `0x113c0010`.
+- Slash command name→id table: `FUN_10917300`; dispatch switch: `FUN_10915fc0`.
+- Message id → text: `asm_data_set_msg_translations` in `out/server.db`
+  (the repo-root `server.db` is 0 bytes; use `out/server.db` via python sqlite3).
+
+
+## 7. If you got here you are my hero.

--- a/src/ControlServer/ChatSession/ChatCommand.cpp
+++ b/src/ControlServer/ChatSession/ChatCommand.cpp
@@ -91,6 +91,21 @@ std::optional<int> ParseInt(const std::string& s) {
 
 } // namespace
 
+std::optional<uint32_t> ChannelForCommandToken(const std::string& token) {
+    const std::string t = LowerAscii(token);
+    // Channel ids: see handoff.md §1. Agency (2), Alliance (3) and Raid (6)
+    // are deliberately absent until the features behind them exist — an
+    // unknown token gets an "unknown command" reply rather than silently
+    // sending into a channel nobody is scoped to.
+    if (t == "l"    || t == "local")    return 4;
+    if (t == "t"    || t == "team")     return 5;
+    if (t == "c"    || t == "city")     return 7;
+    if (t == "i"    || t == "instance") return 1;
+    if (t == "tr"   || t == "trade")    return 12;
+    if (t == "lfg")                     return 13;
+    return std::nullopt;
+}
+
 ParseResult TryParseChatCommand(const std::string& message_text) {
     ParseResult out;
 
@@ -220,6 +235,15 @@ ParseResult TryParseChatCommand(const std::string& message_text) {
         out.suppress_broadcast = true;
         // No args; trailing junk silently ignored (recognized + suppressed).
         if (rest.empty()) out.reload_queues = true;
+        return out;
+    }
+
+    if (cmd_name == "-announce") {
+        out.recognized = true;
+        out.suppress_broadcast = true;
+        // Empty text -> nullopt (silent reject). Permission is the caller's
+        // job — parsing does not know who sent this.
+        if (!rest.empty()) out.announce = rest;
         return out;
     }
 

--- a/src/ControlServer/ChatSession/ChatCommand.cpp
+++ b/src/ControlServer/ChatSession/ChatCommand.cpp
@@ -93,11 +93,12 @@ std::optional<int> ParseInt(const std::string& s) {
 
 std::optional<uint32_t> ChannelForCommandToken(const std::string& token) {
     const std::string t = LowerAscii(token);
-    // Channel ids: see handoff.md §1. Agency (2), Alliance (3) and Raid (6)
-    // are deliberately absent until the features behind them exist — an
-    // unknown token gets an "unknown command" reply rather than silently
-    // sending into a channel nobody is scoped to.
+    // Channel ids: see handoff.md §1. Raid (6) is deliberately absent — no
+    // raid-group concept exists server-side, so an unknown-command reply beats
+    // silently sending into a channel nobody is scoped to.
     if (t == "l"    || t == "local")    return 4;
+    if (t == "a"    || t == "agency")   return 2;
+    if (t == "al"   || t == "alliance") return 3;
     if (t == "t"    || t == "team")     return 5;
     if (t == "c"    || t == "city")     return 7;
     if (t == "i"    || t == "instance") return 1;

--- a/src/ControlServer/ChatSession/ChatCommand.hpp
+++ b/src/ControlServer/ChatSession/ChatCommand.hpp
@@ -92,7 +92,23 @@ struct ParseResult {
     // -reload-queues — re-read ga_queues + ga_map_pool_entries. Handled
     // entirely on the control server; no PLAYER_ACTION IPC dispatched.
     bool reload_queues = false;
+
+    // -announce <text> — server-wide announcement on chat channel 20, the one
+    // channel the client's tab filter cannot exclude. Holds the announcement
+    // text (never empty when set). Handled entirely on the control server;
+    // caller must check the sender is permitted before acting on it.
+    std::optional<std::string> announce;
 };
+
+// Resolve a slash-command token (no leading '/', any case) to the chat channel
+// it targets. Returns nullopt for tokens that aren't channel commands.
+//
+// Covers the commands the client forwards to us as PLAYER_COMMAND (0x019F)
+// because they aren't in its own name->id map — /t, /l, /a, /al, /rg — plus
+// aliases of our own for channels whose combo-box label the client hardcodes
+// (City is shown as "/1", so /c and /city are ours to define). Commands the
+// client handles itself (/w, /gl, /i) never reach us and are absent here.
+std::optional<uint32_t> ChannelForCommandToken(const std::string& token);
 
 // Parse a chat MESSAGE string. Trims leading/trailing whitespace, recognises
 // "-changeteam" (optional arg "attackers" | "defenders"; bare -> Toggle),

--- a/src/ControlServer/ChatSession/ChatSession.cpp
+++ b/src/ControlServer/ChatSession/ChatSession.cpp
@@ -26,6 +26,8 @@ namespace {
 // colour tables built by FUN_10902990 (name at 0x1199ec28 + id*4, ARGB colour
 // at 0x1199eca0 + id*4). See handoff.md §1 for the full table.
 constexpr uint32_t kInstanceChannelId = 1;   // same instance, both sides
+constexpr uint32_t kAgencyChannelId   = 2;   // agency membership
+constexpr uint32_t kAllianceChannelId = 3;   // every agency in the alliance
 constexpr uint32_t kLocalChannelId    = 4;   // same instance + same task force
 constexpr uint32_t kTeamChannelId     = 5;   // party members
 constexpr uint32_t kCityChannelId     = 7;   // every connected session
@@ -222,6 +224,42 @@ std::optional<std::unordered_set<std::string>> RecipientsFor(
         return std::unordered_set<std::string>(guids.begin(), guids.end());
     }
 
+    if (channel == kAgencyChannelId || channel == kAllianceChannelId) {
+        // Agency membership is keyed by account, not character or session, so
+        // resolve guid -> user_id through the session store on both ends.
+        auto sender = PlayerSessionStore::GetByGuid(sender_guid);
+        if (!sender || sender->user_id == 0) return std::unordered_set<std::string>{};
+        const int64_t agency_id = Database::GetAgencyIdForUser(sender->user_id);
+        if (agency_id == 0) return std::unordered_set<std::string>{};
+
+        std::vector<int64_t> member_ids;
+        if (channel == kAgencyChannelId) {
+            member_ids = Database::GetAgencyMemberUserIds(agency_id);
+        } else {
+            const int64_t alliance_id = Database::GetAllianceIdForAgency(agency_id);
+            if (alliance_id == 0) return std::unordered_set<std::string>{};
+            member_ids = Database::GetAllianceMemberUserIds(alliance_id);
+        }
+        const std::unordered_set<int64_t> members(member_ids.begin(), member_ids.end());
+
+        // Walk the connected sessions rather than the member list: offline
+        // members can't receive anything, and this keeps it to one store
+        // lookup per online player instead of a DB query per member.
+        std::unordered_set<std::string> out;
+        PruneExpiredSessions();
+        for (auto& weak : g_chat_sessions) {
+            if (auto peer = weak.lock()) {
+                const std::string& guid = peer->get_session_guid();
+                if (guid.empty()) continue;
+                auto info = PlayerSessionStore::GetByGuid(guid);
+                if (info && members.count(info->user_id)) out.insert(guid);
+            }
+        }
+        Logger::Log("chat", "[Scope] ch=%u agency=%lld members=%zu recipients=%zu\n",
+            channel, (long long)agency_id, members.size(), out.size());
+        return out;
+    }
+
     if (channel == kInstanceChannelId || channel == kLocalChannelId) {
         auto where = InstanceRegistry::GetInstancePlayerTaskForce(sender_guid);
         if (!where) return std::unordered_set<std::string>{};  // not in an instance
@@ -252,7 +290,9 @@ std::optional<std::unordered_set<std::string>> RecipientsFor(
 
 // System line shown when a player sends on a channel they can't currently use.
 const char* UnavailableChannelText(uint32_t channel) {
-    if (channel == kTeamChannelId) return "*** You are not in a team ***";
+    if (channel == kTeamChannelId)     return "*** You are not in a team ***";
+    if (channel == kAgencyChannelId)   return "*** You are not in an agency ***";
+    if (channel == kAllianceChannelId) return "*** Your agency is not in an alliance ***";
     return "*** You are not in an instance ***";
 }
 
@@ -320,7 +360,8 @@ void ChatSession::AnnounceJoinIfNeeded() {
     deliver(BuildChatConfigFrame({ kCityChannelId, kLocalChannelId,
                                    kInstanceChannelId, kTeamChannelId,
                                    kWhisperChannelId, kTradeChannelId,
-                                   kLfgChannelId }));
+                                   kLfgChannelId, kAgencyChannelId,
+                                   kAllianceChannelId }));
     BroadcastSystemMessage(
         "*** " + player_name_ + " has joined the chat ***",
         kSystemChannelId,
@@ -698,8 +739,12 @@ void ChatSession::SendOnChannel(uint32_t channel, const std::string& message) {
                 continue;
             }
             // Ignore gate: don't show this sender's lines to players who
-            // have them on the F3 ignore list.
+            // have them on the F3 ignore list. Logged because a one-way
+            // ignore is indistinguishable from a broken channel when you're
+            // staring at two clients — the sender still sees their own line.
             if (peer.get() != this && peer->is_ignoring(player_name_)) {
+                Logger::Log("chat", "[Chat] ch=%u '%s' ignores '%s' — line dropped\n",
+                    channel, peer->get_player_name().c_str(), player_name_.c_str());
                 continue;
             }
             peer->deliver(chunk);

--- a/src/ControlServer/ChatSession/ChatSession.cpp
+++ b/src/ControlServer/ChatSession/ChatSession.cpp
@@ -1,11 +1,14 @@
 #include "src/ControlServer/ChatSession/ChatSession.hpp"
 #include "src/ControlServer/ChatSession/ChatCommand.hpp"
 #include "src/ControlServer/Database/Database.hpp"
+#include "src/ControlServer/InstanceRegistry/InstanceRegistry.hpp"
 #include "src/ControlServer/MatchmakingService/MatchmakingService.hpp"
+#include "src/ControlServer/TeamService/TeamService.hpp"
 
 #include <algorithm>
 #include <cctype>
 #include <chrono>
+#include <optional>
 #ifndef _WIN32
 #include <netinet/tcp.h>
 #include <sys/socket.h>
@@ -19,14 +22,38 @@ static std::vector<std::weak_ptr<ChatSession>> g_chat_sessions;
 
 namespace {
 
-// Wire-level channel id used for join/leave system announcements. Chosen to
-// be distinct from the gameplay-chat channels the client receives (channel 4
-// = global, channel 8 = DM). Real clients render unknown channels as a
-// default-tinted chat line so the message still appears even if the client
-// has no special styling for this id; the "*** ... ***" decoration in the
-// message body guarantees visibility regardless. If a future client patch
-// adds a dedicated system-tint channel, change here and rebuild.
-constexpr uint32_t kSystemChannelId = 4;
+// Chat channel ids. These are the client's own enum — index into the name and
+// colour tables built by FUN_10902990 (name at 0x1199ec28 + id*4, ARGB colour
+// at 0x1199eca0 + id*4). See handoff.md §1 for the full table.
+constexpr uint32_t kInstanceChannelId = 1;   // same instance, both sides
+constexpr uint32_t kLocalChannelId    = 4;   // same instance + same task force
+constexpr uint32_t kTeamChannelId     = 5;   // party members
+constexpr uint32_t kCityChannelId     = 7;   // every connected session
+constexpr uint32_t kWhisperChannelId  = 8;   // /w, /tell
+constexpr uint32_t kTradeChannelId    = 12;  // every connected session
+constexpr uint32_t kLfgChannelId      = 13;  // every connected session
+
+// Join/leave notices and error replies. Channel 11 (System) is present in all
+// four default tab masks and renders yellow, so these no longer masquerade as
+// Local chat.
+constexpr uint32_t kSystemChannelId = 11;
+
+// -announce goes out on channel 20. FUN_113be150 in the client remaps channel
+// 20 to 11 (System) before testing the player's tab filter mask, and bit 11 is
+// set in all four default tab masks — so a channel-20 line lands in every tab
+// regardless of the player's Chat settings. It is the only id with that
+// property, has no channel-name prefix of its own, and renders yellow.
+constexpr uint32_t kAnnounceChannelId = 20;
+
+// Lowercased names permitted to use -announce. Empty = command disabled.
+// Written once at startup before any session exists, read-only thereafter.
+std::unordered_set<std::string> g_announcers;
+
+std::string ToLowerAscii(std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(),
+        [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return s;
+}
 
 // Hard cap on the per-session write_queue_. Reached only if writes are
 // failing or stalled long enough that the server has queued this many frames
@@ -178,6 +205,57 @@ void BroadcastSystemMessage(const std::string& message_text,
         channel, message_text.c_str(), delivered);
 }
 
+// Which sessions may receive a message on `channel`.
+//
+// nullopt      = every connected session (City, and any channel we don't scope).
+// empty set    = the sender can't use this channel right now (not in an
+//                instance / not in a team) — caller replies with a system line
+//                instead of broadcasting.
+// non-empty    = deliver only to sessions whose guid is in the set. The sender's
+//                own guid is included, so their line still echoes back to them.
+//
+// One roster lookup per message, not per peer.
+std::optional<std::unordered_set<std::string>> RecipientsFor(
+        uint32_t channel, const std::string& sender_guid) {
+    if (channel == kTeamChannelId) {
+        const auto guids = TeamService::GetTeamMemberGuids(sender_guid);
+        return std::unordered_set<std::string>(guids.begin(), guids.end());
+    }
+
+    if (channel == kInstanceChannelId || channel == kLocalChannelId) {
+        auto where = InstanceRegistry::GetInstancePlayerTaskForce(sender_guid);
+        if (!where) return std::unordered_set<std::string>{};  // not in an instance
+        const int64_t instance_id = where->first;
+        const int sender_tf       = where->second;
+
+        // Local is side-scoped ("Attacker/Defender Channel" per the client's
+        // own /help text). On the home map / VR there are no sides — task
+        // force comes back unset, so fall back to instance-wide.
+        const bool side_scoped = (channel == kLocalChannelId) && sender_tf > 0;
+
+        std::unordered_set<std::string> out;
+        const auto roster = InstanceRegistry::GetActivePlayersForInstance(instance_id);
+        for (const auto& row : roster) {
+            if (side_scoped && row.task_force != sender_tf) continue;
+            if (!row.guid.empty()) out.insert(row.guid);
+        }
+        // Recipient count is the one number worth having when someone reports
+        // "my message didn't arrive" — autobalance can leave a player alone on
+        // a side, where recipients=1 is correct rather than broken.
+        Logger::Log("chat", "[Scope] ch=%u inst=%lld sender_tf=%d roster=%zu recipients=%zu\n",
+            channel, (long long)instance_id, sender_tf, roster.size(), out.size());
+        return out;
+    }
+
+    return std::nullopt;  // City + anything unscoped: everyone.
+}
+
+// System line shown when a player sends on a channel they can't currently use.
+const char* UnavailableChannelText(uint32_t channel) {
+    if (channel == kTeamChannelId) return "*** You are not in a team ***";
+    return "*** You are not in an instance ***";
+}
+
 std::string SanitizeCommandForLog(std::string s) {
     for (char& c : s) {
         if (c == '\r' || c == '\n' || c == '\t') c = ' ';
@@ -200,7 +278,8 @@ bool HasParsedCommandAction(const ChatCommand::ParseResult& parsed) {
         || parsed.unpossess
         || parsed.coords
         || parsed.fullheal
-        || parsed.reload_queues;
+        || parsed.reload_queues
+        || parsed.announce.has_value();
 }
 
 } // anonymous namespace
@@ -222,9 +301,26 @@ void ChatSession::start() {
 void ChatSession::AnnounceJoinIfNeeded() {
     if (announced_join_ || player_name_.empty()) return;
     announced_join_ = true;
-    // Enable Local (4) and Tell (8) in the client's channel table so channel
-    // switching (combo box, /local) works — see BuildChatConfigFrame.
-    deliver(BuildChatConfigFrame({ 4, 8 }));
+    // Populate the client's send-channel table (combo box) — see
+    // BuildChatConfigFrame. Sent once at join and never revised: a player who
+    // picks a channel they can't currently use (Team with no party, Local
+    // outside an instance) gets a system reply instead. Far less state to keep
+    // in sync than re-sending CHAT_CONFIG on every instance or party change.
+    //
+    // The combo box can only ever show channels from a hardcoded 10-entry
+    // candidate table in the client (`DAT_1199c770`, read by FUN_113bdd20):
+    // 4 Local, 7 City, 2 Agency, 3 Alliance, 5 Team, 6 Raid, 12 Trade, 13 LFG,
+    // 9 Private1, 10 GM. This packet only decides which of *those* are shown.
+    // Instance (1) and Personal (8) are not on it and can never appear —
+    // Instance is reachable via the client's own /i, Personal via the tell
+    // flow. Both are still enabled here because the client's channel-switch
+    // paths check this table. Private1 (9) and GM (10) are deliberately
+    // omitted: they're selectable but sit in no default tab, so anything sent
+    // on them is invisible to every recipient.
+    deliver(BuildChatConfigFrame({ kCityChannelId, kLocalChannelId,
+                                   kInstanceChannelId, kTeamChannelId,
+                                   kWhisperChannelId, kTradeChannelId,
+                                   kLfgChannelId }));
     BroadcastSystemMessage(
         "*** " + player_name_ + " has joined the chat ***",
         kSystemChannelId,
@@ -433,6 +529,28 @@ void ChatSession::handle_packet(const uint8_t* data, size_t length) {
         if (parsed.recognized && parsed.toggle_broken_suits) {
             ChatCommand::DispatchToggleBrokenSuits(*parsed.toggle_broken_suits, session_guid_);
         }
+        if (parsed.recognized && parsed.announce) {
+            if (!IsAnnouncer()) {
+                Logger::Log("chat-command",
+                    "[ChatCmd] -announce player='%s' guid=%s outcome=denied details=not_in_announcer_list\n",
+                    player_name_.c_str(), session_guid_.c_str());
+                deliver(BuildChatFrame(kSystemChannelId,
+                    "*** You are not permitted to use -announce ***"));
+            } else {
+                // No ignore gate and no self-skip: an announcement goes to
+                // every connected session, sender included.
+                const auto frame = BuildChatFrame(kAnnounceChannelId, *parsed.announce);
+                PruneExpiredSessions();
+                size_t sent = 0;
+                for (auto& weak : g_chat_sessions) {
+                    if (auto peer = weak.lock()) { peer->deliver(frame); sent++; }
+                }
+                Logger::Log("chat-command",
+                    "[ChatCmd] -announce player='%s' guid=%s outcome=sent details=%zu_session(s) text='%s'\n",
+                    player_name_.c_str(), session_guid_.c_str(), sent,
+                    parsed.announce->c_str());
+            }
+        }
         if (parsed.recognized && parsed.reload_queues) {
             Logger::Log("chat-command",
                 "[ChatCmd] -reload-queues player='%s' guid=%s outcome=activated details=MatchmakingService::ReloadQueues\n",
@@ -456,11 +574,13 @@ void ChatSession::broadcast(const uint8_t* data, size_t length) {
 
     PacketView pkt(data + 6, length - 6);
 
-    uint32_t channel = pkt.Read4B(GA_T::CHAT_CH_TYPE).value_or(4);
+    // Missing channel field falls back to City — the unscoped "everyone"
+    // channel, which is what this code did before channels were scoped.
+    uint32_t channel = pkt.Read4B(GA_T::CHAT_CH_TYPE).value_or(kCityChannelId);
 
     std::string message = player_name_ + ": " + pkt.ReadString(GA_T::MESSAGE).value_or("");
 
-    bool isDM = channel == 8;
+    bool isDM = channel == kWhisperChannelId;
 
     if (isDM) {
         // Whisper: recipient arrives in PLAYER_NAME (0x03C5), verified via live capture.
@@ -528,10 +648,30 @@ void ChatSession::broadcast(const uint8_t* data, size_t length) {
         return;
     }
 
-    Logger::Log("chat", "Broadcasting message '%s' to channel %u\n", message.c_str(), channel);
+    SendOnChannel(channel, message);
+}
 
-    uint16_t packet_type = GA_U::CHAT_MESSAGE;
-    uint16_t item_count = 2;
+// Scope, build and deliver one already-formatted chat line. Shared by the chat
+// socket (ChatSession::broadcast) and by slash commands arriving as
+// PLAYER_COMMAND on the main TCP socket (SendChannelMessageFrom).
+void ChatSession::SendOnChannel(uint32_t channel, const std::string& message) {
+    // Scope the recipients before building the frame — an unusable channel
+    // costs the sender a system line and nobody else anything.
+    const auto recipients = RecipientsFor(channel, session_guid_);
+    if (recipients && recipients->empty()) {
+        Logger::Log("chat", "[Chat] ch=%u unavailable for player='%s'\n",
+            channel, player_name_.c_str());
+        deliver(BuildChatFrame(kSystemChannelId, UnavailableChannelText(channel)));
+        return;
+    }
+
+    Logger::Log("chat", "Broadcasting message '%s' to channel %u (%s)\n",
+        message.c_str(), channel,
+        recipients ? "scoped" : "all sessions");
+
+    std::vector<uint8_t> response;
+    const uint16_t packet_type = GA_U::CHAT_MESSAGE;
+    const uint16_t item_count = 2;
 
     append(response, packet_type & 0xFF, packet_type >> 8);
     append(response, item_count & 0xFF, item_count >> 8);
@@ -540,7 +680,7 @@ void ChatSession::broadcast(const uint8_t* data, size_t length) {
     WriteString(response, GA_T::MESSAGE, message);
 
     std::vector<uint8_t> chunk;
-    uint16_t chunk_size = static_cast<uint16_t>(response.size());
+    const uint16_t chunk_size = static_cast<uint16_t>(response.size());
 
     chunk.push_back(chunk_size & 0xFF);
     chunk.push_back(chunk_size >> 8);
@@ -553,18 +693,45 @@ void ChatSession::broadcast(const uint8_t* data, size_t length) {
 
     for (auto& weak : g_chat_sessions) {
         if (auto peer = weak.lock()) {
-            if (isDM) {
-                if (peer.get() == this) {
-                    peer->deliver(chunk);
-                }
-            } else {
-                // Ignore gate: don't show this sender's lines to players who
-                // have them on the F3 ignore list.
-                if (peer.get() != this &&
-                    peer->is_ignoring(player_name_)) {
-                    continue;
-                }
-                peer->deliver(chunk);
+            // Channel scope: instance / side / party membership.
+            if (recipients && !recipients->count(peer->get_session_guid())) {
+                continue;
+            }
+            // Ignore gate: don't show this sender's lines to players who
+            // have them on the F3 ignore list.
+            if (peer.get() != this && peer->is_ignoring(player_name_)) {
+                continue;
+            }
+            peer->deliver(chunk);
+        }
+    }
+}
+
+bool ChatSession::SendChannelMessageFrom(const std::string& session_guid,
+                                         uint32_t channel,
+                                         const std::string& text) {
+    if (session_guid.empty() || text.empty()) return false;
+    PruneExpiredSessions();
+    for (auto& weak : g_chat_sessions) {
+        if (auto peer = weak.lock()) {
+            if (peer->get_session_guid() != session_guid) continue;
+            if (peer->get_player_name().empty()) return false;
+            peer->SendOnChannel(channel, peer->get_player_name() + ": " + text);
+            return true;
+        }
+    }
+    return false;
+}
+
+void ChatSession::SystemMessageToGuid(const std::string& session_guid,
+                                      const std::string& text) {
+    if (session_guid.empty()) return;
+    auto frame = BuildChatFrame(kSystemChannelId, text);
+    for (auto& weak : g_chat_sessions) {
+        if (auto peer = weak.lock()) {
+            if (peer->get_session_guid() == session_guid) {
+                peer->deliver(frame);
+                return;
             }
         }
     }
@@ -583,6 +750,19 @@ bool ChatSession::is_ignoring(const std::string& sender_name) {
     std::transform(lower.begin(), lower.end(), lower.begin(),
         [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
     return ignored_lower_.count(lower) != 0;
+}
+
+void ChatSession::SetAnnouncers(const std::vector<std::string>& names) {
+    g_announcers.clear();
+    for (const auto& n : names) {
+        if (!n.empty()) g_announcers.insert(ToLowerAscii(n));
+    }
+    Logger::Log("chat", "[Chat] announcer list loaded: %zu name(s)\n", g_announcers.size());
+}
+
+bool ChatSession::IsAnnouncer() const {
+    if (g_announcers.empty() || player_name_.empty()) return false;
+    return g_announcers.count(ToLowerAscii(player_name_)) != 0;
 }
 
 void ChatSession::SystemMessageTo(const std::string& player_name, const std::string& text) {

--- a/src/ControlServer/ChatSession/ChatSession.hpp
+++ b/src/ControlServer/ChatSession/ChatSession.hpp
@@ -21,6 +21,7 @@ public:
     void start();
     void deliver(const std::vector<uint8_t>& msg);
     const std::string& get_player_name() const { return player_name_; }
+    const std::string& get_session_guid() const { return session_guid_; }
     // True when this session's player ignores `sender_name`. Backed by a
     // per-session cached ignore set, reloaded only when
     // Database::FriendsEpoch() has changed since the last check.
@@ -29,6 +30,24 @@ public:
     // Deliver a system chat line to one player's chat session, if they have
     // one. Used by TcpSession (e.g. friends "player not found" feedback).
     static void SystemMessageTo(const std::string& player_name, const std::string& text);
+
+    // Same, addressed by session guid — the main TCP socket knows guids, not
+    // player names.
+    static void SystemMessageToGuid(const std::string& session_guid,
+                                    const std::string& text);
+
+    // Send `text` as a chat line on `channel` from the player owning
+    // `session_guid`, with the same recipient scoping an ordinary chat message
+    // gets. Used by the PLAYER_COMMAND (0x019F) slash-command handler, which
+    // arrives on the main TCP socket rather than the chat socket. Returns false
+    // when that player has no bound chat session.
+    static bool SendChannelMessageFrom(const std::string& session_guid,
+                                       uint32_t channel,
+                                       const std::string& text);
+
+    // Names permitted to use -announce. Set once at startup from
+    // ControlServerConfig::announcers; empty means the command is disabled.
+    static void SetAnnouncers(const std::vector<std::string>& names);
 
 private:
     asio::ip::tcp::socket socket_;
@@ -73,10 +92,16 @@ private:
         append(buffer, val & 0xFF, (val >> 8) & 0xFF, (val >> 16) & 0xFF, (val >> 24) & 0xFF);
     }
 
+    // True when this session's player is in the configured announcer list.
+    bool IsAnnouncer() const;
+
     void do_read();
     void do_write();
     void handle_packet(const uint8_t* data, size_t length);
     void broadcast(const uint8_t* data, size_t length);
+    // Scope + build + deliver one formatted chat line. `message` is the final
+    // MESSAGE field ("<name>: <text>"), already prefixed by the caller.
+    void SendOnChannel(uint32_t channel, const std::string& message);
     bool BindPlayerFromRegistry(const char* reason);
     void ScheduleBindRetry();
     void AnnounceJoinIfNeeded();

--- a/src/ControlServer/Config/ControlServerConfig.cpp
+++ b/src/ControlServer/Config/ControlServerConfig.cpp
@@ -110,6 +110,11 @@ ControlServerConfig ControlServerConfig::Load(const std::string& path) {
             if (item.is_string()) cfg.enabled_channels.push_back(item.get<std::string>());
         }
     }
+    if (j.contains("announcers") && j["announcers"].is_array()) {
+        for (const auto& item : j["announcers"]) {
+            if (item.is_string()) cfg.announcers.push_back(item.get<std::string>());
+        }
+    }
     if (j.contains("enabled_crash_channels") && j["enabled_crash_channels"].is_array()) {
         for (const auto& item : j["enabled_crash_channels"]) {
             if (item.is_string()) cfg.enabled_crash_channels.push_back(item.get<std::string>());

--- a/src/ControlServer/Config/ControlServerConfig.hpp
+++ b/src/ControlServer/Config/ControlServerConfig.hpp
@@ -124,6 +124,13 @@ struct ControlServerConfig {
     };
     KickConfig kick;
 
+    // Player names allowed to use "-announce <text>" (case-insensitive).
+    // Empty (the default) = nobody can. Chat channel 20 is unfilterable, so
+    // this is deliberately not open to everyone.
+    // ponytail: a config list, not an ga_users column — swap to a DB flag if
+    // this ever needs per-account revocation or more than a couple of names.
+    std::vector<std::string> announcers;
+
     // Load config from JSON file at path. Returns defaults if file is absent or invalid.
     static ControlServerConfig Load(const std::string& path);
 };

--- a/src/ControlServer/InstanceRegistry/InstanceRegistry.cpp
+++ b/src/ControlServer/InstanceRegistry/InstanceRegistry.cpp
@@ -772,6 +772,9 @@ InstanceRegistry::GetInstancePlayerTaskForce(const std::string& session_guid) {
     const char* sql =
         "SELECT instance_id, task_force_number FROM ga_instance_players "
         "WHERE session_guid = ? AND left_at IS NULL "
+        // Newest first: if a previous instance's row was ever left unstamped,
+        // an unordered LIMIT 1 would hand back the stale instance/task force.
+        "ORDER BY joined_at DESC, id DESC "
         "LIMIT 1";
     if (sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr) != SQLITE_OK || !stmt) {
         Logger::Log("db", "[InstanceRegistry] GetInstancePlayerTaskForce prepare failed: %s\n",

--- a/src/ControlServer/TcpSession/TcpSession.cpp
+++ b/src/ControlServer/TcpSession/TcpSession.cpp
@@ -1,5 +1,6 @@
 #include "src/ControlServer/TcpSession/TcpSession.hpp"
 #include "src/ControlServer/ChatSession/ChatSession.hpp"
+#include "src/ControlServer/ChatSession/ChatCommand.hpp"
 #include "src/ControlServer/Database/Database.hpp"
 #include "src/ControlServer/Auth/LoginAuth.hpp"
 #include "src/ControlServer/Constants/DeviceIds.hpp"
@@ -1925,6 +1926,11 @@ void TcpSession::handle_packet(const uint8_t* data, size_t length) {
 			Logger::Log("tcp", "[%s] Received: QUERY_PLAYERS [0x%04X], item count: %d\n", Logger::GetTime(), packet_type, item_count);
 			PacketView pkt(data + 6, length - 6);
 			send_query_players_response(pkt);
+			break;
+		}
+		case GA_U::PLAYER_COMMAND: {
+			PacketView pkt(data + 6, length - 6);
+			handle_player_command(pkt);
 			break;
 		}
 		case GA_U::FRIEND_GET_LIST:
@@ -4216,6 +4222,64 @@ void TcpSession::send_query_players_response(const PacketView& pkt)
 		caller_id, (int)players.size(), (int)row_count);
 
 	send_response(response);
+}
+
+void TcpSession::handle_player_command(const PacketView& pkt)
+{
+	if (session_guid_.empty()) return;
+
+	// TEXT_VALUE is flagged TYPE_TCP_WCHAR_STR, but the chat path proves this
+	// client ships narrow strings on the wire. Read narrow, fall back to wide.
+	std::string raw = pkt.ReadString(GA_T::TEXT_VALUE).value_or("");
+	if (raw.empty()) {
+		if (auto wide = pkt.ReadWideString(GA_T::TEXT_VALUE)) {
+			raw.assign(wide->begin(), wide->end());  // ASCII-only narrowing
+		}
+	}
+
+	// The client forwards the command with its leading '/' intact on some
+	// paths and stripped on others — tolerate both.
+	size_t start = raw.find_first_not_of(" \t\r\n");
+	if (start == std::string::npos) return;
+	if (raw[start] == '/') start++;
+
+	size_t sep = raw.find_first_of(" \t", start);
+	const std::string token = raw.substr(start, sep == std::string::npos
+		? std::string::npos : sep - start);
+	std::string rest;
+	if (sep != std::string::npos) {
+		size_t body = raw.find_first_not_of(" \t", sep);
+		if (body != std::string::npos) rest = raw.substr(body);
+		while (!rest.empty() && (rest.back() == ' ' || rest.back() == '\t' ||
+		                         rest.back() == '\r' || rest.back() == '\n')) {
+			rest.pop_back();
+		}
+	}
+	if (token.empty()) return;
+
+	const auto channel = ChatCommand::ChannelForCommandToken(token);
+	if (!channel) {
+		Logger::Log("chat-command",
+			"[ChatCmd] PLAYER_COMMAND guid=%s token='%s' outcome=unknown\n",
+			session_guid_.c_str(), token.c_str());
+		ChatSession::SystemMessageToGuid(session_guid_,
+			"*** Unknown command: /" + token + " ***");
+		return;
+	}
+	if (rest.empty()) {
+		ChatSession::SystemMessageToGuid(session_guid_,
+			"*** Usage: /" + token + " <message> ***");
+		return;
+	}
+
+	const bool sent = ChatSession::SendChannelMessageFrom(session_guid_, *channel, rest);
+	Logger::Log("chat-command",
+		"[ChatCmd] PLAYER_COMMAND guid=%s token='%s' channel=%u outcome=%s\n",
+		session_guid_.c_str(), token.c_str(), *channel, sent ? "sent" : "no_chat_session");
+	if (!sent) {
+		ChatSession::SystemMessageToGuid(session_guid_,
+			"*** Chat is not connected ***");
+	}
 }
 
 void TcpSession::handle_friend_update(const PacketView& pkt)

--- a/src/ControlServer/TcpSession/TcpSession.hpp
+++ b/src/ControlServer/TcpSession/TcpSession.hpp
@@ -671,6 +671,12 @@ private:
 void handle_friend_update(const PacketView& pkt);
 void send_friends_list();
 
+    // PLAYER_COMMAND (0x019F) — slash commands the client doesn't recognise
+    // itself are forwarded here verbatim in TEXT_VALUE (0x04FF). Channel
+    // commands (/t, /l, /c, ...) route into the player's chat session;
+    // anything else gets an "unknown command" reply.
+    void handle_player_command(const PacketView& pkt);
+
     // Team wire helpers. Opcodes 0x4A/0x4D/0x4E/0x4F all route to the client's
     // message-display handler (vt[0x54]: MSG_ID 0x36E template + @@token@@
     // fields); 0x4B queues the invitation popup; 0x4C dismisses it (no fields).

--- a/src/ControlServer/TeamService/TeamService.cpp
+++ b/src/ControlServer/TeamService/TeamService.cpp
@@ -68,6 +68,18 @@ bool TeamService::IsTeamed(const std::string& session_guid) {
     return FindTeamByMemberLocked(session_guid) != nullptr;
 }
 
+std::vector<std::string> TeamService::GetTeamMemberGuids(const std::string& session_guid) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<std::string> guids;
+    Team* team = FindTeamByMemberLocked(session_guid);
+    if (!team) return guids;
+    guids.reserve(team->members.size());
+    for (const auto& m : team->members) {
+        if (!m.session_guid.empty()) guids.push_back(m.session_guid);
+    }
+    return guids;
+}
+
 bool TeamService::IsLeader(const std::string& session_guid) {
     std::lock_guard<std::mutex> lock(mutex_);
     Team* team = FindTeamByMemberLocked(session_guid);

--- a/src/ControlServer/TeamService/TeamService.hpp
+++ b/src/ControlServer/TeamService/TeamService.hpp
@@ -92,6 +92,11 @@ public:
     static void KickMember(const std::string& requester_guid, int64_t target_character_id);
 
     static bool IsTeamed(const std::string& session_guid);
+
+    // Session guids of every member of the caller's team, including the
+    // caller. Empty when they aren't in one. Used by the Team chat channel to
+    // resolve recipients.
+    static std::vector<std::string> GetTeamMemberGuids(const std::string& session_guid);
     static bool IsLeader(const std::string& session_guid);
 
     // --- Team queueing -----------------------------------------------------

--- a/src/ControlServer/main.cpp
+++ b/src/ControlServer/main.cpp
@@ -737,6 +737,7 @@ int main(int argc, char* argv[]) {
     }
 
     Logger::Log("main", "Binding chat listener on port %d\n", (int)cfg.chat_port);
+    ChatSession::SetAnnouncers(cfg.announcers);
     // Bind chat listener (GA chat connections — separate port)
     ChatListener chat_listener(io, cfg.chat_port);
     if (!chat_listener.IsListening()) {

--- a/tests/announce_command_test.cpp
+++ b/tests/announce_command_test.cpp
@@ -1,0 +1,102 @@
+// Standalone, host-compiled (x86_64) sanity test for the -announce parse path.
+// NOT part of the server build. Run manually from the repo root:
+//
+//   g++ -std=c++17 -I. -Ilib tests/announce_command_test.cpp \
+//       src/ControlServer/ChatSession/ChatCommand.cpp \
+//       -o /tmp/announce_test && /tmp/announce_test
+//
+// Expected output ends with: "ALL TESTS PASSED".
+//
+// Compile line is unverified (this environment does not build). ChatCommand.cpp
+// also holds the Dispatch* helpers, so the link may pull in Logger /
+// InstanceRegistry / TcpSession translation units — add them to the g++ line if
+// it fails with undefined references. Only TryParseChatCommand is exercised.
+//
+// Covers parsing only — permission (ChatSession::IsAnnouncer) and delivery are
+// not reachable without the asio session, and are exercised in-game.
+
+#include "src/ControlServer/ChatSession/ChatCommand.hpp"
+#include <cassert>
+#include <cstdio>
+
+int main() {
+    using ChatCommand::TryParseChatCommand;
+
+    // Ordinary chat is untouched.
+    {
+        auto r = TryParseChatCommand("hello world");
+        assert(!r.recognized);
+        assert(!r.suppress_broadcast);
+        assert(!r.announce.has_value());
+    }
+
+    // A message that merely mentions the word is still ordinary chat.
+    {
+        auto r = TryParseChatCommand("what does -announce do?");
+        assert(!r.recognized);
+        assert(!r.announce.has_value());
+    }
+
+    // Happy path: text is captured verbatim after the command token.
+    {
+        auto r = TryParseChatCommand("-announce Server restart in 5 minutes");
+        assert(r.recognized);
+        assert(r.suppress_broadcast);
+        assert(r.announce.has_value());
+        assert(*r.announce == "Server restart in 5 minutes");
+    }
+
+    // Case-insensitive command token; leading/trailing space trimmed; inner
+    // spacing of the announcement text preserved.
+    {
+        auto r = TryParseChatCommand("   -ANNOUNCE   keep  inner   spacing   ");
+        assert(r.recognized);
+        assert(r.announce.has_value());
+        assert(*r.announce == "keep  inner   spacing");
+    }
+
+    // No text -> recognized and suppressed, but nothing to send. This must not
+    // broadcast an empty line, and must not fall through to ordinary chat.
+    {
+        auto r = TryParseChatCommand("-announce");
+        assert(r.recognized);
+        assert(r.suppress_broadcast);
+        assert(!r.announce.has_value());
+    }
+    {
+        auto r = TryParseChatCommand("-announce    ");
+        assert(r.recognized);
+        assert(r.suppress_broadcast);
+        assert(!r.announce.has_value());
+    }
+
+    // Neighbouring commands still parse as themselves.
+    {
+        auto r = TryParseChatCommand("-coords");
+        assert(r.recognized);
+        assert(r.coords);
+        assert(!r.announce.has_value());
+    }
+
+    // Channel command tokens (PLAYER_COMMAND path).
+    {
+        using ChatCommand::ChannelForCommandToken;
+        assert(*ChannelForCommandToken("l")        == 4);
+        assert(*ChannelForCommandToken("local")    == 4);
+        assert(*ChannelForCommandToken("T")        == 5);   // case-insensitive
+        assert(*ChannelForCommandToken("c")        == 7);
+        assert(*ChannelForCommandToken("city")     == 7);
+        assert(*ChannelForCommandToken("i")        == 1);
+        assert(*ChannelForCommandToken("tr")       == 12);
+        assert(*ChannelForCommandToken("lfg")      == 13);
+        // Not channel commands: unimplemented features and junk.
+        assert(!ChannelForCommandToken("a").has_value());    // agency
+        assert(!ChannelForCommandToken("al").has_value());   // alliance
+        assert(!ChannelForCommandToken("rg").has_value());   // raid
+        assert(!ChannelForCommandToken("").has_value());
+        assert(!ChannelForCommandToken("nonsense").has_value());
+    }
+
+    printf("ALL TESTS PASSED\n");
+    return 0;
+}


### PR DESCRIPTION
Adds Agency and Alliance chat channels to the channel-based chat system, and brings implement-chats up to date with upstream/master (rebased — the agency/alliance management backend the routing depends on was already merged upstream via PR #44).

What's added

Two new scoped channels wired into the existing RecipientsFor routing in ChatSession.cpp, plus their command tokens in ChatCommand.cpp. Recipient resolution goes guid → user_id → agency/alliance membership (agency is keyed by account, not character/session), then delivers only to online members by walking connected sessions — one session-store lookup per online player, no per-member DB query.

How to use a channel

Prefix a line with the channel command, e.g. /t hello or /team hello. Full token → channel list:

<img width="1651" height="498" alt="image" src="https://github.com/user-attachments/assets/3eadadd6-aaf7-4825-997a-227616ad8014" />

Raid (6) is intentionally unmapped — there's no raid-group concept server-side, so its token gets an "unknown command" reply rather than sending into a channel nobody is scoped to.

Errors when you can't use a channel

If you send on a channel you're not currently scoped to, you get a yellow system line back and the message goes nowhere:
- Team, not in a party → *** You are not in a team ***
- Agency, no agency → *** You are not in an agency ***
- Alliance, agency not in an alliance → *** Your agency is not in an alliance ***
- Instance/Local, not in an instance → *** You are not in an instance ***

The -announce command

-announce <text> broadcasts a server-wide yellow notice that lands in every chat tab regardless of the recipient's Chat settings — it goes out on channel 20, which the client remaps to System (11), a bit set in all four default tab masks. It has no channel prefix, ignores the F3 ignore list, and is not echoed with a self-skip (the announcer sees it too).

Whitelisting an announcer: the command is permission-gated by an allowlist in control-server.json:
"announcers": ["SomeName", "AnotherName"]
Names are case-insensitive. An empty list disables the command entirely. A non-whitelisted player who tries it gets *** You are not permitted to use -announce *** (logged as outcome=denied). The list is read once at startup.

Diagnostics

All routing logs to the chat channel: [Scope] lines report recipient counts per send (including the agency member count), and a one-way ignore now logs [Chat] ch=… 'X' ignores 'Y' — line dropped — otherwise a one-sided ignore looks identical to a broken channel across two test clients.

Branch update note

implement-chats was rebased onto upstream/master (was 1 ahead / 29 behind). One conflict in ChatCommand.cpp (upstream's -toggleallsuits vs this branch's -announce block) — both kept. Pre-rebase tip backed up at branch backup/implement-chats-preupstream. origin/implement-chats was never pushed, so a normal push applies (no force-push).

---

Related to: https://discord.com/channels/994691794627461211/1529206941929439393