### PR TITLE
Fix overlay HP bar reading the wrong max-health field; default to liv…

### DIFF
--- a/src/GameServer/Stats/SpectatorOverlayFeed/SpectatorOverlayFeed.cpp
+++ b/src/GameServer/Stats/SpectatorOverlayFeed/SpectatorOverlayFeed.cpp
@@ -100,7 +100,16 @@ void MaybePushSnapshot(AActor* actor) {
 	j["session_guid"] = session_guid;
 	j["task_force"]   = ResolveTaskForceNumber(pawn);
 	j["health"]       = pawn->Health;
-	j["health_max"]   = pawn->HealthMax;
+	// NOT pawn->HealthMax -- that's the bare UE3 engine field, only ever set
+	// to the class default and not reliably kept in sync with buffs/skills
+	// (see SuperAgent.cpp's SetPawnPowerScale, which explicitly leaves it
+	// stale on one path). r_nHealthMaximum is the replicated field every
+	// other max-HP-aware system in this codebase treats as authoritative
+	// (ApplyBuff, SyncPawnHealth, FullHeal, ReapplyCharacterSkillTree) --
+	// using anything else here is how the overlay ended up showing every
+	// player capped at the same base value regardless of Health skill points
+	// or buffs actually raising their real max.
+	j["health_max"]   = pawn->r_nHealthMaximum;
 	j["effect_ids"]   = effect_ids;
 	IpcClient::Send(j.dump());
 }

--- a/tools/spectator-overlay/skill-tree-overlay.html
+++ b/tools/spectator-overlay/skill-tree-overlay.html
@@ -379,8 +379,9 @@ let ICONS_ROOT_PATH = localStorage.getItem(ICONS_PATH_KEY) || "ICONS/";
 
 // Set true to generate a fake 3v3 match locally instead of calling the
 // server -- lets you rehearse the team-panel layout/cycling without a live
-// match. Toggle it live with the "Demo Mode" button too.
-let DEMO_MODE = true;
+// match. Toggle it live with the "Demo Mode" button too. Off by default --
+// see spectator-overlay.html's matching DEMO_MODE comment.
+let DEMO_MODE = false;
 
 // Canonical left-to-right class order, same convention as the main
 // spectator overlay (see spectator-overlay.html's CLASS_SORT_ORDER) --
@@ -768,6 +769,16 @@ async function refreshInstanceList() {
     const wanted = currentValue || (INSTANCE_ID ? String(INSTANCE_ID) : '');
     if (wanted && [...select.options].some(o => o.value === wanted)) {
       select.value = wanted;
+    } else if (instances.length) {
+      // No valid current selection (first load, or the previously selected
+      // instance ended) -- auto-pick the first active one. Same reasoning
+      // as spectator-overlay.html's refreshInstanceList: the dropdown isn't
+      // interactable inside an OBS browser source, and there's only ever
+      // one instance worth spectating at a time in practice.
+      const first = instances[0];
+      INSTANCE_ID = first.instance_id;
+      localStorage.setItem(INSTANCE_KEY, String(INSTANCE_ID));
+      select.value = String(INSTANCE_ID);
     }
   } catch (e) { /* transient network hiccup -- next poll retries */ }
 }

--- a/tools/spectator-overlay/spectator-overlay.html
+++ b/tools/spectator-overlay/spectator-overlay.html
@@ -477,8 +477,10 @@ const PROFILE_ID_TO_CLASS_ICON = {
 // Set true to generate a fake 3v3 match locally instead of calling the
 // server -- lets you rehearse layout/positioning (and, with a generous
 // effect count, icon-overflow/wrapping) without a live match. Toggle it live
-// with the "Demo Mode" button too.
-let DEMO_MODE = true;
+// with the "Demo Mode" button too. Off by default -- a real broadcast
+// operator wants refreshInstanceList's auto-pick (see below) to take over
+// as soon as a real instance appears, not a page stuck showing fake players.
+let DEMO_MODE = false;
 
 // ---------------------------------------------------------------------------
 // Rendering
@@ -800,6 +802,17 @@ async function refreshInstanceList() {
     const wanted = currentValue || (INSTANCE_ID ? String(INSTANCE_ID) : "");
     if (wanted && [...select.options].some(o => o.value === wanted)) {
       select.value = wanted;
+    } else if (instances.length) {
+      // No valid current selection (first load, or the previously selected
+      // instance ended) -- auto-pick the first active one. The dropdown
+      // itself isn't interactable inside an OBS browser source (no mouse/
+      // keyboard reaches it there), and in practice there's only ever one
+      // instance worth spectating at a time, so this is the only realistic
+      // way the page ever gets off "select an instance above" on its own.
+      const first = instances[0];
+      INSTANCE_ID = first.instance_id;
+      localStorage.setItem(INSTANCE_KEY, String(INSTANCE_ID));
+      select.value = String(INSTANCE_ID);
     }
   } catch (e) { /* transient network hiccup -- next poll retries */ }
 }


### PR DESCRIPTION
…e instance over demo mode

The health-bar overlay was showing every player capped at the same base value (e.g. "2391/1300") regardless of actual max HP, and the bar's fill wouldn't visually change until health dropped below that stale ceiling. SpectatorOverlayFeed was reading pawn->HealthMax -- the bare UE3 engine field, which only ever holds the class default and isn't reliably kept in sync with buffs/skills (SuperAgent.cpp's SetPawnPowerScale explicitly leaves it stale on one path). Every other max-HP-aware system in this codebase (ApplyBuff, SyncPawnHealth, FullHeal, ReapplyCharacterSkillTree) instead treats the replicated r_nHealthMaximum as authoritative -- switched the overlay feed to match, so the reported max (and therefore the bar fill percentage) now reflects a player's real current max HP.

Also: both overlay pages defaulted to DEMO_MODE and required clicking the instance dropdown to select a live instance -- but the dropdown isn't interactable inside an OBS browser source (no mouse/keyboard reaches it there), so a broadcast operator had no way to get off the demo/placeholder state on their own. DEMO_MODE now defaults off, and refreshInstanceList() auto-picks the first active instance whenever there's no currently-valid selection (first load, or the previously selected instance ending) -- matches the real usage pattern of spectating one instance at a time, while still leaving an existing valid selection alone so it won't get yanked off an instance actually being watched.