### PR TITLE
Fix constant image flicker in OBS Browser Source on both overlay pages

### DIFF
--- a/tools/spectator-overlay/skill-tree-overlay.html
+++ b/tools/spectator-overlay/skill-tree-overlay.html
@@ -573,7 +573,17 @@ function buildString(className, investedMap) {
   return sums.join('/');
 }
 
-function playerCard(p) {
+// Persistent per-row card state, keyed by player_key -- reused across polls
+// instead of being torn down and rebuilt from scratch every tick. A full
+// rebuild recreates every hex node's <img> (and the whole SVG) even though a
+// real build practically never changes tick-to-tick (see POLL_MS's own
+// comment on that), which is both wasted work and the direct cause of
+// flicker in OBS's Browser Source (CEF repaints visibly on DOM/img churn far
+// more than a normal browser tab does). The expensive tree-canvas rebuild
+// now only happens when the actual invested skill_id/points set changes.
+const teamCardState = { 'row-attackers': new Map(), 'row-defenders': new Map() };
+
+function buildPlayerCard(p) {
   const className = PROFILE_ID_TO_CLASS[p.profile_id];
   const card = document.createElement('div');
   card.className = 'player-tree-card';
@@ -594,7 +604,6 @@ function playerCard(p) {
   left.appendChild(classIcon);
   const name = document.createElement('div');
   name.className = 'name';
-  name.textContent = p.player_name || '(unknown)';
   left.appendChild(name);
   header.appendChild(left);
 
@@ -603,32 +612,76 @@ function playerCard(p) {
   header.appendChild(build);
   card.appendChild(header);
 
-  const investedMap = {};
-  (p.points || []).forEach(row => { investedMap[row.skill_id] = row.points; });
-  build.textContent = buildString(className, investedMap);
-
   const wrap = document.createElement('div');
   wrap.className = 'tree-canvas-wrap';
-  const canvas = buildTreeCanvas(className, investedMap);
-  wrap.appendChild(canvas);
-  wrap.style.width = canvas.dataset.visualWidth + 'px';
-  wrap.style.height = canvas.dataset.visualHeight + 'px';
   card.appendChild(wrap);
 
-  return card;
+  return { card, name, build, wrap, className, profileId: p.profile_id, lastPointsKey: null };
+}
+
+function updatePlayerCard(state, p) {
+  state.name.textContent = p.player_name || '(unknown)';
+
+  const investedMap = {};
+  (p.points || []).forEach(row => { investedMap[row.skill_id] = row.points; });
+  state.build.textContent = buildString(state.className, investedMap);
+
+  // Order-independent key over the actual invested (skill_id, points) pairs
+  // -- only rebuild the SVG+hex canvas (the expensive, flicker-prone part)
+  // when this genuinely changed, not on every poll tick.
+  const pointsKey = (p.points || [])
+    .map(r => r.skill_id + ':' + r.points).sort().join(',');
+  if (state.lastPointsKey !== pointsKey) {
+    state.wrap.innerHTML = '';
+    const canvas = buildTreeCanvas(state.className, investedMap);
+    state.wrap.appendChild(canvas);
+    state.wrap.style.width = canvas.dataset.visualWidth + 'px';
+    state.wrap.style.height = canvas.dataset.visualHeight + 'px';
+    state.lastPointsKey = pointsKey;
+  }
+}
+
+function renderRow(containerId, players) {
+  const container = document.getElementById(containerId);
+  const stateMap = teamCardState[containerId];
+  const seen = new Set();
+
+  players.forEach(p => {
+    seen.add(p.player_key);
+    let state = stateMap.get(p.player_key);
+    // Class effectively never changes mid-match (only the loadout slot
+    // does), but a stale className would misread the wrong tree data --
+    // handle it correctly by just rebuilding the card fresh.
+    if (state && state.profileId !== p.profile_id) {
+      state.card.remove();
+      stateMap.delete(p.player_key);
+      state = null;
+    }
+    if (!state) {
+      state = buildPlayerCard(p);
+      stateMap.set(p.player_key, state);
+    }
+    updatePlayerCard(state, p);
+    // appendChild on a node already in the document just MOVES it -- no
+    // destroy/recreate -- so reordering to match sortByClassOrder never
+    // touches the tree canvas and can't reintroduce the flicker.
+    container.appendChild(state.card);
+  });
+
+  for (const [key, state] of stateMap) {
+    if (!seen.has(key)) {
+      state.card.remove();
+      stateMap.delete(key);
+    }
+  }
 }
 
 function renderTeams(players) {
   const attackers = sortByClassOrder(players.filter(p => p.task_force === 1));
   const defenders = sortByClassOrder(players.filter(p => p.task_force === 2));
 
-  const rowAtk = document.getElementById('row-attackers');
-  const rowDef = document.getElementById('row-defenders');
-  rowAtk.innerHTML = '';
-  rowDef.innerHTML = '';
-
-  attackers.forEach(p => rowAtk.appendChild(playerCard(p)));
-  defenders.forEach(p => rowDef.appendChild(playerCard(p)));
+  renderRow('row-attackers', attackers);
+  renderRow('row-defenders', defenders);
 }
 
 async function poll() {

--- a/tools/spectator-overlay/spectator-overlay.html
+++ b/tools/spectator-overlay/spectator-overlay.html
@@ -550,70 +550,126 @@ function sortByClassOrder(players) {
   });
 }
 
+// Persistent per-container card state, keyed by player_key -- reused across
+// polls instead of being torn down and rebuilt from scratch every tick.
+// Recreating <img> elements (class icons, effect icons) on every 300ms poll
+// is what was causing constant flicker in OBS's Browser Source (CEF
+// repaints on every new <img>, even a cache-hit one, far more visibly than
+// a normal browser tab does) -- keeping the same DOM/img nodes alive and
+// only touching the fields that actually changed eliminates that entirely.
+// See buildCard/updateCard below; renderTeam just reconciles against this.
+const teamCardState = { "cards-attackers": new Map(), "cards-defenders": new Map() };
+
+function buildCard(p) {
+  const card = document.createElement("div");
+  card.className = "player-card";
+
+  const row = document.createElement("div");
+  row.className = "player-row";
+  const classIconWrap = classIconElement(p.profile_id);
+  row.appendChild(classIconWrap);
+
+  const pill = document.createElement("div");
+  pill.className = "health-pill";
+  const fill = document.createElement("div");
+  fill.className = "health-pill-fill";
+  const name = document.createElement("div");
+  name.className = "health-pill-name";
+  const hpText = document.createElement("div");
+  hpText.className = "health-pill-hp";
+  pill.appendChild(fill);
+  pill.appendChild(name);
+  pill.appendChild(hpText);
+  row.appendChild(pill);
+  card.appendChild(row);
+
+  // Always present, even with zero active effects — its min-height (see
+  // CSS) reserves the space either way, so a buff appearing/disappearing
+  // never shifts the pill above it up and down.
+  const effectsRow = document.createElement("div");
+  effectsRow.className = "effects-row";
+  card.appendChild(effectsRow);
+
+  return {
+    card, classIconWrap, fill, name, hpText, effectsRow,
+    lastProfileId: p.profile_id, // classIconWrap above already matches this
+    lastEffectKey: null,
+  };
+}
+
+function updateCard(state, p) {
+  const pct = p.health_max > 0 ? Math.max(0, Math.min(1, p.health / p.health_max)) : 0;
+
+  // Class practically never changes mid-match (only the loadout slot does),
+  // but handle it correctly rather than assuming -- rebuilds just the icon,
+  // not the whole card.
+  if (state.lastProfileId !== p.profile_id) {
+    const fresh = classIconElement(p.profile_id);
+    state.classIconWrap.replaceWith(fresh);
+    state.classIconWrap = fresh;
+    state.lastProfileId = p.profile_id;
+  }
+
+  state.fill.style.width = (pct * 100) + "%";
+  state.fill.style.backgroundColor = healthColor(pct);
+  state.name.textContent = p.player_name || "(unknown)";
+
+  // Raw HP number is off by default (see SHOW_HP_KEY) -- the bar itself
+  // (fill.style.width above) already conveys health the same way it does
+  // in-game. When off, the "P/T1/T2" build notation (see
+  // SkillTreeCatalog.hpp) occupies this slot alone instead of trailing
+  // after the number. Demo mode sets p.build directly (see DEMO_ROSTER);
+  // real data comes from buildCache, refreshed on its own slower cadence
+  // by pollBuilds() rather than every 300ms tick -- see BUILDS_POLL_MS.
+  const build = p.build || buildCache[p.player_key];
+  const parts = [];
+  if (showHpNumber) parts.push(p.health + " / " + p.health_max);
+  if (build) parts.push(build.balanced + "/" + build.tree1 + "/" + build.tree2);
+  state.hpText.textContent = parts.join("   ");
+
+  // Effect icons are the expensive/flicker-prone part -- only touch the DOM
+  // here if the actual set of active ids changed since last render. Capped
+  // at MAX_VISIBLE_EFFECTS + an overflow badge so a heavily-buffed player
+  // can't grow their card (and shove every card below them down, possibly
+  // off-frame) without bound.
+  const ids = p.effect_ids || [];
+  const effectKey = ids.join(",");
+  if (state.lastEffectKey !== effectKey) {
+    state.effectsRow.innerHTML = "";
+    ids.slice(0, MAX_VISIBLE_EFFECTS).forEach(id => state.effectsRow.appendChild(effectTagElement(id)));
+    if (ids.length > MAX_VISIBLE_EFFECTS) {
+      state.effectsRow.appendChild(overflowTagElement(ids.length - MAX_VISIBLE_EFFECTS));
+    }
+    state.lastEffectKey = effectKey;
+  }
+}
+
 function renderTeam(containerId, players) {
   const container = document.getElementById(containerId);
-  container.innerHTML = "";
+  const stateMap = teamCardState[containerId];
+  const seen = new Set();
 
   players.forEach(p => {
-    const pct = p.health_max > 0 ? Math.max(0, Math.min(1, p.health / p.health_max)) : 0;
-
-    const card = document.createElement("div");
-    card.className = "player-card";
-
-    // Icon + health pill. The pill's own background IS the health bar --
-    // .health-pill-fill is a width:X% layer inside it, so the "missing HP"
-    // portion is just the pill's dark background showing through rather
-    // than a separate bar element next to the name.
-    const row = document.createElement("div");
-    row.className = "player-row";
-    row.appendChild(classIconElement(p.profile_id));
-
-    const pill = document.createElement("div");
-    pill.className = "health-pill";
-    const fill = document.createElement("div");
-    fill.className = "health-pill-fill";
-    fill.style.width = (pct * 100) + "%";
-    fill.style.backgroundColor = healthColor(pct);
-    const name = document.createElement("div");
-    name.className = "health-pill-name";
-    name.textContent = p.player_name || "(unknown)";
-    const hpText = document.createElement("div");
-    hpText.className = "health-pill-hp";
-    // Raw HP number is off by default (see SHOW_HP_KEY) -- the bar itself
-    // (fill.style.width above) already conveys health the same way it does
-    // in-game. When off, the "P/T1/T2" build notation (see
-    // SkillTreeCatalog.hpp) occupies this slot alone instead of trailing
-    // after the number. Demo mode sets p.build directly (see DEMO_ROSTER);
-    // real data comes from buildCache, refreshed on its own slower cadence
-    // by pollBuilds() rather than every 300ms tick -- see BUILDS_POLL_MS.
-    const build = p.build || buildCache[p.player_key];
-    const parts = [];
-    if (showHpNumber) parts.push(p.health + " / " + p.health_max);
-    if (build) parts.push(build.balanced + "/" + build.tree1 + "/" + build.tree2);
-    hpText.textContent = parts.join("   ");
-    pill.appendChild(fill);
-    pill.appendChild(name);
-    pill.appendChild(hpText);
-    row.appendChild(pill);
-    card.appendChild(row);
-
-    // Always append the effects bar, even with zero active effects — its
-    // min-height (see CSS) reserves the space either way, so a buff
-    // appearing/disappearing never shifts the pill above it up and down.
-    // Capped at MAX_VISIBLE_EFFECTS + an overflow badge so a heavily-buffed
-    // player can't grow their card (and shove every card below them down,
-    // possibly off-frame) without bound.
-    const effectsRow = document.createElement("div");
-    effectsRow.className = "effects-row";
-    const ids = p.effect_ids || [];
-    ids.slice(0, MAX_VISIBLE_EFFECTS).forEach(id => effectsRow.appendChild(effectTagElement(id)));
-    if (ids.length > MAX_VISIBLE_EFFECTS) {
-      effectsRow.appendChild(overflowTagElement(ids.length - MAX_VISIBLE_EFFECTS));
+    seen.add(p.player_key);
+    let state = stateMap.get(p.player_key);
+    if (!state) {
+      state = buildCard(p);
+      stateMap.set(p.player_key, state);
     }
-    card.appendChild(effectsRow);
-
-    container.appendChild(card);
+    updateCard(state, p);
+    // appendChild on a node already in the document just MOVES it -- no
+    // destroy/recreate -- so reordering to match sortByClassOrder never
+    // touches an <img> and can't reintroduce the flicker.
+    container.appendChild(state.card);
   });
+
+  // Drop cards for players no longer present (left the team/instance).
+  for (const [key, state] of stateMap) {
+    if (!seen.has(key)) {
+      state.card.remove();
+      stateMap.delete(key);
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Both spectator-overlay.html and skill-tree-overlay.html did container.innerHTML = "" followed by a full rebuild of every card -- and every <img>, and on the skill-tree page every SVG/hex node -- on every single poll (300ms for the main overlay, 2s for skill-tree). OBS's Browser Source (CEF) visibly repaints on that kind of constant DOM/image churn far more aggressively than a normal browser tab does, which is why this didn't show up on other web pages and did show up in demo mode too (demo mode drives the exact same render/poll code path, just with synthetic data instead of a fetch).

Both pages now keep persistent DOM elements per player (keyed by player_key), reused across polls, and only touch what actually changed: health bar width/color, name, and build text update in place with no element recreation; effect icons only rebuild when the actual set of active ids changes; the skill-tree page's SVG+hex canvas (the expensive part) only rebuilds when the invested skill points actually change -- verified all 115 hex nodes across 3 players kept identical DOM references over 5 poll cycles with an unchanged demo build. Reordering to match the class-sort order uses appendChild on already-attached nodes, which just moves them without touching any image, so it can't reintroduce the flicker either.

Doesn't touch poll intervals, fetch calls, or the control-server pipeline -- this is strictly a rendering-side change, and if anything reduces per-tick work (a handful of cheap comparisons replacing a full subtree teardown and image reload) rather than adding any.