### PR TITLE
FIX: Killer Instinct - rework how debuf/prot interaction applies on shot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,6 +257,7 @@ SOURCE_FILES= \
 			  $(SRC_DIR)/GameServer/TgGame/TgDevice_Morale/SendMoraleBoostMessage/TgDevice_Morale__SendMoraleBoostMessage.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/Morale/MoraleCredit.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/_effect_core/DeviceCategorySkill.cpp \
+			  $(SRC_DIR)/GameServer/TgGame/_effect_core/HitSituationalMitigation.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/_effect_core/ScaleTargetProperties.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/_deployable_classify/DeployableClassify.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/_surface_rotation/SurfaceRotation.cpp \

--- a/src/GameServer/TgGame/TgEffect/CheckEffectBuffModifier/TgEffect__CheckEffectBuffModifier.cpp
+++ b/src/GameServer/TgGame/TgEffect/CheckEffectBuffModifier/TgEffect__CheckEffectBuffModifier.cpp
@@ -1,6 +1,7 @@
 #include "src/GameServer/TgGame/TgEffect/CheckEffectBuffModifier/TgEffect__CheckEffectBuffModifier.hpp"
 #include "src/GameServer/TgGame/_effect_core/OriginResolver.hpp"
 #include "src/GameServer/TgGame/_effect_core/DeviceLookup.hpp"
+#include "src/GameServer/TgGame/_effect_core/HitSituationalMitigation.hpp"
 #include "src/GameServer/Utils/ObjectClassCache/ObjectClassCache.hpp"
 #include "src/Utils/Logger/Logger.hpp"
 
