### PR TITLE
Credit mine kills in the Device Stats tab

### DIFF
--- a/src/GameServer/Stats/DeviceStats.hpp
+++ b/src/GameServer/Stats/DeviceStats.hpp
@@ -33,8 +33,11 @@ int DeviceIdFromModeId(int deviceModeId);
 
 // Deployable → the player-equippable device that places it (directly or via
 // its projectile). Loaded once, cached. Returns 0 when unknown or when more
-// than one equippable device spawns the same deployable (mines: Standard Mine
-// vs Archer's Folly — no way to tell them apart from the deployable alone).
+// than one equippable device spawns the same deployable.
+//
+// Last-resort fallback only — callers should read the deployable's r_Owner
+// (the spawning ATgDevice) first. This map resolves 16 of 185 deployables and
+// can't disambiguate deployable 81 "Mine" (devices 2225 / 6521).
 int DeviceIdFromDeployableId(int deployableId);
 
 }  // namespace DeviceStats

--- a/src/GameServer/TgGame/TgEffect/TrackStats/TgEffect__TrackStats.cpp
+++ b/src/GameServer/TgGame/TgEffect/TrackStats/TgEffect__TrackStats.cpp
@@ -313,15 +313,28 @@ void __fastcall TgEffect__TrackStats::Call(UTgEffect* /*Effect*/, void* /*edx*/,
 
 	// Deployable-fired (Medical Station heal, mine blast, force wall): the
 	// fire mode's m_Owner is the ATgDeployable itself, not an ATgDevice, so
-	// the helper above returns 0 and the event would go uncredited. Map the
-	// deployable back to the device the player equipped to place it.
+	// the helper above returns 0 and the event would go uncredited. Recover
+	// the device the player equipped from the deployable's r_Owner — set on
+	// both spawn paths (SpawnDeployable.cpp:1002, TgDeviceFire__Deploy.cpp:160).
+	// The DB deployable→device map only covers the case where r_Owner is gone
+	// (device destroyed before the blast) and can't disambiguate deployables
+	// spawned by more than one device (deployable 81 "Mine" → devices 2225 and
+	// 6521), which is why mine kills never reached the tab.
+	// Needle is "TgDeploy", not "TgDeployable": subclasses (TgDeploy_ForceField,
+	// TgDeploy_Sensor, TgDeploy_Beacon, TgDeploy_Artillery) miss the long one.
 	if (creditDeviceId == 0) {
 		UTgDeviceFire* fireMode = (UTgDeviceFire*)Impact.dw[0x54 / 4];
 		AActor* fmOwner = fireMode ? fireMode->m_Owner : nullptr;
 		if (fmOwner != nullptr &&
-		    ObjectClassCache::ClassNameContains(fmOwner, "TgDeployable")) {
-			creditDeviceId = DeviceStats::DeviceIdFromDeployableId(
-				((ATgDeployable*)fmOwner)->r_nDeployableId);
+		    ObjectClassCache::ClassNameContains(fmOwner, "TgDeploy")) {
+			ATgDeployable* fmDeployable = (ATgDeployable*)fmOwner;
+			if (fmDeployable->r_Owner != nullptr) {
+				creditDeviceId = fmDeployable->r_Owner->r_nDeviceId;
+			}
+			if (creditDeviceId == 0) {
+				creditDeviceId = DeviceStats::DeviceIdFromDeployableId(
+					fmDeployable->r_nDeployableId);
+			}
 		}
 	}
 


### PR DESCRIPTION
Bug

Kills made with the Standard Mine sometimes did not appeared in the Device Stats tab (scoreboard and end-of-mission), while Sticky Poison Mine kills did. Mine damage was missing from the tab too — the Mine row was absent entirely, not just showing 0 kills.

A deployable fires with its own internal m_FireMode, so Impact.DeviceModeReference->m_Owner is the deployable actor rather than an ATgDevice, and ResolveDeviceIdFromFireMode returns 0. The fallback mapped deployable → device through the asm tables, but that query drops any deployable spawned by more than one equippable device. Deployable 81 "Mine" is spawned by both device 2225 and device 6521, so it resolved to 0 and DeviceStats::Credit early-returned. The same query only resolves 16 of 185 deployables overall.

Separately, the fallback was gated on the class-name needle "TgDeployable", which no deployable subclass matches — TgDeploy_ForceField, TgDeploy_Sensor, TgDeploy_Beacon and TgDeploy_Artillery never reached the block.

Fix

Resolve the credited device from the deployable's r_Owner (the spawning ATgDevice), which both spawn paths already populate — TgProj_Deployable__SpawnDeployable.cpp:1002 and TgDeviceFire__Deploy.cpp:160. This disambiguates 2225 vs 6521 at runtime and covers every deployable, not just the 16 the DB query resolves. The DB map is retained as a fallback for when the spawning device has already been destroyed.

Widened the class-name needle to "TgDeploy", matching the target classification already used elsewhere in the same file.

Corrected a stale comment in DeviceStats.hpp that attributed the ambiguity to Standard Mine vs Archer's Folly.

Testing done

Tested in game: both Standard Mine and Poison Mine kills now appear in the Device Stats tab (Tested Sticky poison kill with direct damage and also with DoT damage).

Related to: https://discord.com/channels/994691794627461211/1528579739600818357/1531049866862657767