### PR TITLE
Remove Scramble: Tetra Pier placeholder location text on the character select screen

### DIFF
--- a/src/ControlServer/TcpSession/TcpSession.cpp
+++ b/src/ControlServer/TcpSession/TcpSession.cpp
@@ -4795,7 +4795,9 @@ void TcpSession::send_character_list_response()
 		Write4B(response, GA_T::HEAD_ASM_ID,                c.head_asm_id);
 		Write4B(response, GA_T::HAIR_ASM_ID,                c.hair_asm_id);
 		Write4B(response, GA_T::GENDER_TYPE_VALUE_ID,       c.gender_type_value_id);
-		WriteString(response, GA_T::MAP_NAME,               "Scramble: Tetra Pier");
+		// Per-character "Location" label (CharacterSelectEntry.cseLocation). We
+		// don't track a last-played map, so send empty rather than a placeholder.
+		WriteString(response, GA_T::MAP_NAME,               "");
 		Write4B(response, GA_T::XP_VALUE,                   0xbbddc);
 		Write4B(response, GA_T::SKILL_GROUP_SET_ID,         GetClassConfig(c.profile_id).skillGroupSetId);
 		Write4B(response, GA_T::SKIN_MATERIAL_PARAMETER_ID, c.skin_mat_param_id);


### PR DESCRIPTION
Bug

The character select screen showed a hardcoded "Scramble: Tetra Pier" under every character. The MAP_NAME (0x326) field in the GSC_CHARACTER_LIST response feeds CharacterSelectEntry.cseLocation — the per-character "Location" line — and it was left as a placeholder from when the packet was originally reversed. Same origin as the junk values still sitting in the unused mock variants ("alsdfslfjlj").

Fix

Send an empty string instead of the placeholder. We don't track a last-played map (no such column on ga_characters), so showing a real location would mean a schema change plus a match-end write for a cosmetic label — not worth it. Sending an empty string rather than dropping the TLV keeps the field count at 14 and forces the label blank even if the native UpdateCharacterListCallback only writes the label when the tag is present.

One line changed in send_character_list_response. The mock/queue variants are dead code and were left alone.

Testing done

Launched the game and checked the character select list — the location line is now blank on every character. Photo to follow.
<img width="1375" height="1080" alt="image" src="https://github.com/user-attachments/assets/c185e54d-bd9b-43f6-b895-8b66c552cbcf" />

Related to:  https://discord.com/channels/994691794627461211/1531830090739224746