### PR TITLE
Announce agency joins and departures on the agency chat channel

### DIFF
--- a/src/ControlServer/ChatSession/ChatSession.cpp
+++ b/src/ControlServer/ChatSession/ChatSession.cpp
@@ -768,6 +768,25 @@ bool ChatSession::SendChannelMessageFrom(const std::string& session_guid,
     return false;
 }
 
+void ChatSession::AgencyMessage(int64_t agency_id, const std::string& text) {
+    if (agency_id == 0 || text.empty()) return;
+    const auto ids = Database::GetAgencyMemberUserIds(agency_id);
+    const std::unordered_set<int64_t> members(ids.begin(), ids.end());
+    auto frame = BuildChatFrame(kAgencyChannelId, text);
+    PruneExpiredSessions();
+    size_t delivered = 0;
+    for (auto& weak : g_chat_sessions) {
+        auto peer = weak.lock();
+        if (!peer) continue;
+        const std::string& guid = peer->get_session_guid();
+        if (guid.empty()) continue;
+        auto info = PlayerSessionStore::GetByGuid(guid);
+        if (info && members.count(info->user_id)) { peer->deliver(frame); delivered++; }
+    }
+    Logger::Log("chat", "[Chat] agency msg agency=%lld text='%s' delivered to %zu session(s)\n",
+        (long long)agency_id, text.c_str(), delivered);
+}
+
 void ChatSession::SystemMessageToGuid(const std::string& session_guid,
                                       const std::string& text) {
     if (session_guid.empty()) return;

--- a/src/ControlServer/ChatSession/ChatSession.hpp
+++ b/src/ControlServer/ChatSession/ChatSession.hpp
@@ -36,6 +36,12 @@ public:
     static void SystemMessageToGuid(const std::string& session_guid,
                                     const std::string& text);
 
+    // Push a line onto the green Agency channel for every online member of
+    // `agency_id`. Used by TcpSession for the join/leave/kick notices; the
+    // membership row of the player being announced must already be written
+    // (join) or deleted (leave) so the audience matches the new roster.
+    static void AgencyMessage(int64_t agency_id, const std::string& text);
+
     // Send `text` as a chat line on `channel` from the player owning
     // `session_guid`, with the same recipient scoping an ordinary chat message
     // gets. Used by the PLAYER_COMMAND (0x019F) slash-command handler, which

--- a/src/ControlServer/TcpSession/TcpSession.cpp
+++ b/src/ControlServer/TcpSession/TcpSession.cpp
@@ -3385,6 +3385,8 @@ void TcpSession::handle_agency_disband()
 		Logger::Log("agency", "[TCP] AGENCY leave: user %lld leaving agency %lld\n",
 			(long long)user_id_, (long long)agency_id);
 		Database::RemoveAgencyMember(agency_id, selected_character_id_);
+		// Announced after the delete so the leaver isn't in the audience.
+		ChatSession::AgencyMessage(agency_id, player_name + " has left the agency.");
 		// Alliance tab needs the explicit reset too — it only refreshes while open.
 		send_agency_get_roster_response();
 		send_alliance_member_list_response();
@@ -3515,6 +3517,7 @@ void TcpSession::handle_agency_accept()
 	}
 	Logger::Log("agency", "[TCP] AGENCY_ACCEPT: user %lld joined agency %lld\n",
 		(long long)user_id_, (long long)agency_id);
+	ChatSession::AgencyMessage(agency_id, player_name + " has joined the agency.");
 	// Roster + alliance both: the agency I just joined may already be in an
 	// alliance, and the Alliance tab won't refresh on its own until opened.
 	send_agency_get_roster_response();
@@ -3761,7 +3764,9 @@ void TcpSession::handle_agency_kick(int64_t target_char)
 	}
 
 	const int64_t kicked_user = target->user_id;
+	const std::string kicked_name = target->player_name;
 	if (!Database::RemoveAgencyMember(my_agency, target_char)) return;
+	ChatSession::AgencyMessage(my_agency, kicked_name + " has left the agency.");
 	send_agency_get_roster_response();
 	// Push the reset to the kicked player too: their agency panel would clear on
 	// its own roster poll, but the Alliance tab only refreshes while that tab is


### PR DESCRIPTION
Announce agency joins and departures on the agency chat channel

Problem

Agency membership changes were completely silent. A player accepting an invite, leaving, or being kicked produced no chat output — the only signal was the roster panel quietly gaining or losing a row, which members only notice if the agency window happens to be open. Long-standing agencies had no way to see who came and went.

Fix

New ChatSession::AgencyMessage(agency_id, text) pushes a line onto channel 2 (Agency, green) to every online member of an agency. It reuses the existing BuildChatFrame and the same session-guid to user_id resolution that agency chat scoping already does, so recipients match ordinary agency chat exactly.

Wired into all three membership mutation sites — the only callers of Database::AddAgencyMember / RemoveAgencyMember:

- handle_agency_accept — "X has joined the agency."
- handle_agency_disband, non-leader leave path — "X has left the agency."
- handle_agency_kick — same line; the name is captured before the row is deleted.

Each notice is sent after the DB write, so the audience is the post-change roster: joiners see their own arrival, leavers and kicked players do not see their own departure.

Notes

- Disband is deliberately not announced — by the time it completes, every membership row is gone, so an agency-channel line would reach nobody.
- No new .cpp, so the Makefile is unchanged.
- Log channel chat reports agency id, text, and delivered session count for each notice.


Related to:  https://discord.com/channels/994691794627461211/1530705129911877752