### PR TITLE
Spectator Overlay - Mission Type detection rewor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ SOURCE_FILES= \
 			  $(SRC_DIR)/GameServer/Engine/MapDataDumper/Writers/TgTeleporter.cpp \
 			  $(SRC_DIR)/GameServer/Engine/MapObjectConfig/MapObjectConfig.cpp \
 			  $(SRC_DIR)/GameServer/Engine/MapGameInfo/MapGameInfo.cpp \
+			  $(SRC_DIR)/GameServer/Engine/ObjectiveNames/ObjectiveNames.cpp \
 			  $(SRC_DIR)/GameServer/Engine/SeqActNullGuard/SeqActNullGuard.cpp \
 			  $(SRC_DIR)/GameServer/Engine/Actor/Spawn/Actor__Spawn.cpp \
 			  $(SRC_DIR)/GameServer/Engine/Actor/Tick/Actor__Tick.cpp \

--- a/src/ControlServer/IpcServer/IpcServer.cpp
+++ b/src/ControlServer/IpcServer/IpcServer.cpp
@@ -349,24 +349,30 @@ private:
             snap.mode = j.value("mode", "");
             if (snap.mode.empty()) return;
 
-            // Additive, not mutually exclusive by mode -- ticket AND koth both
-            // carry the team-score fields, and every mode except raid carries
-            // objectives (see IpcProtocol.hpp's MSG_MISSION_PROGRESS_SNAPSHOT doc).
+            // Additive, not mutually exclusive by mode -- see
+            // IpcProtocol.hpp's MSG_MISSION_PROGRESS_SNAPSHOT doc.
             if (snap.mode == "ticket" || snap.mode == "koth") {
                 snap.attacker_points = j.value("attacker_points", 0);
                 snap.defender_points = j.value("defender_points", 0);
                 snap.points_to_win   = j.value("points_to_win", 0);
             }
             if (snap.mode == "raid") {
-                snap.round_current   = j.value("round_current", 0);
-                snap.round_max       = j.value("round_max", 0);
+                snap.round_current = j.value("round_current", 0);
+                snap.round_max     = j.value("round_max", 0);
+                snap.friendly_health     = j.value("friendly_health", 0);
+                snap.friendly_health_max = j.value("friendly_health_max", 0);
+                snap.friendly_name       = j.value("friendly_name", "");
+            }
+            if (snap.mode == "raid" || snap.mode == "pve" || snap.mode == "superagent") {
                 snap.boss_health     = j.value("boss_health", 0);
                 snap.boss_health_max = j.value("boss_health_max", 0);
+                snap.boss_name       = j.value("boss_name", "");
             }
             if (j.contains("objectives") && j["objectives"].is_array()) {
                 for (const auto& raw : j["objectives"]) {
                     MissionProgressState::Objective obj;
                     obj.id              = raw.value("id", 0);
+                    obj.name            = raw.value("name", "");
                     obj.priority        = raw.value("priority", 0);
                     obj.locked          = raw.value("locked", false);
                     obj.active          = raw.value("active", false);

--- a/src/ControlServer/SpectatorOverlay/MissionProgressState.hpp
+++ b/src/ControlServer/SpectatorOverlay/MissionProgressState.hpp
@@ -17,6 +17,7 @@ class MissionProgressState {
 public:
     struct Objective {
         int id = 0;
+        std::string name;  // "" if no DB row/translation -- see ObjectiveNames.hpp
         int priority = 0;
         bool locked = false;
         bool active = false;
@@ -25,9 +26,9 @@ public:
     };
 
     struct MissionSnapshot {
-        std::string mode;  // "ticket" | "raid" | "koth" | "payload" | "breach"
+        std::string mode;  // "ticket" | "raid" | "koth" | "payload" | "breach" | "pve" | "superagent"
 
-        // mode == "ticket"
+        // mode == "ticket" | "koth"
         int attacker_points = 0;
         int defender_points = 0;
         int points_to_win = 0;
@@ -35,10 +36,19 @@ public:
         // mode == "raid"
         int round_current = 0;
         int round_max = 0;
+
+        // mode == "raid" | "pve" | "superagent"
         int boss_health = 0;
         int boss_health_max = 0;
+        std::string boss_name;
 
-        // mode == "koth" | "payload" | "breach"
+        // mode == "raid" only -- a defender-owned NPC/reactor being protected,
+        // separate from the boss (e.g. "Bancroft" on Raid_DomeCityDefense_P).
+        int friendly_health = 0;
+        int friendly_health_max = 0;
+        std::string friendly_name;
+
+        // mode == "ticket" | "koth" | "payload" | "breach" | "superagent"
         std::vector<Objective> objectives;
 
         int64_t updated_at = 0;  // unix seconds -- used to prune a stale/ended match

--- a/src/ControlServer/SpectatorOverlay/OverlayHttpServer.cpp
+++ b/src/ControlServer/SpectatorOverlay/OverlayHttpServer.cpp
@@ -203,15 +203,26 @@ private:
                 m["points_to_win"]   = mission->points_to_win;
             }
             if (mission->mode == "raid") {
-                m["round_current"]   = mission->round_current;
-                m["round_max"]       = mission->round_max;
+                m["round_current"]       = mission->round_current;
+                m["round_max"]           = mission->round_max;
+                m["friendly_health"]     = mission->friendly_health;
+                m["friendly_health_max"] = mission->friendly_health_max;
+                m["friendly_name"]       = mission->friendly_name;
+            }
+            if (mission->mode == "raid" || mission->mode == "pve" || mission->mode == "superagent") {
                 m["boss_health"]     = mission->boss_health;
                 m["boss_health_max"] = mission->boss_health_max;
-            } else {
+                m["boss_name"]       = mission->boss_name;
+            }
+            // Every mode except raid/pve carries the objectives list (koth/
+            // ticket/payload/breach always did; superagent's boss-then-2-
+            // captures flow needs it too, once the boss is down).
+            if (mission->mode != "raid" && mission->mode != "pve") {
                 nlohmann::json objectives = nlohmann::json::array();
                 for (const auto& o : mission->objectives) {
                     nlohmann::json jo;
                     jo["id"]              = o.id;
+                    jo["name"]            = o.name;
                     jo["priority"]        = o.priority;
                     jo["locked"]          = o.locked;
                     jo["active"]          = o.active;

--- a/src/GameServer/Engine/MapGameInfo/MapGameInfo.cpp
+++ b/src/GameServer/Engine/MapGameInfo/MapGameInfo.cpp
@@ -24,7 +24,7 @@ std::optional<MapGameInfoRow> MapGameInfo::LookupByNameAndGameMode(
 	// with an empty/unmatched gameMode the predicate is 0 for every row and this
 	// degrades to "first name match" — the old name-only behavior.
 	const char* kSql =
-		"SELECT map_game_id, mission_time_secs, is_pvp, overtime_secs, allow_overtime "
+		"SELECT map_game_id, mission_time_secs, is_pvp, overtime_secs, allow_overtime, gameplay_type_value_id "
 		"FROM map_game_info "
 		"WHERE map_name = ? COLLATE NOCASE OR map_name = ? COLLATE NOCASE "
 		"ORDER BY (game_class = ? COLLATE NOCASE) DESC "
@@ -48,6 +48,7 @@ std::optional<MapGameInfoRow> MapGameInfo::LookupByNameAndGameMode(
 		r.is_pvp            = sqlite3_column_int(stmt, 2) != 0;
 		r.overtime_secs     = sqlite3_column_int(stmt, 3);
 		r.allow_overtime    = sqlite3_column_int(stmt, 4) != 0;
+		r.gameplay_type_value_id = sqlite3_column_int(stmt, 5);
 		out = r;
 	}
 	sqlite3_finalize(stmt);

--- a/src/GameServer/Engine/MapGameInfo/MapGameInfo.hpp
+++ b/src/GameServer/Engine/MapGameInfo/MapGameInfo.hpp
@@ -20,6 +20,14 @@ struct MapGameInfoRow {
 	bool is_pvp;
 	int  overtime_secs;
 	bool allow_overtime;
+	// The real differentiator between game modes that share a TgGame class --
+	// e.g. TgGame_Mission covers both Breach (1544) and solo/PvE missions
+	// (1553); TgGame_PointRotation covers both standard (1548) and small-map
+	// (1569) Scramble. 0 = column absent on this DB (older schema -- this
+	// repo's own dev copy predates it) or no row; callers must fall back to
+	// class-name-only detection in that case. See MissionProgressFeed.cpp's
+	// ResolveMissionMode for the full value -> mode mapping.
+	int  gameplay_type_value_id = 0;
 };
 
 class MapGameInfo {

--- a/src/GameServer/Engine/ObjectiveNames/ObjectiveNames.cpp
+++ b/src/GameServer/Engine/ObjectiveNames/ObjectiveNames.cpp
@@ -1,0 +1,42 @@
+#include "src/GameServer/Engine/ObjectiveNames/ObjectiveNames.hpp"
+#include "src/Database/Database.hpp"
+
+#include <unordered_map>
+
+namespace ObjectiveNames {
+
+std::string LookupFriendlyName(int objectiveId) {
+	static std::unordered_map<int, std::string> cache;
+
+	auto it = cache.find(objectiveId);
+	if (it != cache.end()) return it->second;
+
+	std::string name;
+
+	sqlite3* db = Database::GetConnection();
+	if (db) {
+		sqlite3_stmt* stmt = nullptr;
+		const char* kSql =
+			"SELECT m.message "
+			"FROM asm_data_set_objectives o "
+			"JOIN asm_data_set_msg_translations m ON o.text_msg_id = m.msg_id "
+			"WHERE o.objective_id = ? "
+			"LIMIT 1";
+		// Prepare failure = table(s) missing on this DB (pre-import dev copy) --
+		// cache the empty result same as a real "not found" so we don't retry
+		// the failing prepare on every subsequent lookup for this id.
+		if (sqlite3_prepare_v2(db, kSql, -1, &stmt, nullptr) == SQLITE_OK && stmt) {
+			sqlite3_bind_int(stmt, 1, objectiveId);
+			if (sqlite3_step(stmt) == SQLITE_ROW) {
+				const unsigned char* text = sqlite3_column_text(stmt, 0);
+				if (text) name = reinterpret_cast<const char*>(text);
+			}
+			sqlite3_finalize(stmt);
+		}
+	}
+
+	cache[objectiveId] = name;
+	return name;
+}
+
+}  // namespace ObjectiveNames

--- a/src/GameServer/Engine/ObjectiveNames/ObjectiveNames.hpp
+++ b/src/GameServer/Engine/ObjectiveNames/ObjectiveNames.hpp
@@ -1,0 +1,35 @@
+#pragma once
+#include <string>
+
+// Friendly display-name lookup for ATgMissionObjective::nObjectiveId, e.g.
+// turning KOTH/Ticket/Breach/SuperAgent capture-point ids into the same names
+// players see on the retail HUD ("Security Gate 1", "Tower Gates", ...).
+//
+// The join (confirmed against a live DB copy, 2026-07-30 -- NOT what's in
+// this repo's own tiny dev server.db, which predates these tables entirely):
+//   asm_data_set_objectives.objective_id  = ATgMissionObjective::nObjectiveId
+//     (confirmed directly in code: SuperAgent.cpp's SpawnPoint does
+//      `Obj->nObjectiveId = cfg.objectiveDefId;`, and CapturePoint::objectiveDefId
+//      is doc'd as "asm_data_set_objectives id")
+//   asm_data_set_objectives.text_msg_id   = asm_data_set_msg_translations.msg_id
+//   asm_data_set_msg_translations.message = the friendly text
+// NOT name_msg_id/name_msg_translated on asm_data_set_objectives -- those hold
+// an internal dev placeholder (e.g. "Him_Fac_Climate_Control01"), confirmed
+// against real data, not the player-facing name.
+//
+// Custom-spawned point pools (KOTH's CtrPointRotation.cpp, and apparently at
+// least some Payload/Escort maps) reuse the SAME nObjectiveId for every point
+// in the pool, so this correctly returns the SAME name for all of them --
+// callers that need to tell points apart (the overlay) must detect that
+// case themselves (e.g. fall back to numbering when multiple concurrently-
+// shown points resolve to an identical name) rather than treating a returned
+// name as automatically unique.
+namespace ObjectiveNames {
+
+// "" if there's no row, no translation, or this DB predates these tables.
+// Cached in memory after the first lookup per id -- this is static config
+// data (never changes mid-process), and MissionProgressFeed calls this once
+// per active objective every push (~1/sec).
+std::string LookupFriendlyName(int objectiveId);
+
+}  // namespace ObjectiveNames

--- a/src/GameServer/Stats/MissionProgressFeed/MissionProgressFeed.cpp
+++ b/src/GameServer/Stats/MissionProgressFeed/MissionProgressFeed.cpp
@@ -2,6 +2,10 @@
 
 #include "lib/nlohmann/json.hpp"
 
+#include "src/Config/Config.hpp"
+#include "src/GameServer/Engine/MapGameInfo/MapGameInfo.hpp"
+#include "src/GameServer/Engine/ObjectiveNames/ObjectiveNames.hpp"
+#include "src/GameServer/GameModes/SuperAgent/SuperAgent.hpp"
 #include "src/GameServer/Globals.hpp"
 #include "src/GameServer/Storage/ActiveSpectatorCount/ActiveSpectatorCount.hpp"
 #include "src/GameServer/Storage/TeamsData/TeamsData.hpp"
@@ -20,30 +24,62 @@ constexpr DWORD kPushIntervalMs = 1000;
 
 DWORD g_lastPushMs = 0;
 
+// gameplay_type_value_id -> mode. Confirmed against a live map_game_info
+// export (2026-07-30) -- this is the REAL differentiator between modes that
+// share one TgGame class (TgGame_Mission covers both Breach and solo/PvE
+// missions; TgGame_PointRotation covers both standard and small-map koth).
+// This repo's own dev server.db predates the column entirely (map_game_info
+// doesn't even exist there), so MapGameInfo::LookupByNameAndGameMode returns
+// nullopt and ResolveMissionMode falls back to the original class-name-only
+// guess for that case.
+//   1544 = Breach            1545 = Ticket/Control      1547 = Payload/Push
+//   1548 = koth (standard, 5 points)   1569 = koth (small map, 3 points) --
+//     mechanically identical, same "koth" mode either way
+//   1550 = Raid (boss + a defended "friendly" NPC/reactor + wave count)
+//   1553 = PvE mission (boss bar) -- EXCEPT Super Agent, which is a boss
+//     then two sequential captures; detected via SuperAgent::IsActive(),
+//     not a distinct gameplay_type value of its own
+//   1542 = Home (not spectatable), 1546 = stock CTR/DualCTF (not played) --
+//     both intentionally fall through to "" (no overlay section)
+std::string ModeForGameplayType(int gameplayTypeValueId) {
+    switch (gameplayTypeValueId) {
+        case 1544: return "breach";
+        case 1545: return "ticket";
+        case 1547: return "payload";
+        case 1548:
+        case 1569: return "koth";
+        case 1550: return "raid";
+        case 1553: return SuperAgent::IsActive() ? "superagent" : "pve";
+        default:   return "";
+    }
+}
+
 // Same "Class Pkg.Name" comparison this codebase already uses everywhere
 // else to branch on game mode (see TgGame__InitGameRepInfo.cpp's
-// GameClassName == "Class TgGame.TgGame_X" checks) -- kept consistent
-// rather than inventing a second convention.
-//
-// TgGame_Ticket/_Escort/_Defense/_PointRotation map 1:1 to the ticket/
-// payload/raid/koth categories. TgGame_Mission is the shared base class
-// both the "Breach" 3-point sequential-capture maps and a handful of
-// unrelated solo/PvE missions run under (confirmed via ga_map_pool_entries
-// -- there's no separate Breach class to key off); since the underlying
-// ATgMissionObjective priority/lock/capture fields are identical either
-// way, mapping the whole class to "breach" is accurate for the maps that
-// matter and harmless (an objective list nobody looks at) for the rest.
-// City/OpenWorldPVE/OpenWorldPVP/CTF/DualCTF have no requested overlay
-// section, so they fall through to "".
+// GameClassName == "Class TgGame.TgGame_X" checks).
 std::string ResolveMissionMode(ATgGame* Game) {
     if (!Game || !Game->Class) return "";
     const char* raw = Game->Class->GetFullName();
     const std::string className(raw ? raw : "");
-    if (className == "Class TgGame.TgGame_Ticket")        return "ticket";
-    if (className == "Class TgGame.TgGame_Escort")        return "payload";
-    if (className == "Class TgGame.TgGame_Defense")       return "raid";
-    if (className == "Class TgGame.TgGame_PointRotation") return "koth";
-    if (className == "Class TgGame.TgGame_Mission")       return "breach";
+    const std::string classStripped =
+        (className.rfind("Class ", 0) == 0) ? className.substr(6) : className;
+
+    const std::string mapName = Config::GetMapNameChar();
+    const auto mapRow = MapGameInfo::LookupByNameAndGameMode(mapName, classStripped);
+    if (mapRow && mapRow->gameplay_type_value_id != 0) {
+        return ModeForGameplayType(mapRow->gameplay_type_value_id);
+    }
+
+    // No map_game_info row (older/local DB predating the column) -- fall
+    // back to the class-name-only behavior this feed originally shipped
+    // with. City/OpenWorldPVE/OpenWorldPVP/CTF/DualCTF have no requested
+    // overlay section, so they (and anything else unrecognized) fall
+    // through to "".
+    if (classStripped == "TgGame.TgGame_Ticket")        return "ticket";
+    if (classStripped == "TgGame.TgGame_Escort")        return "payload";
+    if (classStripped == "TgGame.TgGame_Defense")       return "raid";
+    if (classStripped == "TgGame.TgGame_PointRotation") return "koth";
+    if (classStripped == "TgGame.TgGame_Mission")       return SuperAgent::IsActive() ? "superagent" : "breach";
     return "";
 }
 
@@ -55,10 +91,17 @@ void CollectObjectives(TArray<ATgMissionObjective*>& arr, nlohmann::json& out) {
 
         nlohmann::json o;
         o["id"]              = obj->nObjectiveId;
-        o["priority"]        = obj->nPriority;
-        o["locked"]          = (bool)obj->r_bIsLocked;
-        o["active"]          = (bool)obj->r_bIsActive;
-        o["owner_taskforce"] = obj->r_nOwnerTaskForce;
+        // May be "" (no DB row/translation, or this DB predates those
+        // tables) -- the overlay falls back to numbering in that case, and
+        // must ALSO fall back when multiple concurrently-shown points
+        // resolve to the SAME name, since custom-spawned pools (koth, at
+        // least some Payload maps) reuse one nObjectiveId across every
+        // point in the pool. See ObjectiveNames.hpp.
+        o["name"]             = ObjectiveNames::LookupFriendlyName(obj->nObjectiveId);
+        o["priority"]         = obj->nPriority;
+        o["locked"]           = (bool)obj->r_bIsLocked;
+        o["active"]           = (bool)obj->r_bIsActive;
+        o["owner_taskforce"]  = obj->r_nOwnerTaskForce;
         // Same percent-progress formula TgGame's own SuperAgent capture-bar
         // logic uses (SuperAgent.cpp) -- not clamped there either; the
         // overlay HTML already clamps on the render side (see power/health
@@ -70,24 +113,59 @@ void CollectObjectives(TArray<ATgMissionObjective*>& arr, nlohmann::json& out) {
     }
 }
 
-// Boss = the attacker-owned TgMissionObjective_Bot (nDefaultOwnerTaskForce
-// == 1), same convention ObjectiveBotOutcome() uses to find the raid boss
-// among m_MissionObjectives. Health/max are the same ATgPawn fields the
-// pawn-health feed already trusts (r_nHealthMaximum, not HealthMax).
-void CollectBossHealth(TArray<ATgMissionObjective*>& arr, int& outHealth, int& outHealthMax) {
+// The FIRST TgMissionObjective_Bot found, no owner filtering -- matches
+// SuperAgent::Init()'s own boss-finding loop exactly. Solo PvE/Super Agent
+// maps have no second "defended NPC" bot to disambiguate against, unlike
+// Raid (see CollectRaidBots below), so there's nothing to filter by.
+void CollectSoloBoss(TArray<ATgMissionObjective*>& arr,
+        int& outHealth, int& outHealthMax, std::string& outName) {
     outHealth = 0;
     outHealthMax = 0;
+    outName.clear();
     if (!arr.Data) return;
     for (int i = 0; i < arr.Num(); i++) {
         ATgMissionObjective* obj = arr.Data[i];
         if (!obj || !ObjectClassCache::ClassNameContains((UObject*)obj, "TgMissionObjective_Bot")) continue;
         ATgMissionObjective_Bot* bot = (ATgMissionObjective_Bot*)obj;
-        if (bot->nDefaultOwnerTaskForce != 1) continue;
+        outName = ObjectiveNames::LookupFriendlyName(obj->nObjectiveId);
         if (bot->r_ObjectiveBot) {
             outHealth    = bot->r_ObjectiveBot->Health;
             outHealthMax = bot->r_ObjectiveBot->r_nHealthMaximum;
         }
         break;
+    }
+}
+
+// Raid has TWO bots to tell apart: the attacker-owned boss
+// (nDefaultOwnerTaskForce == 1) and a defender-owned "friendly" NPC/reactor
+// the defenders are protecting (== 2, e.g. "Bancroft" on
+// Raid_DomeCityDefense_P -- see ObjectiveBotOutcome.hpp's exact win/loss
+// convention, reused here for display purposes). Either can be absent
+// (health_max stays 0) on a map that doesn't use that half of the pattern.
+void CollectRaidBots(TArray<ATgMissionObjective*>& arr,
+        int& bossHealth, int& bossHealthMax, std::string& bossName,
+        int& friendlyHealth, int& friendlyHealthMax, std::string& friendlyName) {
+    bossHealth = bossHealthMax = friendlyHealth = friendlyHealthMax = 0;
+    bossName.clear();
+    friendlyName.clear();
+    if (!arr.Data) return;
+    for (int i = 0; i < arr.Num(); i++) {
+        ATgMissionObjective* obj = arr.Data[i];
+        if (!obj || !ObjectClassCache::ClassNameContains((UObject*)obj, "TgMissionObjective_Bot")) continue;
+        ATgMissionObjective_Bot* bot = (ATgMissionObjective_Bot*)obj;
+        if (bot->nDefaultOwnerTaskForce == 1 && bossHealthMax == 0) {
+            bossName = ObjectiveNames::LookupFriendlyName(obj->nObjectiveId);
+            if (bot->r_ObjectiveBot) {
+                bossHealth    = bot->r_ObjectiveBot->Health;
+                bossHealthMax = bot->r_ObjectiveBot->r_nHealthMaximum;
+            }
+        } else if (bot->nDefaultOwnerTaskForce == 2 && friendlyHealthMax == 0) {
+            friendlyName = ObjectiveNames::LookupFriendlyName(obj->nObjectiveId);
+            if (bot->r_ObjectiveBot) {
+                friendlyHealth    = bot->r_ObjectiveBot->Health;
+                friendlyHealthMax = bot->r_ObjectiveBot->r_nHealthMaximum;
+            }
+        }
     }
 }
 
@@ -120,7 +198,7 @@ void MaybePushSnapshot(AActor* actor) {
     // ATgGame_PointRotation extends ATgGame_Arena, the same round-scoring
     // base TgGame_Defense::FinalizeRoundScore increments. Ticket already
     // surfaces this as the X/points_to_win score bar; koth has nowhere else
-    // showing it, hence the overlay's new "points captured" pip row.
+    // showing it, hence the overlay's "points captured" pip row.
     if (mode == "ticket" || mode == "koth") {
         j["attacker_points"] = GTeamsData.Attackers ? GTeamsData.Attackers->r_nCurrentPointCount : 0;
         j["defender_points"] = GTeamsData.Defenders ? GTeamsData.Defenders->r_nCurrentPointCount : 0;
@@ -131,20 +209,47 @@ void MaybePushSnapshot(AActor* actor) {
         ATgGame_Defense* GameDef = (ATgGame_Defense*)Game;
         // s_nRoundNumber is already the 1-based "round in progress" number
         // once a round starts (see MissionVODirector.cpp's `round < 1`
-        // pre-round guard) -- shown as-is, not re-derived.
+        // pre-round guard) -- shown as-is, not re-derived. Displayed as
+        // "Wave" on the overlay, not "Round" -- same underlying counter.
         j["round_current"] = GameDef->s_nRoundNumber;
-        j["round_max"]      = GameDef->s_nMaxRoundNumber;
+        j["round_max"]     = GameDef->s_nMaxRoundNumber;
 
-        int bossHealth = 0, bossHealthMax = 0;
-        CollectBossHealth(GRI->m_MissionObjectives, bossHealth, bossHealthMax);
+        int bossHealth, bossHealthMax, friendlyHealth, friendlyHealthMax;
+        std::string bossName, friendlyName;
+        CollectRaidBots(GRI->m_MissionObjectives,
+            bossHealth, bossHealthMax, bossName,
+            friendlyHealth, friendlyHealthMax, friendlyName);
+        j["boss_health"]         = bossHealth;
+        j["boss_health_max"]     = bossHealthMax;
+        j["boss_name"]           = bossName;
+        j["friendly_health"]     = friendlyHealth;
+        j["friendly_health_max"] = friendlyHealthMax;
+        j["friendly_name"]       = friendlyName;
+    } else if (mode == "pve" || mode == "superagent") {
+        int bossHealth, bossHealthMax;
+        std::string bossName;
+        CollectSoloBoss(GRI->m_MissionObjectives, bossHealth, bossHealthMax, bossName);
         j["boss_health"]     = bossHealth;
         j["boss_health_max"] = bossHealthMax;
+        j["boss_name"]       = bossName;
+
+        if (mode == "superagent") {
+            // A (the 5-min hold) then B (final, back to the dropship) --
+            // both regular ATgMissionObjective_Proximity entries with real
+            // priority/lock fields (SuperAgent.cpp's SpawnPoint), so the
+            // exact same collector breach/ticket/koth use already reads
+            // their progress correctly with no special-casing needed.
+            nlohmann::json objectives = nlohmann::json::array();
+            CollectObjectives(GRI->m_MissionObjectives, objectives);
+            j["objectives"] = objectives;
+        }
     } else {
         // ticket / koth / payload / breach -- all carry the priority-ordered
         // objective-capture list. Ticket's 3 control points are always
         // active simultaneously (rendered as 3 small bars); koth uses
         // whichever single one is currently active/unlocked for its one big
-        // tug-of-war bar; payload/breach render every entry as a tile.
+        // tug-of-war bar; payload/breach render every entry as a
+        // tile/segment.
         nlohmann::json objectives = nlohmann::json::array();
         CollectObjectives(GRI->m_MissionObjectives, objectives);
         j["objectives"] = objectives;

--- a/src/Shared/IpcProtocol.hpp
+++ b/src/Shared/IpcProtocol.hpp
@@ -128,29 +128,43 @@ constexpr const char* MSG_PAWN_HEALTH_SNAPSHOT = "PAWN_HEALTH_SNAPSHOT";
 
 // Sent by a mission instance on the same ~1/sec rate-limited timer basis as
 // PAWN_HEALTH_SNAPSHOT, but once per instance (there's one ATgGame per
-// match, not one per pawn). "mode" is derived server-side from the game's
-// own class (TgGame_Ticket/_Escort/_Defense/_PointRotation/_Mission) and
-// selects which of the fields below are populated; modes with no requested
-// overlay treatment (City, OpenWorldPVE/PVP, CTF, DualCTF) never push at
-// all. Fields are ADDITIVE, not mutually exclusive by mode:
+// match, not one per pawn). "mode" is derived server-side primarily from
+// map_game_info.gameplay_type_value_id (the real differentiator between
+// modes sharing one TgGame class -- e.g. TgGame_Mission covers both Breach
+// and solo/PvE missions), falling back to class-name-only detection when a
+// map has no map_game_info row (older/local DB). Modes with no requested
+// overlay treatment (Home, stock CTR/DualCTF, City, OpenWorldPVE/PVP, CTF)
+// never push at all. Fields are ADDITIVE, not mutually exclusive by mode:
 //   - attacker_points/defender_points/points_to_win: ticket AND koth (both
 //     track a first-to-N team score via ATgRepInfo_TaskForce::r_nCurrentPointCount).
-//   - round_current/round_max/boss_health/boss_health_max: raid only.
-//   - objectives: ticket/koth/payload/breach (every mode except raid) -- a
-//     priority-ordered list of every ATgMissionObjective on the game's
-//     GameReplicationInfo -- id/priority/locked/active/owner_taskforce plus a
-//     0..1 capture_pct (m_fCurrCaptureTime / m_fTimeToCapture, unclamped same
-//     as the server's own SuperAgent capture-bar math). NOTE: id and
+//   - round_current/round_max: raid only (shown as "Wave" on the overlay,
+//     not "Round" -- same underlying s_nRoundNumber/s_nMaxRoundNumber).
+//   - boss_health/boss_health_max/boss_name: raid, pve, superagent.
+//   - friendly_health/friendly_health_max/friendly_name: raid only -- a
+//     defender-owned NPC/reactor the defenders are protecting (e.g.
+//     "Bancroft" on Raid_DomeCityDefense_P), separate from the boss.
+//   - objectives: ticket/koth/payload/breach/superagent (every mode except
+//     raid and plain pve) -- a priority-ordered list of every
+//     ATgMissionObjective on the game's GameReplicationInfo --
+//     id/name/priority/locked/active/owner_taskforce plus a 0..1
+//     capture_pct (m_fCurrCaptureTime / m_fTimeToCapture, unclamped same as
+//     the server's own SuperAgent capture-bar math). NOTE: id, name, and
 //     priority are NOT guaranteed unique per point -- e.g. every koth
-//     rotation point shares the same nObjectiveId/nPriority by design (see
-//     CtrPointRotation.cpp) -- consumers must key UI elements by array
-//     position, never by id/priority.
+//     rotation point shares the same nObjectiveId/nPriority/name by design
+//     (see CtrPointRotation.cpp), and at least some Payload maps reuse one
+//     id across all their checkpoints too -- consumers must key UI elements
+//     by array position, never by id/priority, and must fall back to
+//     numbering when multiple concurrently-shown points share a name.
 //   ticket: { "mode":"ticket", "attacker_points":<int>, "defender_points":<int>,
 //     "points_to_win":<int>, "objectives":[...] }
 //   raid:   { "mode":"raid", "round_current":<int>, "round_max":<int>,
-//     "boss_health":<int>, "boss_health_max":<int> }
+//     "boss_health":<int>, "boss_health_max":<int>, "boss_name":<string>,
+//     "friendly_health":<int>, "friendly_health_max":<int>, "friendly_name":<string> }
 //   koth:   { "mode":"koth", "attacker_points":<int>, "defender_points":<int>,
 //     "points_to_win":<int>, "objectives":[...] }
+//   pve:        { "mode":"pve", "boss_health":<int>, "boss_health_max":<int>, "boss_name":<string> }
+//   superagent: { "mode":"superagent", "boss_health":<int>, "boss_health_max":<int>,
+//     "boss_name":<string>, "objectives":[...] }  -- boss then 2 sequential captures
 //   payload/breach: { "mode":"payload"|"breach", "objectives":[...] }
 constexpr const char* MSG_MISSION_PROGRESS_SNAPSHOT = "MISSION_PROGRESS_SNAPSHOT";
 

--- a/tools/spectator-overlay/spectator-overlay.html
+++ b/tools/spectator-overlay/spectator-overlay.html
@@ -456,12 +456,26 @@
   .mission-point-pip.filled.attackers { background: #ff8a5c; }
   .mission-point-pip.filled.defenders { background: #5cc7ff; }
 
+  /* Raid/pve/superagent all stack their bar(s) vertically -- the koth-block
+     flex-direction bug (forgotten once already) is exactly why each of
+     these gets its own explicit rule rather than relying on inheritance. */
+  .mission-raid-block, .mission-pve-block, .mission-superagent-block {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+  }
+
   .mission-raid-round {
     font-size: 13px;
     font-weight: 700;
     text-shadow: 0 1px 3px rgba(0,0,0,0.9);
   }
 
+  /* Shared boss/friendly health-bar widget -- raid's hostile boss AND its
+     defended "friendly" NPC (distinct color), plus pve/superagent's solo
+     boss, all use this. Label shows "Name: HP / MaxHP" when a name resolved
+     (see ObjectiveNames.hpp), else just "HP / MaxHP". */
   .mission-boss-bar {
     position: relative;
     width: 260px;
@@ -478,6 +492,7 @@
     background: #e53935;
     transition: width 150ms linear;
   }
+  .mission-boss-bar-fill.friendly { background: #4caf50; }
   .mission-boss-label {
     position: absolute;
     inset: 0;
@@ -487,6 +502,9 @@
     font-size: 10px;
     text-shadow: 0 1px 2px rgba(0,0,0,0.8);
   }
+
+  #mission-superagent-points { display: flex; flex-direction: column; gap: 4px; }
+  #mission-superagent-points .mission-tug-bar { width: 240px; height: 18px; }
 
   /* payload -- ONE connected pill divided into N equal segments (one per
      push checkpoint, usually 3), not N separate widgets: a captured segment
@@ -670,12 +688,29 @@
     </div>
     <div id="mission-ticket-points" class="mission-ticket-points-row"></div>
   </div>
-  <div id="mission-raid" class="mission-raid-row">
+  <div id="mission-raid" class="mission-raid-block">
     <div class="mission-raid-round" id="mission-raid-round"></div>
     <div class="mission-boss-bar">
       <div class="mission-boss-bar-fill" id="mission-boss-fill"></div>
       <div class="mission-boss-label" id="mission-boss-label"></div>
     </div>
+    <div class="mission-boss-bar" id="mission-friendly-bar">
+      <div class="mission-boss-bar-fill friendly" id="mission-friendly-fill"></div>
+      <div class="mission-boss-label" id="mission-friendly-label"></div>
+    </div>
+  </div>
+  <div id="mission-pve" class="mission-pve-block">
+    <div class="mission-boss-bar">
+      <div class="mission-boss-bar-fill" id="mission-pve-boss-fill"></div>
+      <div class="mission-boss-label" id="mission-pve-boss-label"></div>
+    </div>
+  </div>
+  <div id="mission-superagent" class="mission-superagent-block">
+    <div class="mission-boss-bar">
+      <div class="mission-boss-bar-fill" id="mission-superagent-boss-fill"></div>
+      <div class="mission-boss-label" id="mission-superagent-boss-label"></div>
+    </div>
+    <div id="mission-superagent-points"></div>
   </div>
   <div id="mission-koth" class="mission-koth-block">
     <div class="mission-tug-bar" id="mission-koth-tugbar">
@@ -1003,6 +1038,16 @@ const missionRaid            = document.getElementById("mission-raid");
 const missionRaidRound       = document.getElementById("mission-raid-round");
 const missionBossFill        = document.getElementById("mission-boss-fill");
 const missionBossLabel       = document.getElementById("mission-boss-label");
+const missionFriendlyBar     = document.getElementById("mission-friendly-bar");
+const missionFriendlyFill    = document.getElementById("mission-friendly-fill");
+const missionFriendlyLabel   = document.getElementById("mission-friendly-label");
+const missionPve             = document.getElementById("mission-pve");
+const missionPveBossFill     = document.getElementById("mission-pve-boss-fill");
+const missionPveBossLabel    = document.getElementById("mission-pve-boss-label");
+const missionSuperagent           = document.getElementById("mission-superagent");
+const missionSuperagentBossFill   = document.getElementById("mission-superagent-boss-fill");
+const missionSuperagentBossLabel  = document.getElementById("mission-superagent-boss-label");
+const missionSuperagentPoints     = document.getElementById("mission-superagent-points");
 const missionKoth            = document.getElementById("mission-koth");
 const missionKothFillAtk     = document.getElementById("mission-koth-fill-atk");
 const missionKothFillDef     = document.getElementById("mission-koth-fill-def");
@@ -1026,6 +1071,22 @@ const missionPayload         = document.getElementById("mission-payload");
 function tugFractions(pct) {
   const p = Math.max(0, Math.min(1, pct));
   return { atk: p, def: 1 - p };
+}
+
+// Prefer the friendly name the server resolved (ObjectiveNames.hpp, joining
+// nObjectiveId through asm_data_set_objectives/msg_translations) -- but
+// custom-spawned pools (koth's rotation points, and apparently at least some
+// Payload maps) reuse ONE nObjectiveId across every point, so if multiple
+// points in THIS SAME array share a name, showing it would look like a bug
+// (every point labeled identically). Falls back to "Point N" for all of
+// them in that case rather than trusting a duplicate name.
+function pointLabels(points) {
+  const counts = new Map();
+  points.forEach(o => {
+    if (!o.name) return;
+    counts.set(o.name, (counts.get(o.name) || 0) + 1);
+  });
+  return points.map((o, idx) => (o.name && counts.get(o.name) === 1) ? o.name : "Point " + (idx + 1));
 }
 
 const missionPayloadSegments = new Map(); // array position -> {el, fillAtk, fillDef}
@@ -1118,6 +1179,7 @@ function ensureTugBar(barMap, container, position) {
 // bar instead of a live 50/50-or-shifted split -- there's nothing to tug
 // over yet since it isn't contestable.
 function renderTugBarStack(container, barMap, points) {
+  const labels = pointLabels(points);
   const seen = new Set();
   points.forEach((o, idx) => {
     seen.add(idx);
@@ -1128,11 +1190,11 @@ function renderTugBarStack(container, barMap, points) {
       const frac = tugFractions(o.capture_pct != null ? o.capture_pct : 0.5);
       entry.fillAtk.style.width = (frac.atk * 100) + "%";
       entry.fillDef.style.width = (frac.def * 100) + "%";
-      entry.label.textContent = "Point " + (idx + 1);
+      entry.label.textContent = labels[idx];
     } else {
       entry.fillAtk.style.width = "0%";
       entry.fillDef.style.width = "0%";
-      entry.label.textContent = "Point " + (idx + 1) + " (locked)";
+      entry.label.textContent = labels[idx] + " (locked)";
     }
   });
   for (const [pos, entry] of barMap) {
@@ -1140,8 +1202,9 @@ function renderTugBarStack(container, barMap, points) {
   }
 }
 
-const missionTicketTugBars = new Map(); // array position -> {el, fillAtk, fillDef, label}
-const missionBreachTugBars = new Map();
+const missionTicketTugBars     = new Map(); // array position -> {el, fillAtk, fillDef, label}
+const missionBreachTugBars     = new Map();
+const missionSuperagentTugBars = new Map();
 
 // koth's "first to points_to_win" pip row -- cheap plain divs with no images
 // and no fill-transition to preserve, so a full rebuild each poll is fine
@@ -1164,9 +1227,19 @@ function updateMissionPanel(mission) {
   missionPanel.classList.add("visible");
   missionTicket.style.display = "none";
   missionRaid.style.display = "none";
+  missionPve.style.display = "none";
+  missionSuperagent.style.display = "none";
   missionKoth.style.display = "none";
   missionBreach.style.display = "none";
   missionPayload.style.display = "none";
+
+  // "Name: HP / MaxHP" when a friendly name resolved server-side, else just
+  // "HP / MaxHP" -- shared by raid's boss/friendly bars and pve/superagent's
+  // boss bar. "" (bar hidden/empty) when maxHp is 0 (no such bot on this map).
+  function bossLabelText(name, hp, maxHp) {
+    if (maxHp <= 0) return "";
+    return (name ? name + ": " : "") + hp + " / " + maxHp;
+  }
 
   if (mission.mode === "ticket") {
     missionTicket.style.display = "flex";
@@ -1184,12 +1257,51 @@ function updateMissionPanel(mission) {
     renderTugBarStack(missionTicketPoints, missionTicketTugBars, points);
   } else if (mission.mode === "raid") {
     missionRaid.style.display = "flex";
-    missionRaidRound.textContent = "Round " + mission.round_current + " / " + mission.round_max;
+    // Shown as "Wave" on the overlay -- same underlying round counter.
+    missionRaidRound.textContent = "Wave " + mission.round_current + " / " + mission.round_max;
+
     const bossPct = mission.boss_health_max > 0
       ? Math.max(0, Math.min(1, mission.boss_health / mission.boss_health_max)) : 0;
     missionBossFill.style.width = (bossPct * 100) + "%";
-    missionBossLabel.textContent = mission.boss_health_max > 0
-      ? (mission.boss_health + " / " + mission.boss_health_max) : "";
+    missionBossLabel.textContent = bossLabelText(mission.boss_name, mission.boss_health, mission.boss_health_max);
+
+    // The defended "friendly" NPC/reactor -- absent on maps that don't use
+    // that half of the pattern, so the whole bar hides rather than showing
+    // an empty one.
+    const hasFriendly = mission.friendly_health_max > 0;
+    missionFriendlyBar.style.display = hasFriendly ? "block" : "none";
+    if (hasFriendly) {
+      const friendlyPct = Math.max(0, Math.min(1, mission.friendly_health / mission.friendly_health_max));
+      missionFriendlyFill.style.width = (friendlyPct * 100) + "%";
+      missionFriendlyLabel.textContent =
+        bossLabelText(mission.friendly_name, mission.friendly_health, mission.friendly_health_max);
+    }
+  } else if (mission.mode === "pve") {
+    missionPve.style.display = "flex";
+    const bossPct = mission.boss_health_max > 0
+      ? Math.max(0, Math.min(1, mission.boss_health / mission.boss_health_max)) : 0;
+    missionPveBossFill.style.width = (bossPct * 100) + "%";
+    missionPveBossLabel.textContent = bossLabelText(mission.boss_name, mission.boss_health, mission.boss_health_max);
+  } else if (mission.mode === "superagent") {
+    missionSuperagent.style.display = "flex";
+    const bossAlive = mission.boss_health_max > 0 && mission.boss_health > 0;
+    const bossPct = mission.boss_health_max > 0
+      ? Math.max(0, Math.min(1, mission.boss_health / mission.boss_health_max)) : 0;
+    missionSuperagentBossFill.style.width = (bossPct * 100) + "%";
+    missionSuperagentBossLabel.textContent = mission.boss_health_max > 0
+      ? bossLabelText(mission.boss_name, mission.boss_health, mission.boss_health_max)
+      : "Boss defeated";
+
+    // Boss first, then the two sequential captures (the 5-min hold, then
+    // the final dropship point) once it's dead -- matches the mission's
+    // real flow (kill boss -> only the captures matter after that).
+    if (bossAlive) {
+      missionSuperagentPoints.style.display = "none";
+    } else {
+      missionSuperagentPoints.style.display = "flex";
+      const points = (mission.objectives || []).slice().sort((a, b) => a.priority - b.priority);
+      renderTugBarStack(missionSuperagentPoints, missionSuperagentTugBars, points);
+    }
   } else if (mission.mode === "koth") {
     missionKoth.style.display = "flex";
     const points = (mission.objectives || []).slice().sort((a, b) => a.priority - b.priority);
@@ -1200,7 +1312,7 @@ function updateMissionPanel(mission) {
       const frac = tugFractions(points[activeIdx].capture_pct != null ? points[activeIdx].capture_pct : 0.5);
       missionKothFillAtk.style.width = (frac.atk * 100) + "%";
       missionKothFillDef.style.width = (frac.def * 100) + "%";
-      missionKothLabel.textContent = "Point " + (activeIdx + 1);
+      missionKothLabel.textContent = pointLabels(points)[activeIdx];
     } else {
       missionKothFillAtk.style.width = "50%";
       missionKothFillDef.style.width = "50%";
@@ -1308,55 +1420,76 @@ const DEMO_MAX_EFFECTS = 14;
 // around every poll.
 const demoState = new Map();
 
-// Mission-progress demo -- cycles through ticket, raid, koth, breach,
-// payload every 6s so layout/positioning for all of them can be rehearsed
-// without needing five different live matches. Running counters persist
-// across polls the same way demoState does above, so values drift smoothly
-// instead of jumping.
+// Mission-progress demo -- cycles through ticket, raid, pve, superagent,
+// koth, breach, payload every 6s so layout/positioning for all of them can
+// be rehearsed without needing seven different live matches. Running
+// counters persist across polls the same way demoState does above, so
+// values drift smoothly instead of jumping.
 const demoMissionState = {
   // ticket -- overall score (unrelated to the per-point tug bars below) plus
   // 3 simultaneously-active capture points that drift around the neutral
-  // midpoint (0.5), same as a real contested Control map.
+  // midpoint (0.5), same as a real contested Control map. Distinct real-
+  // looking names (map-authored points genuinely have distinct
+  // nObjectiveIds/names, unlike koth's shared-pool ids below) to exercise
+  // the friendly-name label path.
   ticketAttackerPoints: 0, ticketDefenderPoints: 0,
   ticketPoints: [
-    { id: 1, priority: 1, locked: false, active: true, owner_taskforce: 0, capture_pct: 0.5 },
-    { id: 1, priority: 2, locked: false, active: true, owner_taskforce: 0, capture_pct: 0.5 },
-    { id: 1, priority: 3, locked: false, active: true, owner_taskforce: 0, capture_pct: 0.5 },
+    { id: 272, name: "Security Gate 1", priority: 1, locked: false, active: true, owner_taskforce: 0, capture_pct: 0.5 },
+    { id: 273, name: "Tower Gates",      priority: 2, locked: false, active: true, owner_taskforce: 0, capture_pct: 0.5 },
+    { id: 274, name: "Tower Controls",   priority: 3, locked: false, active: true, owner_taskforce: 0, capture_pct: 0.5 },
   ],
 
   round: 1, bossHealth: 100000, bossHealthMax: 100000,
+  friendlyHealth: 30000, friendlyHealthMax: 30000,
 
-  // koth -- a small rotation pool sharing the same id/priority (exactly like
-  // CtrPointRotation.cpp's real pool) with one point active at a time.
-  // capture_pct tugs toward 0 (attacker) or 1 (defender); reaching an
-  // extreme awards that team a point and starts a brief "being selected" gap.
+  // pve -- a single boss bar, no capture points.
+  pveBossHealth: 60000, pveBossHealthMax: 60000,
+
+  // superagent -- boss bar first; once it's dead, the two sequential
+  // captures (the 5-min hold, then the final dropship point) cycle forever
+  // via advanceSequentialCapture's own wraparound (see below) -- fine for a
+  // rehearsal loop even though the real mission only plays that once.
+  superagentBossHealth: 50000, superagentBossHealthMax: 50000,
+  superagentPoints: [
+    { id: 194, name: "", priority: 2, locked: true, active: false, owner_taskforce: 0, capture_pct: 0.5 },
+    { id: 287, name: "", priority: 3, locked: true, active: false, owner_taskforce: 0, capture_pct: 0.5 },
+  ],
+
+  // koth -- a small rotation pool sharing the same id/priority/name
+  // (exactly like CtrPointRotation.cpp's real pool) with one point active
+  // at a time. capture_pct tugs toward 0 (attacker) or 1 (defender);
+  // reaching an extreme awards that team a point and starts a brief
+  // "being selected" gap. name left "" to exercise the numbered fallback --
+  // real koth points don't resolve a usable distinct name either.
   kothAttackerPoints: 0, kothDefenderPoints: 0,
   kothPoints: [
-    { id: 345, priority: 1, locked: true, active: false, owner_taskforce: 0, capture_pct: 0.5 },
-    { id: 345, priority: 1, locked: true, active: false, owner_taskforce: 0, capture_pct: 0.5 },
-    { id: 345, priority: 1, locked: true, active: false, owner_taskforce: 0, capture_pct: 0.5 },
+    { id: 345, name: "", priority: 1, locked: true, active: false, owner_taskforce: 0, capture_pct: 0.5 },
+    { id: 345, name: "", priority: 1, locked: true, active: false, owner_taskforce: 0, capture_pct: 0.5 },
+    { id: 345, name: "", priority: 1, locked: true, active: false, owner_taskforce: 0, capture_pct: 0.5 },
   ],
   kothRotatingUntil: 0,
 
   // breach -- sequential 3-point unlock chain, rendered as stacked tug bars.
   breachObjectives: [
-    { id: 1, priority: 1, locked: false, active: true,  owner_taskforce: 0, capture_pct: 0.5 },
-    { id: 2, priority: 2, locked: true,  active: false, owner_taskforce: 0, capture_pct: 0.5 },
-    { id: 3, priority: 3, locked: true,  active: false, owner_taskforce: 0, capture_pct: 0.5 },
+    { id: 272, name: "Security Gate 1", priority: 1, locked: false, active: true,  owner_taskforce: 0, capture_pct: 0.5 },
+    { id: 273, name: "Tower Gates",     priority: 2, locked: true,  active: false, owner_taskforce: 0, capture_pct: 0.5 },
+    { id: 274, name: "Tower Controls",  priority: 3, locked: true,  active: false, owner_taskforce: 0, capture_pct: 0.5 },
   ],
 
   // payload -- same sequential-unlock mechanic as breach, but rendered as
   // one connected segmented pill (see renderPayloadBar) instead of stacked
-  // separate bars.
+  // separate bars. No name display on this widget, so names are irrelevant
+  // here -- left blank like the real objId=60-shared-across-checkpoints
+  // payload map observed in testing.
   payloadObjectives: [
-    { id: 1, priority: 1, locked: false, active: true,  owner_taskforce: 0, capture_pct: 0.5 },
-    { id: 2, priority: 2, locked: true,  active: false, owner_taskforce: 0, capture_pct: 0.5 },
-    { id: 3, priority: 3, locked: true,  active: false, owner_taskforce: 0, capture_pct: 0.5 },
+    { id: 60, name: "", priority: 1, locked: false, active: true,  owner_taskforce: 0, capture_pct: 0.5 },
+    { id: 60, name: "", priority: 2, locked: true,  active: false, owner_taskforce: 0, capture_pct: 0.5 },
+    { id: 60, name: "", priority: 3, locked: true,  active: false, owner_taskforce: 0, capture_pct: 0.5 },
   ],
 };
 
 function generateDemoMission() {
-  const mode = ["ticket", "raid", "koth", "breach", "payload"][Math.floor(Date.now() / 6000) % 5];
+  const mode = ["ticket", "raid", "pve", "superagent", "koth", "breach", "payload"][Math.floor(Date.now() / 6000) % 7];
 
   if (mode === "ticket") {
     demoMissionState.ticketAttackerPoints = Math.min(800, demoMissionState.ticketAttackerPoints + Math.random() * 6);
@@ -1379,12 +1512,33 @@ function generateDemoMission() {
       demoMissionState.bossHealth = demoMissionState.bossHealthMax;
       demoMissionState.round = demoMissionState.round >= 4 ? 1 : demoMissionState.round + 1;
     }
+    // The defended "friendly" NPC drains slowly and independently of the
+    // boss -- on a real map this only moves if the attackers reach it, but
+    // for layout rehearsal a steady trickle is enough to show the bar isn't
+    // static.
+    demoMissionState.friendlyHealth = Math.max(0, demoMissionState.friendlyHealth - Math.random() * 150);
+    if (demoMissionState.friendlyHealth <= 0) demoMissionState.friendlyHealth = demoMissionState.friendlyHealthMax;
     return {
       mode,
       round_current: demoMissionState.round,
       round_max: 4,
       boss_health: Math.max(0, Math.round(demoMissionState.bossHealth)),
       boss_health_max: demoMissionState.bossHealthMax,
+      boss_name: "Colony Dismantler",
+      friendly_health: Math.round(demoMissionState.friendlyHealth),
+      friendly_health_max: demoMissionState.friendlyHealthMax,
+      friendly_name: "Bancroft",
+    };
+  }
+
+  if (mode === "pve") {
+    demoMissionState.pveBossHealth -= Math.random() * 900;
+    if (demoMissionState.pveBossHealth <= 0) demoMissionState.pveBossHealth = demoMissionState.pveBossHealthMax;
+    return {
+      mode,
+      boss_health: Math.max(0, Math.round(demoMissionState.pveBossHealth)),
+      boss_health_max: demoMissionState.pveBossHealthMax,
+      boss_name: "Ancient Guardian",
     };
   }
 
@@ -1435,6 +1589,25 @@ function generateDemoMission() {
     } else if (active.capture_pct >= 0.9) {
       active.capture_pct = 0.75;
     }
+  }
+
+  if (mode === "superagent") {
+    if (demoMissionState.superagentBossHealth > 0) {
+      demoMissionState.superagentBossHealth = Math.max(0, demoMissionState.superagentBossHealth - Math.random() * 1500);
+      if (demoMissionState.superagentBossHealth <= 0) {
+        demoMissionState.superagentPoints[0].locked = false;
+        demoMissionState.superagentPoints[0].active = true;
+      }
+    } else {
+      advanceSequentialCapture(demoMissionState.superagentPoints);
+    }
+    return {
+      mode,
+      boss_health: Math.round(demoMissionState.superagentBossHealth),
+      boss_health_max: demoMissionState.superagentBossHealthMax,
+      boss_name: "Colony Dismantler",
+      objectives: demoMissionState.superagentPoints.map(o => ({ ...o })),
+    };
   }
 
   if (mode === "breach") {


### PR DESCRIPTION
map_game_info.gameplay_type_value_id is the real differentiator between game modes that share one TgGame class -- TgGame_Mission covers both Breach and solo/PvE missions, TgGame_PointRotation covers both standard and small-map Scramble. The previous class-name-only detection couldn't tell these apart, so every solo/PvE mission was incorrectly labeled "breach". Confirmed against a live map_game_info export.

- MapGameInfo: added gameplay_type_value_id to the lookup row. Falls back to nullopt (and callers fall back to class-name-only detection) on this repo's own dev DB, which predates the column entirely.
- MissionProgressFeed: gameplay_type_value_id now picks the mode, with the old class-name check kept as a fallback. Adds two new modes:
  - "pve": a boss health bar for solo/PvE missions.
  - "superagent": boss bar, then (once it's dead) the two real sequential capture points, detected via SuperAgent::IsActive() since Super Agent doesn't get its own gameplay_type_value_id.
- Raid: added a second health bar for the defender-owned "friendly" NPC/reactor being protected (distinct from the boss), and relabeled "Round" to "Wave" on the overlay.
- New ObjectiveNames lookup (nObjectiveId -> asm_data_set_objectives.text_ msg_id -> asm_data_set_msg_translations.message) resolves real point names (e.g. "Security Gate 1") for ticket/koth/breach/superagent's labels, confirmed against live data. Custom-spawned point pools (koth's rotation points, at least one payload map) reuse one nObjectiveId across every point, so the overlay falls back to numbering whenever multiple concurrently-shown points would otherwise share a name.

