### PR TITLE
Add player power/energy bars to the spectator overlay

### DIFF
--- a/src/ControlServer/IpcServer/IpcServer.cpp
+++ b/src/ControlServer/IpcServer/IpcServer.cpp
@@ -313,6 +313,8 @@ private:
             snap.task_force    = j.value("task_force", 0);
             snap.health        = j.value("health", 0);
             snap.health_max    = j.value("health_max", 0);
+            snap.power         = j.value("power", 0.0f);
+            snap.power_max     = j.value("power_max", 0.0f);
             // Filter the DLL's raw group-id dump down to the two curated
             // whitelists (OverlayIdCatalog) and split by kind -- effect ids
             // render as a tile icon, skill ids are pushed through but never

--- a/src/ControlServer/SpectatorOverlay/OverlayHttpServer.cpp
+++ b/src/ControlServer/SpectatorOverlay/OverlayHttpServer.cpp
@@ -161,6 +161,8 @@ private:
             p["task_force"]   = s.task_force;
             p["health"]       = s.health;
             p["health_max"]   = s.health_max;
+            p["power"]        = s.power;
+            p["power_max"]    = s.power_max;
             p["effect_ids"]   = s.effect_ids;
             p["skill_ids"]    = s.skill_ids;
             auto info = PlayerSessionStore::GetByGuid(s.session_guid);

--- a/src/ControlServer/SpectatorOverlay/SpectatorOverlayState.hpp
+++ b/src/ControlServer/SpectatorOverlay/SpectatorOverlayState.hpp
@@ -17,6 +17,8 @@ public:
         int task_force = 0;   // 0 = unknown/none, 1 = attackers, 2 = defenders
         int health = 0;
         int health_max = 0;
+        float power = 0.0f;
+        float power_max = 0.0f;
         // Whitelisted (OverlayIdCatalog::IsEffectId), deduped -- the only ids
         // the HTML renders as a tile icon.
         std::vector<int> effect_ids;

--- a/src/GameServer/Stats/SpectatorOverlayFeed/SpectatorOverlayFeed.cpp
+++ b/src/GameServer/Stats/SpectatorOverlayFeed/SpectatorOverlayFeed.cpp
@@ -110,6 +110,10 @@ void MaybePushSnapshot(AActor* actor) {
 	// player capped at the same base value regardless of Health skill points
 	// or buffs actually raising their real max.
 	j["health_max"]   = pawn->r_nHealthMaximum;
+	// Same replicated-field pattern as health/health_max above -- both CPF_Net
+	// on ATgPawn, kept in sync by the same buff/skill/gear systems.
+	j["power"]        = pawn->r_fCurrentPowerPool;
+	j["power_max"]    = pawn->r_fMaxPowerPool;
 	j["effect_ids"]   = effect_ids;
 	IpcClient::Send(j.dump());
 }

--- a/tools/spectator-overlay/spectator-overlay.html
+++ b/tools/spectator-overlay/spectator-overlay.html
@@ -130,6 +130,33 @@
     box-shadow: inset 0 1px 0 rgba(255,255,255,0.4), inset 0 -3px 5px rgba(0,0,0,0.35);
   }
 
+  /* Thin secondary bar under the health pill for power/energy -- same
+     pill-is-the-bar convention as .health-pill, just shorter, and aligned
+     past the class icon the same way .effects-row is. */
+  .power-pill {
+    position: relative;
+    height: 6px;
+    margin-top: 3px;
+    margin-left: 38px;
+    border-radius: 3px;
+    background: rgba(12, 14, 20, 0.72);
+    border: 1px solid rgba(255,255,255,0.25);
+    overflow: hidden;
+  }
+
+  .power-pill-fill {
+    position: absolute;
+    inset: 0;
+    width: 0%;
+    background: #29b6d8;
+    transition: width 150ms linear;
+  }
+
+  .defenders .power-pill {
+    margin-left: 0;
+    margin-right: 38px;
+  }
+
   .health-pill-name,
   .health-pill-hp {
     position: relative; /* sits above .health-pill-fill in paint order */
@@ -583,6 +610,13 @@ function buildCard(p) {
   row.appendChild(pill);
   card.appendChild(row);
 
+  const powerPill = document.createElement("div");
+  powerPill.className = "power-pill";
+  const powerFill = document.createElement("div");
+  powerFill.className = "power-pill-fill";
+  powerPill.appendChild(powerFill);
+  card.appendChild(powerPill);
+
   // Always present, even with zero active effects — its min-height (see
   // CSS) reserves the space either way, so a buff appearing/disappearing
   // never shifts the pill above it up and down.
@@ -591,7 +625,7 @@ function buildCard(p) {
   card.appendChild(effectsRow);
 
   return {
-    card, classIconWrap, fill, name, hpText, effectsRow,
+    card, classIconWrap, fill, name, hpText, powerFill, effectsRow,
     lastProfileId: p.profile_id, // classIconWrap above already matches this
     lastEffectKey: null,
   };
@@ -613,6 +647,9 @@ function updateCard(state, p) {
   state.fill.style.width = (pct * 100) + "%";
   state.fill.style.backgroundColor = healthColor(pct);
   state.name.textContent = p.player_name || "(unknown)";
+
+  const powerPct = p.power_max > 0 ? Math.max(0, Math.min(1, p.power / p.power_max)) : 0;
+  state.powerFill.style.width = (powerPct * 100) + "%";
 
   // Raw HP number is off by default (see SHOW_HP_KEY) -- the bar itself
   // (fill.style.width above) already conveys health the same way it does
@@ -731,11 +768,13 @@ function generateDemoSnapshot() {
   const players = DEMO_ROSTER.map((p, idx) => {
     let st = demoState.get(p.name);
     if (!st) {
-      st = { health: 1300, health_max: 1300, effect_ids: [] };
+      st = { health: 1300, health_max: 1300, power: 100, power_max: 100, effect_ids: [] };
       demoState.set(p.name, st);
     }
     st.health += (Math.random() - 0.55) * 45;
     st.health = Math.max(0, Math.min(st.health_max, Math.round(st.health)));
+    st.power += (Math.random() - 0.45) * 12;
+    st.power = Math.max(0, Math.min(st.power_max, Math.round(st.power)));
     if (Math.random() < 0.08) {
       const count = DEMO_MIN_EFFECTS +
         Math.floor(Math.random() * (DEMO_MAX_EFFECTS - DEMO_MIN_EFFECTS + 1));
@@ -753,6 +792,8 @@ function generateDemoSnapshot() {
       profile_id: p.profile_id,
       health: st.health,
       health_max: st.health_max,
+      power: st.power,
+      power_max: st.power_max,
       effect_ids: st.effect_ids,
       build: p.build,
     };


### PR DESCRIPTION
Same replicated-field pattern already used for health: pawn->r_fCurrentPowerPool and r_fMaxPowerPool (both CPF_Net on ATgPawn, kept in sync by the same buff/skill/gear systems as health/r_nHealthMaximum) are now pushed through SpectatorOverlayFeed alongside health, plumbed through SpectatorOverlayState and the GET /overlay endpoint, and rendered as a new thin teal bar under each player's health bar on the main overlay page (docker->tools/spectator-overlay/ spectator-overlay.html), using the same persistent-DOM-element pattern as the rest of the page so it doesn't reintroduce the OBS flicker issue. Demo mode also drifts a power value per player so this is visible without a live match.

Skill-tree page is unaffected -- power isn't relevant there.