### PR TITLE
Load the player's chosen hair and face morphs in game

### DIFF
--- a/src/ControlServer/TcpSession/TcpSession.cpp
+++ b/src/ControlServer/TcpSession/TcpSession.cpp
@@ -1656,6 +1656,10 @@ void TcpSession::handle_packet(const uint8_t* data, size_t length) {
 		}
 		case GA_U::ADD_PLAYER_CHARACTER: {
 			Logger::Log("tcp", "[%s] Received: ADD_PLAYER_CHARACTER [0x%04X]\n", Logger::GetTime(), packet_type);
+			// Field set confirmed from a live capture: PROFILE_ID, HEAD_ASM_ID,
+			// HAIR_ASM_ID, GENDER_TYPE_VALUE_ID, DWORDS (morph blob), CALLER_ID.
+			// The client sends no SKIN/EYE_MATERIAL_PARAMETER_ID — skin tone is
+			// carried inside the morph blob, so those two columns stay 0.
 			PacketView pkt(data + 6, length - 6);
 			// uint32_t trainingMapGameId  = pkt.Read4B(GA_T::TRAINING_MAP_GAME_ID).value_or(0);  // unused: both paths now use initiate_player_register_and_go_play
 			pkt.Read4B(GA_T::TRAINING_MAP_GAME_ID);  // consume but ignore
@@ -3668,10 +3672,28 @@ void TcpSession::send_character_list_response()
 		}
 	}
 
+	// Head-morph poses, decoded from the (node index, weight) uint32 pairs the
+	// client sent at creation. TgUICharacterSelectScene.UpdateCustomModel feeds
+	// these to the preview model via PopulateCurrentMorphSettings — the skin
+	// tone rides along with them (the head menu's colour sliders are morph
+	// nodes: EHeadMorphGroups has HMG_Colors / HMG_HairColors), which is why
+	// the assembly's SkinToneParameterId alone can't carry it.
+	struct MorphEntry { uint32_t char_id; uint32_t node_index; uint32_t weight; };
+	std::vector<MorphEntry> morphs;
+	for (const auto& c : characters) {
+		const size_t pairs = c.morph_data.size() / 8;
+		for (size_t i = 0; i < pairs; ++i) {
+			uint32_t idx = 0, weight = 0;
+			std::memcpy(&idx,    c.morph_data.data() + i * 8,     4);
+			std::memcpy(&weight, c.morph_data.data() + i * 8 + 4, 4);
+			morphs.push_back({ static_cast<uint32_t>(c.id), idx, weight });
+		}
+	}
+
 	std::vector<uint8_t> response;
 
 	uint16_t packet_type = GA_U::GSC_CHARACTER_LIST;
-	uint16_t item_count = 3;
+	uint16_t item_count = 4;
 
 	append(response, packet_type & 0xFF, packet_type >> 8);
 	append(response, item_count & 0xFF, item_count >> 8);
@@ -3708,6 +3730,16 @@ void TcpSession::send_character_list_response()
 		Write4B(response, GA_T::CHARACTER_ID,           entry.char_id);
 		Write4B(response, GA_T::ITEM_ID,                static_cast<uint32_t>(entry.item_id));
 		Write4B(response, GA_T::EQUIPPED_SLOT_VALUE_ID, static_cast<uint32_t>(entry.slot_value_id));
+	}
+
+	append(response, GA_T::DATA_SET_CHAR_MORPH_SETTINGS & 0xFF, GA_T::DATA_SET_CHAR_MORPH_SETTINGS >> 8);
+	append(response, static_cast<uint8_t>(morphs.size() & 0xFF),
+	                 static_cast<uint8_t>(morphs.size() >> 8));
+	for (const auto& m : morphs) {
+		append(response, 0x03, 0x00);  // 3 fields: CHARACTER_ID, MORPH_NODE_INDEX, MORPH_NODE_WEIGHT
+		Write4B(response, GA_T::CHARACTER_ID,      m.char_id);
+		Write4B(response, GA_T::MORPH_NODE_INDEX,  m.node_index);
+		Write4B(response, GA_T::MORPH_NODE_WEIGHT, m.weight);
 	}
 
 	send_response(response);

