### PR TITLE
Armed bombs and mines survive their deployer's death

### DIFF
--- a/src/Database/Database.cpp
+++ b/src/Database/Database.cpp
@@ -10658,6 +10658,21 @@ void Database::Init() {
 			"Think-Tank (1417) back in natural rotation\n");
 	}
 
+	if (version < 155) {
+		// v155: placed mines survive their deployer's death. destroy_on_owner_death_flag=1
+		// made Recon's mines (77-81) and sticky poison mines (95-98) vanish the moment the
+		// deployer died — an armed mine is a trap that runs its own trigger/lifespan, same
+		// as the timer bombs KillDeployables already skips. Sticky grenades (62/65/66/67)
+		// and HackNSlash (215) keep the flag.
+		result = sqlite3_exec(db,
+			"UPDATE asm_data_set_deployables SET destroy_on_owner_death_flag = 0 "
+			"WHERE deployable_id IN (77, 78, 79, 81, 95, 96, 97, 98);",
+			nullptr, nullptr, &err);
+		if (result != SQLITE_OK) { Logger::Log("db", "Failed v155 (mines survive owner death): %s\n", err); return; }
+
+		Logger::Log("db", "v155: mines 77-81 / 95-98 no longer destroyed on owner death\n");
+	}
+
 	// VR heal pad: enforce the pad device unconditionally (idempotent) —
 	// branch-divergent DBs have version counters past the v101/v102 gates.
 	// 2064 = Medical Station pulse (1.0s refire, FX 432 visual pulse);
@@ -10669,7 +10684,7 @@ void Database::Init() {
 		nullptr, nullptr, &err);
 	if (result != SQLITE_OK) { Logger::Log("db", "Failed VR heal pad device enforce: %s\n", err); return; }
 
-	result = sqlite3_exec(db, "UPDATE version_info SET version = 154", nullptr, nullptr, &err);
+	result = sqlite3_exec(db, "UPDATE version_info SET version = 155", nullptr, nullptr, &err);
 	if (result != SQLITE_OK) {
 		Logger::Log("db", "Failed to update version_info: %s\n", err);
 		return;

--- a/src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.cpp
+++ b/src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.cpp
@@ -61,6 +61,27 @@ void __fastcall TgPawn__KillDeployables::Call(ATgPawn* Pawn, void* edx, unsigned
 			continue;
 		}
 
+		// An armed explosive outlives its owner. Two kinds, both of which run
+		// their own trigger-then-expire lifecycle and self-destroy without any
+		// help from the deployer:
+		//   - timer bombs (show_countdown_timer_flag — Elite Assassin's Timed
+		//     Explosive 129, Recon's Fire/EMP/Venom/Graviton bombs, AVA BOMB):
+		//     fuse then explode, LifeSpan bounded by s_fActivationTime.
+		//   - proximity mines (s_fProximityRadius > 0, set from prop 8 — the
+		//     same field UC's Active.BeginState uses as its "this is a mine"
+		//     discriminator): sit armed until touched, LifeSpan-bounded.
+		// This sits ABOVE both blankets on purpose. bAll fires from
+		// KillAllOwnedPets at pawn Destroyed(), which is where a player's mines
+		// were still being swept a few seconds after death — the flag gate
+		// below never gets a say there.
+		if (DeployableClassify::IsTimerBomb(dep->r_nDeployableId) ||
+		    dep->s_fProximityRadius > 0.0f) {
+			Logger::Log("debug",
+				"  [KillDeployables] keep [%d] 0x%p deployableId=%d (armed explosive — expires on its own)\n",
+				i, dep, dep->r_nDeployableId);
+			continue;
+		}
+
 		const bool shouldDestroy = bDestroyAll || dep->m_bDestroyOnOwnerDeathFlag;
 		if (!shouldDestroy) {
 			Logger::Log("debug",


### PR DESCRIPTION
Bug

Killing an Elite Assassin made his Timed Explosive vanish instead of detonating, and a Recon's deployed mines were swept a few seconds after he died. The owner-death fix that made a Techro's drone/station die with him (TgPawn::KillDeployables) treated every AI owner's death as a blanket destroy-all, catching the assassin's fused bomb. Mines were reaped separately by the bAll=true call from KillAllOwnedPets() at pawn Destroyed(), which ignores destroy_on_owner_death_flag entirely.

Fix

Exempt armed explosives from every destroy p both blankets. Two kinds, both of which run their own trigger-then-expire lifecycle and self-destroy with no help from the deployer: timer bombs (show_countdown_timer_flag — assassin's Timed Explosive 129, Recon's Fire/EMP/Venom/Graviton bombs, AVA BOMB) and
proximity mines (s_fProximityRadius > 0, theState uses as its mine discriminator). Bothare LifeSpan-bounded, so nothing leaks.

DB migration v155 clears destroy_on_owner_death_flag on mines 77-81 / 95-98 so the data agrees with the behavior. Sticky grenades (62/65/66/67) and HackNSlash (215) keep the flag.                                              
Unchanged: KillAllOwned (leave-mission / team-change / profile-swap) still sweeps bombs and mines unconditionalturrets, stations, drones and decoys still d

Testing done

Tested on a live instance: killed an Elite Assassin — his Timed Explosive stayed and detonated. Killed a Recon mid-fight with bombs thrown and mines deployff on their own. Recon decoy still gets killed with its owner, as expected, but bombs and mines stay alive.

Related to: https://discord.com/channels/994691794627461211/1531822354114678974