@@ -60,6 +61,20 @@ void __fastcall TgEffect__CheckEffectBuffModifier::Call(UTgEffect* effect, void*
 	if (!effect || !NewValue) return;
 	UTgEffectGroup* g = effect->m_EffectGroup;
 	if (!g) return;
+
+	// Self-shot mitigation bracket. This native is the last thing that runs on
+	// an effect before its value reaches the target, which makes it the one
+	// place that sees both halves of the type-505 ordering defect at the right
+	// moment: the debuff at TgEffect.uc:115 (before ApplyToProperty writes it)
+	// and the damage at TgEffectDamage.uc:131 (before ProtectionModifier reads
+	// it). Both calls come first so the early-outs below can't skip them.
+	// See HitSituationalMitigation.hpp.
+	const bool isDamage = ObjectClassCache::ClassNameContains(effect, "TgEffectDamage");
+	if (isDamage) {
+		HitSituationalMitigation::BeginImpactMitigation(effect);
+	} else {
+		HitSituationalMitigation::NoteDebuffApplied(effect);
+	}
 
 	const float origValue = *NewValue;
 	if (origValue == 0.0f) return;  // nothing to scale

--- a/src/GameServer/TgGame/TgEffectManager/RemoveEffectGroupsByCategory/TgEffectManager__RemoveEffectGroupsByCategory.cpp
+++ b/src/GameServer/TgGame/TgEffectManager/RemoveEffectGroupsByCategory/TgEffectManager__RemoveEffectGroupsByCategory.cpp
@@ -1,5 +1,6 @@
 #include "src/GameServer/TgGame/TgEffectManager/RemoveEffectGroupsByCategory/TgEffectManager__RemoveEffectGroupsByCategory.hpp"
 #include "src/GameServer/TgGame/TgEffectGroup/RemoveEffects/TgEffectGroup__RemoveEffects.hpp"
+#include "src/GameServer/TgGame/_effect_core/HitSituationalMitigation.hpp"
 #include "src/Utils/Logger/Logger.hpp"
 
 // TgEffectManager::RemoveEffectGroupsByCategory — reimplements the stripped stub
@@ -15,6 +16,16 @@ typedef void(__fastcall* ClearEffectRepFn)(ATgEffectManager*, void*, int, int);
 static const ClearEffectRepFn ClearEffectRepNative = (ClearEffectRepFn)0x10a6f030;
 
 bool __fastcall TgEffectManager__RemoveEffectGroupsByCategory::Call(ATgEffectManager* Manager, void* /*edx*/, int nCategoryCode, int nQuantity) {
+	// Closing bracket for the type-505 self-shot guard. TgEffectDamage.uc:206
+	// calls this with exactly (431, 99) on the victim's manager, after
+	// ProtectionModifier and the health cap and before TakeDamage — the one
+	// unconditional beat in the damage path where mitigation is finished but
+	// the hit has not landed yet. Runs before the arg checks so a window
+	// always closes. See HitSituationalMitigation.hpp.
+	if (nCategoryCode == 431 && nQuantity == 99) {
+		HitSituationalMitigation::EndImpactMitigation(Manager);
+	}
+
 	if (!Manager || nQuantity <= 0) return false;
 
 	int removed = 0;

--- a/src/GameServer/TgGame/_effect_core/HitSituationalMitigation.cpp
+++ b/src/GameServer/TgGame/_effect_core/HitSituationalMitigation.cpp
@@ -1,0 +1,166 @@
+#include "src/GameServer/TgGame/_effect_core/HitSituationalMitigation.hpp"
+#include "src/GameServer/TgGame/TgPawn/GetProperty/TgPawn__GetProperty.hpp"
+#include "src/GameServer/Utils/ObjectClassCache/ObjectClassCache.hpp"
+#include "src/Utils/Logger/Logger.hpp"
+
+#include <vector>
+
+namespace {
+
+// Every property `TgEffectDamage.ProtectionModifier` can consume for an
+// impact, read straight off the three switches in TgEffectGroup.uc:
+//   CalcCategoryProtection   (608) — by m_nCategoryCode
+//   CalcDamageTypeProtection (673) — by m_nDamageType
+//   CalcAttackTypeProtection (715) — by m_eAttackType, category 302/963 only
+// Anything outside this set cannot change a mitigation result, so a 505 debuff
+// on it is left strictly alone.
+bool IsMitigationProp(int propId) {
+	switch (propId) {
+		// Category axis
+		case 159: case 158: case 160: case 163: case 168:
+		case 233: case 235: case 266: case 371: case 328:
+		// Damage-type axis
+		case 155: case 157: case 156: case 324:
+		// Attack-type axis
+		case 217: case 218: case 219:
+			return true;
+		default:
+			return false;
+	}
+}
+
+// A protection write made by this impact's own 505 pass, captured before it
+// landed. Keyed by (victim, instigator): both the debuff group and the damage
+// group get `m_Instigator` from the same `SubmitEffect` call
+// (TgDeviceFire.uc:400-408 — `m_Owner.Instigator`), so equality means "same
+// shooter, same victim".
+//
+// NOTE: deliberately NOT keyed on m_nSourceDeviceInstId. A skill-sourced group
+// resolves that differently from the device's damage group, and that asymmetry
+// is what scopes Eagle Eye's potency to weapon debuffs only — confirmed
+// intended behaviour we must not disturb.
+struct PendingDebuff {
+	ATgPawn* victim;
+	AActor*  instigator;
+	int      propId;
+	float    preRaw;
+};
+
+// A property currently lent back to its pre-debuff value, with the delta owed.
+struct ActiveSwap {
+	UTgProperty* prop;
+	float        delta;   // what the 505 pass had applied; re-added on close
+};
+
+std::vector<PendingDebuff> g_pending;
+std::vector<ActiveSwap>    g_active;
+
+ATgPawn* AsPawn(AActor* actor) {
+	if (!actor) return nullptr;
+	if (!ObjectClassCache::ClassNameContains(actor, "TgPawn")) return nullptr;
+	return static_cast<ATgPawn*>(actor);
+}
+
+}  // namespace
+
+namespace HitSituationalMitigation {
+
+void NoteDebuffApplied(UTgEffect* effect) {
+	if (!effect) return;
+	UTgEffectGroup* g = effect->m_EffectGroup;
+	if (!g) return;
+
+	// Only the HP-gated situational pass runs ahead of the damage submit.
+	if (g->m_nType != 505) return;
+	if (g->m_nSituationalType != 1270 && g->m_nSituationalType != 1271) return;
+	if (!IsMitigationProp(effect->m_nPropertyId)) return;
+
+	// Pawn victims only: the closing bracket (TgEffectDamage.uc:206) is inside
+	// `if(bIsPawnTarget)`, so arming for a deployable would leave the swap open.
+	ATgPawn* victim = AsPawn(g->m_Target);
+	if (!victim) return;
+
+	UTgProperty* prop = TgPawn__GetProperty::CallOriginal(victim, nullptr, effect->m_nPropertyId);
+	if (!prop) return;
+
+	// Two 505 groups hitting the same prop on one impact: keep the earliest
+	// capture, which is the true pre-impact value.
+	for (const PendingDebuff& rec : g_pending) {
+		if (rec.victim == victim && rec.propId == effect->m_nPropertyId) return;
+	}
+
+	g_pending.push_back(PendingDebuff{ victim, g->m_Instigator,
+	                                   effect->m_nPropertyId, prop->m_fRaw });
+
+	if (Logger::IsChannelEnabled("ki")) {
+		Logger::Log("ki",
+			"[NOTE] egId=%d type=505 sit=%d prop=%d victim=%p inst=%p preRaw=%.3f\n",
+			g->m_nEffectGroupId, g->m_nSituationalType, effect->m_nPropertyId,
+			(void*)victim, (void*)g->m_Instigator, prop->m_fRaw);
+	}
+}
+
+void BeginImpactMitigation(UTgEffect* damageEffect) {
+	if (!damageEffect) return;
+	UTgEffectGroup* g = damageEffect->m_EffectGroup;
+	if (!g) return;
+
+	// A window left open would be a bug in the bracketing, not something to
+	// paper over — close it before opening a new one so a property can never
+	// be double-lent.
+	if (!g_active.empty()) {
+		Logger::Log("ki",
+			"[BEGIN] window still open with %d entries — closing before reopen\n",
+			(int)g_active.size());
+		for (ActiveSwap& s : g_active) {
+			if (s.prop) s.prop->m_fRaw += s.delta;
+		}
+		g_active.clear();
+	}
+
+	ATgPawn* victim = AsPawn(g->m_Target);
+	if (victim) {
+		for (const PendingDebuff& rec : g_pending) {
+			if (rec.victim != victim || rec.instigator != g->m_Instigator) continue;
+
+			UTgProperty* prop = TgPawn__GetProperty::CallOriginal(victim, nullptr, rec.propId);
+			if (!prop) continue;
+
+			// Store the delta rather than the absolute value so anything else
+			// that writes this property inside the window (a shield breaking
+			// mid-mitigation, say) composes correctly on close.
+			const float delta = prop->m_fRaw - rec.preRaw;
+			prop->m_fRaw = rec.preRaw;
+			g_active.push_back(ActiveSwap{ prop, delta });
+
+			if (Logger::IsChannelEnabled("ki")) {
+				Logger::Log("ki",
+					"[BEGIN] egId=%d victim=%p prop=%d  m_fRaw %.3f -> %.3f (delta %.3f held)\n",
+					g->m_nEffectGroupId, (void*)victim, rec.propId,
+					rec.preRaw + delta, rec.preRaw, delta);
+			}
+		}
+	}
+
+	// Records are consumed by the first damage application that follows them.
+	// Clearing unconditionally bounds how long a record can survive an impact
+	// that never dealt damage — it cannot reach a later, unrelated shot.
+	g_pending.clear();
+}
+
+void EndImpactMitigation(ATgEffectManager* Manager) {
+	if (g_active.empty()) return;
+
+	for (ActiveSwap& s : g_active) {
+		if (!s.prop) continue;
+		s.prop->m_fRaw += s.delta;
+		if (Logger::IsChannelEnabled("ki")) {
+			Logger::Log("ki",
+				"[END] mgr=%p prop restored to %.3f (delta %.3f re-applied)\n",
+				(void*)Manager, s.prop->m_fRaw, s.delta);
+		}
+	}
+	g_active.clear();
+}
+
+}  // namespace HitSituationalMitigation

--- a/src/GameServer/TgGame/_effect_core/HitSituationalMitigation.hpp
+++ b/src/GameServer/TgGame/_effect_core/HitSituationalMitigation.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "src/pch.hpp"
+
+// HitSituationalMitigation — stops a type-505 "Hit-Situational" protection
+// debuff from mitigating the very shot that triggered it.
+//
+// THE DEFECT (Killer Instinct, skill 836 / eg 16596, prop 155 −10, gate
+// "target HP > 75%"). `TgDeviceFire.ApplyHit` submits the HP-gated situational
+// pass BEFORE the pass that carries the base damage:
+//
+//   ApplyHit:1409-1412   SubmitHitEffects(.., 0/1, 505, 1270/1271)   ← debuff lands
+//   ApplyHit:1445        SubmitHitEffects(.., 0,   264)              ← base damage
+//   ApplyHit:1495        SubmitHitEffects(.., 1,   264)
+//
+// `SubmitEffect → ProcessEffect → ApplyEffects → ApplyToProperty` is fully
+// synchronous, so by the time `TgEffectDamage.ProtectionModifier` reads prop
+// 155 the debuff is already in `m_fRaw`. Every other 505 dispatch in ApplyHit
+// (backstab 509 at 1480/1485, situational melee at 1491) sits AFTER the damage
+// submit — only the 1270/1271 block is ahead of it.
+//
+// Measured on a bare target (max HP 1300, Physical protection 30, Ballista OC,
+// raw 1600, attack rating 100): shot 1 dealt 1170 with Killer Instinct slotted
+// vs 1120 without. 1170 is NOT a mitigation figure — it is the anti-one-shot
+// health cap in `TgEffectDamage.ApplyEffect:174-200` (`Health − ceil(0.1 ×
+// maxHealth)` = 1300 − 130), which arms only at exactly full HP because
+// `ApplyHit:1287` compares two ints (`Health / r_nHealthMaximum > 90/100`).
+// The uncapped figure is 1600 × 0.80 = 1280, i.e. the FULL −10 reaches the
+// triggering shot. The cap also inflates the reported "mitigated" number,
+// since `SendDamageMessages` reports `pre − post` after the clamp.
+//
+// THE FIX. Everything in that chain is UnrealScript, so the apply order is not
+// ours to change. Instead the debuff applies exactly as it does today —
+// canonical gate, potency query, lifetime, HUD slot, Remove path all untouched
+// — and we lend the target its pre-debuff `m_fRaw` back for the duration of
+// this impact's mitigation only:
+//
+//   NoteDebuffApplied()   ← TgEffect::CheckEffectBuffModifier, on a 505/1270/1271
+//                           protection effect. Runs at TgEffect.uc:115, i.e.
+//                           BEFORE ApplyToProperty, so m_fRaw is still clean.
+//   BeginImpactMitigation() ← same hook, on a TgEffectDamage effect. Runs at
+//                           TgEffectDamage.uc:131, before ProtectionModifier.
+//                           Swaps the recorded pre-value back in.
+//   EndImpactMitigation()  ← TgEffectManager::RemoveEffectGroupsByCategory(431, 99).
+//                           Runs at TgEffectDamage.uc:206 — after mitigation and
+//                           the health cap, before TakeDamage. Puts the debuff back.
+//
+// The two brackets sit inside one UC function with no `return` between them,
+// and TgEffectDamage.uc:202 gates the closing call on the target being a pawn —
+// which is why we only ever arm for pawn targets. So the swap cannot leak past
+// the damage application that opened it.
+//
+// Not covered, deliberately: category-963 damage groups (they skip the opening
+// bracket at TgEffectDamage.uc:128) and DOT interval ticks after the first
+// (`m_bUseOnInterval` short-circuits the same branch). Neither is a triggering
+// shot, so both keep today's behaviour.
+namespace HitSituationalMitigation {
+
+// Record a type-505 Hit-Situational protection debuff about to be written to
+// the target, capturing the property's value before the write. No-op unless
+// the effect group is type 505 with situational 1270/1271, the property is one
+// `ProtectionModifier` consumes, and the target is a pawn.
+void NoteDebuffApplied(UTgEffect* effect);
+
+// Open the mitigation window for a TgEffectDamage effect: lend back the
+// pre-debuff value of anything this shot's own 505 pass just applied to the
+// same victim from the same instigator.
+void BeginImpactMitigation(UTgEffect* damageEffect);
+
+// Close the window and restore the debuff. Safe to call when no window is open.
+void EndImpactMitigation(ATgEffectManager* Manager);
+
+}  // namespace HitSituationalMitigation


### PR DESCRIPTION
Type-505 Hit-Situational effect groups are submitted in ApplyHit at lines 1409-1412, before the type-264 pass at 1445 that carries the base damage. The apply chain is synchronous, so by the time ProtectionModifier reads prop 155 the debuff is already in m_fRaw and the shot that triggered Killer Instinct is mitigated against the reduced value. Every other 505 dispatch in ApplyHit - backstab 509 at 1480/1485, situational melee at 1491 - sits after the damage submit; only the HP-gated block is ahead of it.

The earlier analysis had this as a PARTIAL leak, ~3.1 of the 10 points, because shot 1 measured 1170 dealt where a clean shot measured 1120 and a fully leaked one should have been 1280. No integer protection produces 1170, which sent the investigation looking for damage submitted in pieces.

There are no pieces. 1170 is not a mitigation figure at all - it is the anti-one-shot health cap in TgEffectDamage.uc:174-200, Health - ceil(0.1 x maxHealth), which on a bare 1300 HP target is exactly 1300 - 130. It arms only at precisely full health because ApplyHit:1287 divides two ints, so Health / r_nHealthMaximum > 90/100 reduces to "is the target at max". The rig specified full HP before shot 1 of every run, so it armed every time, and it also inflates the reported mitigation because SendDamageMessages reports pre - post after the clamp. The full -10 was reaching the shot all along.

The apply order is UnrealScript, so it is not ours to change. Instead the debuff applies exactly as it does today - gate, potency query, lifetime, HUD slot and Remove path all canonical - and the target is lent its pre-debuff m_fRaw back for the duration of that impact's mitigation only. Three calls on hooks we already own:

  NoteDebuffApplied      TgEffect::CheckEffectBuffModifier on a 505/1270/1271
                         protection effect. TgEffect.uc:115, before
                         ApplyToProperty writes it, so m_fRaw is still clean.
  BeginImpactMitigation  same hook on a TgEffectDamage effect.
                         TgEffectDamage.uc:131, before ProtectionModifier.
  EndImpactMitigation    TgEffectManager::RemoveEffectGroupsByCategory(431, 99).
                         TgEffectDamage.uc:206, after mitigation and the health
                         cap, before TakeDamage.

Both brackets sit inside one UC function with no return between them, and line 202 gates the closing call on a pawn target, which is why the guard only ever arms for pawn victims - the swap cannot outlive the damage application that opened it. It stores the delta rather than an absolute so anything else writing that property inside the window still composes.

Deliberately narrow: only the props ProtectionModifier can actually consume are eligible, and the guard never assumes -10 - it captures the pre-value and re-applies whatever delta it measured. Nothing is keyed on m_nSourceDeviceInstId, which is what scopes Eagle Eye's potency to weapon debuffs and must not be disturbed.

Verified on Scorpia OC (device 3249, a near-twin of the Ballista with the prop-155 debuff swapped for a prop-210 one, so Eagle Eye is inert and the shot-2 delta is Killer Instinct alone). All six rows land to the unit:

  Killer Instinct     shot 1  1075/461  protection 30   shots 2-3  1278/320  20
  no Killer Instinct  shot 1  1075/461  protection 30   shots 2-3  1119/479  30

Shot 1 is identical across builds, the -10 still lands in full on later shots, and Killer Instinct reads -10 rather than -13 with Eagle Eye slotted in both runs - the asymmetry the handoff flagged as intended survives. A Ballista run separately confirms the other half, its device debuff still amplified to -13.