--- a/src/GameServer/Cosmetics/CosmeticEquip.cpp
+++ b/src/GameServer/Cosmetics/CosmeticEquip.cpp
@@ -541,19 +541,21 @@ void LoadFromDB(ATgPawn* Pawn, int64_t character_id, int item_profile_id) {
 	auto* PRI      = (ATgRepInfo_Player*)Pawn->PlayerReplicationInfo;
 	item_profile_id = NormalizeItemProfileId(Pawn, item_profile_id);
 
-	// (0) Pull head_asm_id + gender from ga_characters. These are character
-	// state (picked at character creation), not cosmetic-equip state. Engine
-	// class defaults (TgPawn_Character.uc:1097 male / line 907-908 female via
+	// (0) Pull the character-creation state from ga_characters: head, gender,
+	// hair and the morph-pose blob. These are character state (picked in the
+	// head menu at creation), not cosmetic-equip state. Engine class defaults
+	// (TgPawn_Character.uc:1097 male / line 907-908 female via
 	// GetDefaultAssembly) are used as the fallback when the row is missing.
 	int headMesh = 1605;                          // male class default
 	int genderId = GA_G::GENDER_TYPE_ID_MALE;     // 853
 	uint32_t profileId = 680;                     // Assault class default
+	int hairAsmId = 0;                            // 0 = not set → gender default below
 	{
 		sqlite3* db = Database::GetConnection();
 		if (db) {
 			sqlite3_stmt* stmt = nullptr;
 			if (sqlite3_prepare_v2(db,
-				"SELECT head_asm_id, gender_type_value_id, profile_id "
+				"SELECT head_asm_id, gender_type_value_id, profile_id, hair_asm_id, morph_data "
 				"FROM ga_characters WHERE id = ?",
 				-1, &stmt, nullptr) == SQLITE_OK) {
 				sqlite3_bind_int64(stmt, 1, character_id);
@@ -561,22 +563,48 @@ void LoadFromDB(ATgPawn* Pawn, int64_t character_id, int item_profile_id) {
 					const int h = sqlite3_column_int(stmt, 0);
 					const int g = sqlite3_column_int(stmt, 1);
 					const int p = sqlite3_column_int(stmt, 2);
+					const int hr = sqlite3_column_int(stmt, 3);
 					if (h > 0) headMesh = h;
 					if (g > 0) genderId = g;
 					if (p > 0) profileId = (uint32_t)p;
+					if (hr > 0) hairAsmId = hr;
+
+					// morph_data is the client's CharacterInfoStruct.nMorphSettings
+					// array, sent at creation as (node index, weight) uint32 pairs
+					// (TgDataInterface.uc:19, ADD_PLAYER_CHARACTER DWORDS payload).
+					// r_nMorphSettings is index-addressed, so scatter the pairs into
+					// it; the client's repnotify sets m_bApplyMorphSettingsNextTick
+					// and ApplyMorphSettings drives the head morph nodes from there.
+					const auto* blob = (const uint8_t*)sqlite3_column_blob(stmt, 4);
+					const int pairs  = blob ? sqlite3_column_bytes(stmt, 4) / 8 : 0;
+					int maxIdx = -1;
+					for (int i = 0; i < pairs; ++i) {
+						uint32_t idx = 0, weight = 0;
+						memcpy(&idx,    blob + i * 8,     4);
+						memcpy(&weight, blob + i * 8 + 4, 4);
+						if (idx >= 255) continue;   // r_nMorphSettings[255]
+						charPawn->r_nMorphSettings[idx] = (int)weight;
+						if ((int)idx > maxIdx) maxIdx = (int)idx;
+					}
+					// Inclusive bound: ApplyMorphSettings (client 0x109dc1d0) does
+					// `cmp poseId, r_nMaxMorphIndexSentFromServer; jle use-sent-value`
+					// and substitutes a default weight for pose ids above it.
+					charPawn->r_nMaxMorphIndexSentFromServer = maxIdx;
 				}
 				sqlite3_finalize(stmt);
 			}
 		}
 	}
-	// Hair pairs with gender. Both branches now use 1757 (NewHair1) — the
-	// male class default that was already in use. The original code wrote
-	// 0 for female, which crashes the client at 0x109d1f5b on the hair-
-	// component deref through 0xCCCCCCCC. This is the MINIMAL change off
-	// the pre-session baseline. Earlier attempts in this session widened
-	// the SELECT and added a SpawnPlayerCharacter pre-Fill — both regressed
-	// the inventory pipeline and have been reverted.
-	const int hairMesh = 1757;
+	// Hair pairs with gender: male hair meshes are asm_mesh_type 596, female
+	// 850, and a mismatched pair crashes the client at 0x109d1f5b on the hair-
+	// component deref. 403 (PC_CHARBUILD_Bald) is a character-builder-only asm
+	// that isn't loadable from the in-game pawn-attach pipeline — it crashes
+	// the same way, so it falls back to the gender default too.
+	const int hairMesh =
+		(hairAsmId > 0 && hairAsmId != 403)
+			? hairAsmId
+			: (genderId == GA_G::GENDER_TYPE_ID_FEMALE ? 1974   // NewHair15, type 850
+			                                           : 1757); // NewHair1,  type 596
 
 	// (1) Initialize the baseline assembly. Owning this here (instead of in
 	// SpawnPlayerCharacter) keeps the cosmetic state machine in one place and


### PR DESCRIPTION
Bug

A character's face and hair were only correct on the character-select screen. In game every player spawned with a hardcoded hair mesh (1757 NewHair1) and no head morphs at all — everyone wore the same default face. Logging in from a second machine also showed a default face at character select, because the morph data was never sent by the server; the creating client was just rendering its own in-memory copy.

Root cause

Two independent gaps, both server-side:

1. CosmeticEquip::LoadFromDB builds the pawn's baseline r_CustomCharacterAssembly. It read head_asm_id, gender_type_value_id and profile_id from ga_characters, but hardcoded hairMesh = 1757 and never touched r_nMorphSettings. The columns it needed — hair_asm_id and morph_data — were already populated at character creation and simply never read back.
2. GSC_CHARACTER_LIST carried the assembly fields and the equipped cosmetics, but no morph payload. TgUICharacterSelectScene.UpdateCustomModel feeds the preview model from two separate sources — SetCustomAssembly(...) and PopulateCurrentMorphSettings() — and we

What the data actually looks like

ga_characters.morph_data is the client's CharacterInfoStruct.nMorphSettings array (TgDataInterface.uc:19), sent verbatim in the ADD_PLAYER_CHARACTER DWORDS field: uint32 (node index, weight) pairs, indices 0–73, weights 0–255 with 127 neutral. Confirmed against every row in server.db and against a live packet capture.

Disassembling the client settled the two thiet right.ATgPawn_Character::ApplyMorphSettings (vtable 0x116c74b8 slot 0x964, impl 0x109dc1d0) walks the head anim tree, reads each node's pose id from byte [node+0x99], and indexes r_nMorphSettings with it — so the array is addressed by pose
id, not by array position. It then does cmp se-sent-value, substituting a default weightfor pose ids above the bound: r_nMaxMorphIndexSentFromServer is inclusive, so it gets maxIdx, not maxIdx + 1.

Hair asm ids are gendered — male hair is asmle 850 — and a mismatched pair crashes theclient at 0x109d1f5b on the hair-component deref. Asm 403 PC_CHARBUILD_Bald is character-builder-only and crashes the same way from the in-game pawn-attach pipeline, so it falls back too.

the last piece. A capture of ADD_PLAYER_CHARACTER (0x0082) shows exactly six fields — PROFILE_ID, HEAD_ASM_ID, HAIR_ASM_ID, GENDER_TYPE_VALUE_ID, DWORDS, CALLER_ID — and no SKIN_MATERIAL_PARAMETER_ID or EYE_MATERIAL_PARAMETER_ID, which is why those two columns are 0 for every character that has ever been created. The tone travels inside the morph blob instead: after the pose pairs there is a run of exactly 7 entries with node index 0, matching the builder's GetSkinColorsFromHeadMorphData(out SkinColor, out BaseSkinColor, out SkinTone), and the first of those 7 is the only value that differs between characters. Sending the morph block therefore fixes the tone as a side effect — no new column, no new field.

Changes

src/GameServer/Cosmetics/CosmeticEquip.cpp
- Widened the ga_characters read to include hair_asm_id and morph_data.
- Scatter the morph pairs into r_nMorphSettings[idx] and set r_nMaxMorphIndexSentFromServer = maxIdx (inclusive). No blob leaves it at -1, i.e. the client's own defaults.
- Hair comes from hair_asm_id; 0 and 403 fall back to a gender-matched default (1757 male / 1974 female) instead of the unconditional 1757.

src/ControlServer/TcpSession/TcpSession.cpp
- send_character_list_response gains a fourth block, DATA_SET_CHAR_MORPH_SETTINGS, one record per pair: CHARACTER_ID + MORPH_NODE_INDEX + MORPH_NODE_WEIGHT, mirrorYER_INVENTORY record shape. Outer item count 3 → 4.
- Comment recording the confirmed ADD_PLAYER_CHARACTER field set, so the next person doesn't re-hunt for a skin-tone tag that isn't there.
on — every column involved already existed and was already populated.

Testing

Two clients on a LAN against one server, VR Arena.

- In game, both clients: correct face morphsskin tone, on the client that created thecharacter and on the one that never saw it. Female character with hair_asm_id 1941 (type 850) and male characters on type-596 hair — no hair-attach crash on eith
- Character select before the change: correct face only on the creating client, default skin tone everywhere.
- Character select after the change: correct face and tone on a client that had never created either character — GSC_CHARACTER_LIST sent 152 morph rows for 2 characters, 3553-byte payload over 3 chunks, no client-side error and no GET_MORPH_SETTINGS (0x0156) request, confirming the character-list block is the entire delivery path.

Known cosmetic seam, deliberately not addressed: on the character-select model the face reads its colour from the morph blob while the body reads SkinToneParameterId from the assembly, which stays 0 — so arms render slightly darker than the face there. It does not occur in ga inventing a mapping from the blob's tonebyte onto asm_data_set_material_parameters (type 521) with nothing to validate it against.

Expanded on https://github.com/commonwealthga/commonwealth-ga-server/pull/17 PR by [YPowTecH](https://github.com/commonwealthga/commonwealth-ga-server/issues?q=is%3Apr+is%3Aopen+author%3AYPowTecH)

Related to:  https://discord.com/channels/994691794627461211/1530601026896400464