### PR TITLE
Spectator team highlight

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,8 @@ SOURCE_FILES= \
 			  $(SRC_DIR)/GameServer/TgGame/TgPlayerActions/Coords/Coords.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/TgPlayerActions/FullHeal/FullHeal.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/TgPlayerActions/ToggleBrokenSuits/ToggleBrokenSuits.cpp \
+			  $(SRC_DIR)/GameServer/TgGame/TgPlayerActions/Markers/Markers.cpp \
+			  $(SRC_DIR)/GameServer/TgGame/TgPlayerActions/FxBrowse/FxBrowse.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/TgPawn/SwapAttachedDeviceMaterials/TgPawn__SwapAttachedDeviceMaterials.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/TgTeamBeaconManager/SpawnNewBeaconForTeam/TgTeamBeaconManager__SpawnNewBeaconForTeam.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/TgTeamBeaconManager/BeaconSdkSafe/BeaconSdkSafe.cpp \

--- a/src/ControlServer/ChatSession/ChatCommand.cpp
+++ b/src/ControlServer/ChatSession/ChatCommand.cpp
@@ -312,6 +312,75 @@ ParseResult TryParseChatCommand(const std::string& message_text) {
         return out;
     }
 
+    if (cmd_name == "-fx") {
+        // -fx            -> re-show / re-apply current entry
+        // -fx next|prev  -> step
+        // -fx <n>        -> jump to entry n (1-based)
+        // -fx pawn|own   -> switch delivery route
+        // -fx off        -> stop
+        out.recognized = true;
+        out.suppress_broadcast = true;
+        FxBrowseArgs args;
+        if (!rest.empty()) {
+            const std::string tok = LowerAscii(rest);
+            if (tok == "next" || tok == "n")      args.action = "next";
+            else if (tok == "prev" || tok == "p") args.action = "prev";
+            else if (tok == "off")                args.action = "off";
+            else if (tok == "pawn")               args.action = "pawn";
+            else if (tok == "own")                args.action = "own";
+            else {
+                std::optional<int> n = ParseInt(tok);
+                if (!n || *n < 1) return out;  // bad arg — silent reject
+                args.action = "jump";
+                args.index  = *n;
+            }
+        }
+        out.fx_browse = args;
+        return out;
+    }
+
+    if (cmd_name == "-markers") {
+        // -markers        -> toggle
+        // -markers on|1   -> enable
+        // -markers off|0  -> disable
+        out.recognized = true;
+        out.suppress_broadcast = true;
+        // -markers                       -> toggle (defaults: glow route, all)
+        // -markers off                   -> off
+        // -markers all|attackers|defenders -> pick who gets highlighted
+        // -markers glow|foreman          -> pick delivery route
+        // -markers <uu>                  -> foreman-route near-cull radius
+        MarkersArgs args;
+        if (!rest.empty()) {
+            const std::string tok = LowerAscii(rest);
+            if (tok == "off" || tok == "0")            args.mode = "off";
+            else if (tok == "on" || tok == "1" || tok == "all") args.mode = "all";
+            else if (tok == "attack" || tok == "attackers")     args.mode = "attackers";
+            else if (tok == "defense" || tok == "defence"
+                     || tok == "defenders")                     args.mode = "defenders";
+            // Relative to the spectator's own -spectate team assignment.
+            else if (tok == "friendly" || tok == "friends"
+                     || tok == "mine" || tok == "own")          args.mode = "friendly";
+            else if (tok == "enemy" || tok == "enemies"
+                     || tok == "them" || tok == "theirs")       args.mode = "enemy";
+            else if (tok == "glow")                    args.mode = "glow";
+            else if (tok == "foreman")                 args.mode = "foreman";
+            else {
+                try {
+                    const float uu = std::stof(tok);
+                    // Reject nonsense rather than let a typo cull the map.
+                    if (uu <= 0.0f || uu > 100000.0f) return out;
+                    args.mode = "distance";
+                    args.min_distance_uu = uu;
+                } catch (...) {
+                    return out;  // bad arg — silent reject
+                }
+            }
+        }
+        out.markers = args;
+        return out;
+    }
+
     if (cmd_name == "-topdown") {
         // -topdown            -> toggle, default lift
         // -topdown <lift_z>   -> toggle, explicit lift in world units (cm)
@@ -686,6 +755,43 @@ void DispatchToggleBrokenSuits(const ToggleBrokenSuitsArgs& args,
             "[ChatCmd] guid=%s command=%s mode=%d outcome=ignored details=dispatch_failed\n",
             session_guid.c_str(),
             args.all ? "-toggleallsuits" : "-togglebrokensuits", args.mode);
+    }
+}
+
+void DispatchFxBrowse(const FxBrowseArgs& args, const std::string& session_guid) {
+    if (session_guid.empty()) {
+        Logger::Log("chat-command", "[ChatCmd] DispatchFxBrowse dropped: empty session_guid\n");
+        return;
+    }
+    nlohmann::json payload;
+    payload["type"]         = IpcProtocol::MSG_PLAYER_ACTION;
+    payload["session_guid"] = session_guid;
+    payload["action"]       = "fx_browse";
+    payload["args"]         = { {"fx_action", args.action}, {"index", args.index} };
+    const bool sent = TcpSession::DeliverPlayerAction(session_guid, payload);
+    if (!sent) {
+        Logger::Log("chat-command",
+            "[ChatCmd] guid=%s command=-fx action=%s outcome=ignored details=dispatch_failed\n",
+            session_guid.c_str(), args.action.c_str());
+    }
+}
+
+void DispatchMarkers(const MarkersArgs& args, const std::string& session_guid) {
+    if (session_guid.empty()) {
+        Logger::Log("chat-command", "[ChatCmd] DispatchMarkers dropped: empty session_guid\n");
+        return;
+    }
+    nlohmann::json payload;
+    payload["type"]         = IpcProtocol::MSG_PLAYER_ACTION;
+    payload["session_guid"] = session_guid;
+    payload["action"]       = "markers";
+    payload["args"]         = { {"mode", args.mode},
+                                {"min_distance_uu", args.min_distance_uu} };
+    const bool sent = TcpSession::DeliverPlayerAction(session_guid, payload);
+    if (!sent) {
+        Logger::Log("chat-command",
+            "[ChatCmd] guid=%s command=-markers mode=%s nearcull=%.0f outcome=ignored details=dispatch_failed\n",
+            session_guid.c_str(), args.mode.c_str(), args.min_distance_uu);
     }
 }
 

--- a/src/ControlServer/ChatSession/ChatCommand.hpp
+++ b/src/ControlServer/ChatSession/ChatCommand.hpp
@@ -106,6 +106,38 @@ struct SetDlcArgs {
     bool installed = false;
 };
 
+// -markers [off|all|attackers|defenders|friendly|enemy|glow|foreman|<uu>]:
+// SPECTATOR-ONLY team highlight, visible only to the spectator who has it on.
+// Auto-enabled on spectator join, so live use needs no command at all. Purely
+// visual — the DLL pushes effect group 1469 (FX 131, a silent material swap)
+// through SetEffectRep on its own owner-only effect managers. See Markers.hpp.
+struct MarkersArgs {
+    // "toggle" (default), "off", "all", "attackers", "defenders",
+    // "friendly", "enemy", "glow", "foreman", or "distance". String rather
+    // than an enum because it rides the JSON args blob straight through to
+    // the DLL.
+    //
+    // "friendly"/"enemy" are resolved DLL-side against the spectator's own
+    // PRI.r_TaskForce — the cosmetic team seeded by `-spectate <id> <team>` —
+    // so they follow how the caller joined. A teamless spectator has no
+    // r_TaskForce and both degrade to "all".
+    std::string mode = "toggle";
+    // `-markers <uu>`: near-cull radius in UE3 world units. Pawns closer than
+    // this to the spectator's view point are not marked, because at close
+    // range the world-scaled FX fills the screen. 0 = leave unchanged / use
+    // the DLL default. Applied live on an already-enabled session.
+    float min_distance_uu = 0.0f;
+};
+
+// -fx [next|prev|<n>|off|pawn|own]: step through candidate special-FX on the
+// pawn the caller is currently viewing, so a marker look can be picked by eye.
+// Dev/preview tooling — see FxBrowse.hpp.
+struct FxBrowseArgs {
+    // "show" (default), "next", "prev", "jump", "off", "pawn", "own".
+    std::string action = "show";
+    int index = 0;  // only meaningful for action == "jump"
+};
+
 struct ParseResult {
     // True if the message was a /-prefixed slash command attempt that we own
     // (currently: "-changeteam", "-spawnfriend", "-spawnenemy", "-possess",
@@ -128,6 +160,8 @@ struct ParseResult {
     std::optional<ToggleBrokenSuitsArgs> toggle_broken_suits;
     std::optional<ToggleSoloModeArgs>    toggle_solo_mode;
     std::optional<SetDlcArgs>            set_dlc;
+    std::optional<MarkersArgs>      markers;
+    std::optional<FxBrowseArgs>     fx_browse;
 
     // No-arg toggles. Flag is set when recognized + parsed cleanly.
     bool possess   = false;
@@ -224,6 +258,13 @@ void ExecuteClassCounts(const std::string& session_guid);
 // Send -topdown to the game DLL. Toggles top-down view in the DLL — repeated
 // invocations alternate enter/restore. lift_z=0 means "use the DLL default".
 void DispatchTopDown(const TopDownArgs& args, const std::string& session_guid);
+
+// Send -markers to the game DLL. The DLL owns the enable set and the refresh
+// timer; repeated bare invocations alternate on/off.
+void DispatchMarkers(const MarkersArgs& args, const std::string& session_guid);
+
+// Send -fx to the game DLL. The DLL owns the candidate table and the cursor.
+void DispatchFxBrowse(const FxBrowseArgs& args, const std::string& session_guid);
 
 // Send -togglebrokensuits to the game DLL. The DLL owns the preference
 // (ga_user_preferences read/write + in-memory cache used at replication).

--- a/src/ControlServer/ChatSession/ChatSession.cpp
+++ b/src/ControlServer/ChatSession/ChatSession.cpp
@@ -314,6 +314,8 @@ bool HasParsedCommandAction(const ChatCommand::ParseResult& parsed) {
         || parsed.spawn_target.has_value()
         || parsed.deploy_target.has_value()
         || parsed.topdown.has_value()
+        || parsed.markers.has_value()
+        || parsed.fx_browse.has_value()
         || parsed.spectate.has_value()
         || parsed.toggle_broken_suits.has_value()
         || parsed.toggle_solo_mode.has_value()
@@ -575,6 +577,12 @@ void ChatSession::handle_packet(const uint8_t* data, size_t length) {
         }
         if (parsed.recognized && parsed.topdown) {
             ChatCommand::DispatchTopDown(*parsed.topdown, session_guid_);
+        }
+        if (parsed.recognized && parsed.markers) {
+            ChatCommand::DispatchMarkers(*parsed.markers, session_guid_);
+        }
+        if (parsed.recognized && parsed.fx_browse) {
+            ChatCommand::DispatchFxBrowse(*parsed.fx_browse, session_guid_);
         }
         if (parsed.recognized && parsed.spectate) {
             HandleSpectateCommand(parsed.spectate->instance_id, parsed.spectate->team);

--- a/src/GameServer/Engine/Actor/GetOptimizedRepList/Actor__GetOptimizedRepListV2.cpp
+++ b/src/GameServer/Engine/Actor/GetOptimizedRepList/Actor__GetOptimizedRepListV2.cpp
@@ -2,6 +2,7 @@
 #include "src/Utils/Macros.hpp"
 #include "src/Utils/Logger/Logger.hpp"
 #include "src/GameServer/Utils/ClassPreloader/ClassPreloader.hpp"
+#include "src/GameServer/TgGame/TgPlayerActions/Markers/Markers.hpp"
 #include <cstdint>
 #include <unordered_map>
 
@@ -2521,7 +2522,27 @@ static void ResolveRepListProperties() {
 
 
 int* __fastcall Actor__GetOptimizedRepList::Call(void* thisxx, void* edx_dummy, int param_1, void* param_2, int* param_3, int* param_4, int param_5) {
+	// -markers glow route: send AActor::Owner as NULL for the effect managers
+	// we spawn, and ONLY those. The client's effect-form updater resolves its
+	// target as `Owner ?: r_Owner` (FUN_10a70a70 reads +0x98 then +0x480), so a
+	// replicated Owner makes it paint the PlayerController — which has no mesh —
+	// instead of falling through to r_Owner. We still need the real Owner on the
+	// server for bOnlyRelevantToOwner / bNetOwner, hence null-around-the-call
+	// rather than clearing the field outright. Relevancy is decided before
+	// ReplicateActor, so it is unaffected. See Markers.hpp.
+	AActor* markerMgr = nullptr;
+	AActor* savedOwner = nullptr;
+	if (TgPlayerActions::MarkersCmd::IsMarkerEffectManager(thisxx)) {
+		markerMgr = (AActor*)thisxx;
+		savedOwner = markerMgr->Owner;
+		markerMgr->Owner = nullptr;
+	}
+
 	param_3 = CallOriginal(thisxx, edx_dummy, param_1, param_2, param_3, param_4, param_5);
+
+	if (markerMgr) {
+		markerMgr->Owner = savedOwner;
+	}
 	if (!bRepListCached) {
 		bRepListCached = true;
 		ResolveRepListProperties();

--- a/src/GameServer/Engine/GameEngine/Tick/GameEngine__Tick.cpp
+++ b/src/GameServer/Engine/GameEngine/Tick/GameEngine__Tick.cpp
@@ -8,6 +8,8 @@
 #include "src/GameServer/TgGame/MissionVODirector/MissionVODirector.hpp"
 #include "src/GameServer/Cosmetics/SuitRebuildKick.hpp"
 #include "src/GameServer/TgGame/TgDeviceVolume/setupDevice/TgDeviceVolume__setupDevice.hpp"
+#include "src/GameServer/TgGame/TgPlayerActions/Markers/Markers.hpp"
+#include "src/GameServer/TgGame/TgPlayerActions/FxBrowse/FxBrowse.hpp"
 
 void __fastcall GameEngine__Tick::Call(void* Engine, void* edx, float DeltaSeconds) {
 	IpcClient::DrainInbound();
@@ -36,5 +38,10 @@ void __fastcall GameEngine__Tick::Call(void* Engine, void* edx, float DeltaSecon
 	// One-shot: verify (and if needed redo) the VR heal pad's PostBeginPlay
 	// arming ~5s after setupDevice registered it. No-op on other maps.
 	DomeVrHealPad::TickArmCheck();
+	// -markers highlight refresh. Returns immediately unless some session has
+	// markers enabled; otherwise self-throttles to ~0.45Hz.
+	TgPlayerActions::MarkersCmd::Tick();
+	// -fx browser refresh; no-op unless someone is stepping through candidates.
+	TgPlayerActions::FxBrowseCmd::Tick();
 	CallOriginal(Engine, edx, DeltaSeconds);
 }

--- a/src/GameServer/IpDrv/NetConnection/Cleanup/NetConnection__Cleanup.cpp
+++ b/src/GameServer/IpDrv/NetConnection/Cleanup/NetConnection__Cleanup.cpp
@@ -11,6 +11,8 @@
 #include "src/GameServer/Storage/ActiveSpectatorCount/ActiveSpectatorCount.hpp"
 #include "src/GameServer/Stats/MatchStats.hpp"
 #include "src/GameServer/Stats/SpectatorOverlayFeed/SpectatorOverlayFeed.hpp"
+#include "src/GameServer/TgGame/TgPlayerActions/Markers/Markers.hpp"
+#include "src/GameServer/TgGame/TgPlayerActions/FxBrowse/FxBrowse.hpp"
 #include "src/GameServer/TgGame/TgPawn/KillDeployables/TgPawn__KillDeployables.hpp"
 #include "src/Utils/Logger/Logger.hpp"
 
@@ -101,6 +103,13 @@ void __fastcall NetConnection__Cleanup::Call(UNetConnection* Connection) {
 		// entry now rather than leaving it to accumulate for the life of the
 		// process (see SpectatorOverlayFeed.cpp's g_lastPushMs comment).
 		SpectatorOverlayFeed::ForgetPawn((int)pawn->r_nPawnId);
+	}
+
+	// Same reasoning again: a session that leaves with -markers still on would
+	// otherwise keep the per-frame sweep armed for the life of the instance.
+	if (!session_guid.empty()) {
+		TgPlayerActions::MarkersCmd::ForgetSession(session_guid);
+		TgPlayerActions::FxBrowseCmd::ForgetSession(session_guid);
 	}
 
 	// Matches the increment in the TgGamePostLogin ProcessEvent case. Clamped

--- a/src/GameServer/TgGame/TgPlayerActions/FxBrowse/FxBrowse.cpp
+++ b/src/GameServer/TgGame/TgPlayerActions/FxBrowse/FxBrowse.cpp
@@ -1,0 +1,417 @@
+#include "src/GameServer/TgGame/TgPlayerActions/FxBrowse/FxBrowse.hpp"
+
+#include <map>
+#include <string>
+
+#include "src/GameServer/Combat/MissionAlerts/SendAlert.hpp"
+#include "src/GameServer/Globals.hpp"
+#include "src/GameServer/Storage/ClientConnectionsData/ClientConnectionsData.hpp"
+#include "src/GameServer/TgGame/TgEffectManager/SetEffectRep/TgEffectManager__SetEffectRep.hpp"
+#include "src/GameServer/Utils/ClassPreloader/ClassPreloader.hpp"
+#include "src/GameServer/TgGame/TgPlayerActions/Markers/Markers.hpp"
+#include "src/GameServer/Utils/ObjectClassCache/ObjectClassCache.hpp"
+#include "src/IpcClient/IpcClient.hpp"
+#include "src/Utils/Logger/Logger.hpp"
+
+namespace TgPlayerActions::FxBrowseCmd {
+
+namespace {
+
+struct Candidate {
+    int         egId;
+    int         fxId;
+    float       lifetime;
+    const char* name;
+};
+
+// Generated from gaa.db: effect groups whose target_fx_id has zero rows in
+// asm_data_set_special_fx_sounds (silent) and non-zero particles or materials.
+// Longest lifetime first — a longer-lived effect needs fewer re-pushes, and
+// each re-push replays the intro animation.
+const Candidate kCandidates[] = {
+    { 25353, 1543, 600.0f, "P_Sword_DamageBuff" },
+    {  3007,  455, 120.0f, "NanoSwarmDebuff_OrangeA" },
+    {  3385,  125,  60.0f, "DOTGasGreenA00" },
+    {  3236,  254,  60.0f, "NanoSwarmDOTA" },
+    {  2712,  328,  60.0f, "NanoSwarmHealA" },
+    {  2005,  126,  60.0f, "MeleeStunA_Orange" },
+    { 25830, 1616,  50.0f, "CubeBuffA" },
+    {  7282,  643,  40.0f, "Player_Contagious_boundary" },
+    {  3502,  320,  30.0f, "BioBodyLoop" },
+    { 27646, 1770,  30.0f, "ChloeBuff" },
+    {  1185,   81,  30.0f, "ElecHold_CWhite00" },
+    {  1469,  131,  30.0f, "(materials only)" },
+    {  2198,  116,  20.0f, "NanoSwarmHealA (short)" },
+    {  8861,  860,  20.0f, "ElecDOT" },
+    {  7063,  656,  18.0f, "NanoSwarmDebuff_OrangeA (b)" },
+    {  3472,  331,  15.0f, "NanoSwarmSLOWA" },
+    {  3897,  456,  15.0f, "NanoSwarmSLOWGOLD" },
+    {  7756,  682,  15.0f, "GraphicHOTA" },
+    {  1481,   79,  12.0f, "ElecHold" },
+    {  1480,  128,  12.0f, "MeleeHoldA_Orange" },
+    {  5853,  741,  12.0f, "OnFireA_torso" },
+    { 10021,  448,  10.0f, "GraphicBuffMixA" },
+    {  4525,  450,  10.0f, "GraphicBuffShieldA" },
+    {  3814,  459,  10.0f, "GraphicHOTA (b)" },
+    {  3996,  482,  10.0f, "GraphicRepairA00" },
+    {  8769,  680,  10.0f, "NanoSwarmSLOWGOLD (b)" },
+    {  5098,  918,  10.0f, "PurpleBolts" },
+    { 16625, 1295,  10.0f, "Agony_DEBUFF" },
+    {  7351, 1505,  10.0f, "Poisoned" },
+    { 26009, 1628,  10.0f, "GraphicBuff_Green" },
+    {  4188,  434,   8.0f, "GraphicRedHitA" },
+    {  5864,  552,   8.0f, "TurretStun_01" },
+    { 27755, 1823,   8.0f, "Bolonov_Stun" },
+    { 16932, 1289,   7.0f, "EnergySapInit" },
+    {  7379,  522,   6.0f, "CyberBodyLoopA" },
+    {  4836,  489,   6.0f, "Crit" },
+    { 22323, 1567,   5.0f, "Commander_MoralBoost_Buff" },
+    { 13004, 1233,   5.0f, "Poisoned (b)" },
+    {  7724,  828,   3.0f, "GraphicBuffPurpleA" },
+    {  8698,  847,   3.0f, "MixColorFractal (team-coloured, materials only)" },
+    { 13708, 1165,   0.0f, "(materials only) 1165" },
+    { 13709, 1166,   0.0f, "(materials only) 1166" },
+};
+constexpr int kCandidateCount = (int)(sizeof(kCandidates) / sizeof(kCandidates[0]));
+
+// Re-push a little before the entry's own lifetime lapses. Entries with
+// lifetime 0 are one-shot, so fall back to a steady low rate.
+constexpr DWORD kZeroLifetimeStepMs = 2000;
+constexpr DWORD kMinStepMs          = 500;
+
+enum class DeliveryMode { Pawn, Own };
+
+// The first push into a freshly-spawned manager is always lost: the client's
+// initial-replication handler does `c_nLastQueueIndex = r_nNextQueueIndex - 1`,
+// marking the entry we just wrote as consumed. Re-push shortly after so the
+// selected entry actually appears instead of waiting for the next step.
+constexpr DWORD kRepushMs   = 1200;
+constexpr int   kRepushCount = 2;
+
+struct Session {
+    APlayerController* pc      = nullptr;
+    int                index   = 0;
+    DeliveryMode       mode    = DeliveryMode::Pawn;
+    ATgEffectManager*  ownMgr  = nullptr;   // Own mode only
+    ATgPawn*           lastTarget = nullptr;
+    DWORD              lastPushMs = 0;
+    int                repushesLeft = 0;
+};
+
+std::map<std::string, Session> g_active;
+
+UNetConnection* ConnectionForSession(const std::string& guid) {
+    for (auto& kv : GClientConnectionsData) {
+        if (kv.second.SessionGuid == guid && !kv.second.bClosed) {
+            return (UNetConnection*)(uintptr_t)(uint32_t)kv.first;
+        }
+    }
+    return nullptr;
+}
+
+// HARD GATE — spectator-only, same reasoning as MarkersCmd::IsSpectatorSession.
+// -fx paints arbitrary effects on other players' pawns; a live player must
+// never be able to reach it.
+bool IsSpectatorSession(const std::string& guid) {
+    for (auto& kv : GClientConnectionsData) {
+        if (kv.second.SessionGuid == guid && !kv.second.bClosed) {
+            return kv.second.PlayerInfo.is_spectator;
+        }
+    }
+    return false;
+}
+
+APlayerController* FindControllerForSession(const std::string& guid) {
+    UNetConnection* conn = ConnectionForSession(guid);
+    if (!conn) return nullptr;
+    AActor* game = (AActor*)Globals::Get().GGameInfo;
+    AWorldInfo* wi = game ? game->WorldInfo : nullptr;
+    if (!wi) return nullptr;
+    for (AController* c = wi->ControllerList; c; c = c->NextController) {
+        if (!ObjectClassCache::ClassNameContains(c, "PlayerController")) continue;
+        APlayerController* pc = (APlayerController*)c;
+        if ((void*)pc->Player == (void*)conn) return pc;
+    }
+    return nullptr;
+}
+
+bool IsMarkablePawn(ATgPawn_Character* pawn) {
+    if (!pawn || pawn->bDeleteMe) return false;
+    if (pawn->Health <= 0) return false;
+    // Real players only. bIsPlayer is unreliable on this build (AI bots
+    // default it true), so test the controller class instead.
+    return pawn->Controller &&
+           ObjectClassCache::ClassNameContains(pawn->Controller, "PlayerController");
+}
+
+// Nearest live player pawn to `from`. Used when the spectator camera is in
+// free-look rather than attached to a player.
+ATgPawn* NearestPlayerPawn(const FVector& from) {
+    ATgPawn* best = nullptr;
+    float bestSq = 0.0f;
+    for (auto& kv : GClientConnectionsData) {
+        if (kv.second.bClosed) continue;
+        ATgPawn_Character* pawn = kv.second.Pawn;
+        if (!IsMarkablePawn(pawn)) continue;
+        const float dx = pawn->Location.X - from.X;
+        const float dy = pawn->Location.Y - from.Y;
+        const float dz = pawn->Location.Z - from.Z;
+        const float d2 = dx * dx + dy * dy + dz * dz;
+        if (!best || d2 < bestSq) { best = (ATgPawn*)pawn; bestSq = d2; }
+    }
+    return best;
+}
+
+// The pawn to paint. Following a player as a spectator sets ViewTarget to that
+// pawn, which is what we want — but a free-look spectator camera leaves
+// ViewTarget pointing at the controller itself, which is not a pawn. Rather
+// than refuse to do anything (which just looks like the command is broken),
+// fall back to the nearest live player.
+ATgPawn* CurrentTarget(APlayerController* pc) {
+    AActor* vt = pc->ViewTarget;
+    if (vt && !vt->bDeleteMe && ObjectClassCache::ClassNameContains(vt, "TgPawn")) {
+        return (ATgPawn*)vt;
+    }
+    return NearestPlayerPawn(((AActor*)pc)->Location);
+}
+
+void Reply(const std::string& guid, const std::wstring& text) {
+    UNetConnection* conn = ConnectionForSession(guid);
+    if (!conn) return;
+    // priority 1 Normal, type 0 Regular. SendText renders as a private chat
+    // line rather than a toast, which is what we want for a readable label.
+    SendAlert::SendText(conn, text.c_str(), 1, 0, 5.0f);
+}
+
+std::wstring Widen(const char* s) {
+    std::wstring out;
+    for (const char* p = s; p && *p; ++p) out.push_back((wchar_t)(unsigned char)*p);
+    return out;
+}
+
+std::wstring DescribeEntry(const Session& s) {
+    const Candidate& c = kCandidates[s.index];
+    std::wstring w = L"[fx " + std::to_wstring(s.index + 1) + L"/"
+                   + std::to_wstring(kCandidateCount) + L"] fx=" + std::to_wstring(c.fxId)
+                   + L" eg=" + std::to_wstring(c.egId)
+                   + L" life=" + std::to_wstring((int)c.lifetime) + L"s "
+                   + Widen(c.name)
+                   + (s.mode == DeliveryMode::Own ? L"  [own]" : L"  [pawn]");
+    return w;
+}
+
+// Spawn the per-session effect manager used by DeliveryMode::Own.
+ATgEffectManager* SpawnOwnManager(APlayerController* pc) {
+    UClass* cls = ClassPreloader::GetClass("Class TgGame.TgEffectManager");
+    if (!cls) {
+        Logger::Log("markers", "[FxBrowse] TgEffectManager class not resolved\n");
+        return nullptr;
+    }
+    FRotator rot; rot.Pitch = 0; rot.Yaw = 0; rot.Roll = 0;
+    ATgEffectManager* m = (ATgEffectManager*)((AActor*)pc)->Spawn(
+        cls, (AActor*)pc, FName(), ((AActor*)pc)->Location, rot, nullptr, 1);
+    if (!m) {
+        Logger::Log("markers", "[FxBrowse] effect manager Spawn returned null\n");
+        return nullptr;
+    }
+    ((AActor*)m)->Owner                = (AActor*)pc;
+    ((AActor*)m)->bOnlyRelevantToOwner = 1;
+    ((AActor*)m)->bAlwaysRelevant      = 0;
+    ((AActor*)m)->bHidden              = 1;
+    ((AActor*)m)->bCollideActors       = 0;
+    ((AActor*)m)->bCollideWorld        = 0;
+    // Suppress Owner on the wire so the client falls through to r_Owner —
+    // see MarkersCmd::IsMarkerEffectManager for the full reasoning.
+    MarkersCmd::RegisterMarkerEffectManager((const void*)m);
+    return m;
+}
+
+void Push(const std::string& guid, Session& s, ATgPawn* target) {
+    const Candidate& c = kCandidates[s.index];
+
+    ATgEffectManager* mgr = nullptr;
+    if (s.mode == DeliveryMode::Own) {
+        if (!s.ownMgr || ((AActor*)s.ownMgr)->bDeleteMe) s.ownMgr = SpawnOwnManager(s.pc);
+        if (!s.ownMgr) return;
+        // Point our manager at the pawn we want painted. This is the whole
+        // experiment: if the client's UpdateEffectForms honours r_Owner, the
+        // FX lands on that pawn and only this session ever sees it.
+        s.ownMgr->r_Owner = (AActor*)target;
+        ((AActor*)s.ownMgr)->bNetDirty       = 1;
+        ((AActor*)s.ownMgr)->bForceNetUpdate = 1;
+        mgr = s.ownMgr;
+    } else {
+        mgr = target->r_EffectManager;
+    }
+    if (!mgr) return;
+
+    const int ret = TgEffectManager__SetEffectRep::Call(
+        mgr, nullptr, c.egId, c.lifetime, /*bIsBuff=*/0, /*nHealthChange=*/0);
+
+    Logger::Log("markers",
+        "[FxBrowse] guid=%s mode=%s idx=%d eg=%d fx=%d life=%.1f target=%s -> %s(%d)\n",
+        guid.c_str(), s.mode == DeliveryMode::Own ? "own" : "pawn",
+        s.index, c.egId, c.fxId, c.lifetime,
+        ((UObject*)target)->GetName(), (ret == -1) ? "A:queue" : "B:managed", ret);
+}
+
+// Clear the currently-selected entry from whichever manager is delivering it,
+// so switching entries (or turning the browser off) takes effect immediately
+// rather than waiting out the effect's lifetime.
+void ClearCurrent(Session& s, ATgPawn* target) {
+    const int egId = kCandidates[s.index].egId;
+    ATgEffectManager* mgr = nullptr;
+    if (s.mode == DeliveryMode::Own) {
+        mgr = s.ownMgr;
+    } else if (target) {
+        mgr = target->r_EffectManager;
+    }
+    if (!mgr || ((AActor*)mgr)->bDeleteMe) return;
+    mgr->ClearEffectRep(egId, -1);
+    ((AActor*)mgr)->bNetDirty       = 1;
+    ((AActor*)mgr)->bForceNetUpdate = 1;
+}
+
+DWORD StepFor(const Session& s) {
+    const float life = kCandidates[s.index].lifetime;
+    if (life <= 0.0f) return kZeroLifetimeStepMs;
+    // Re-push at ~80% of lifetime so the look never lapses mid-inspection.
+    DWORD step = (DWORD)(life * 800.0f);
+    if (step < kMinStepMs) step = kMinStepMs;
+    return step;
+}
+
+void DestroyOwnMgr(Session& s) {
+    if (!s.ownMgr) return;
+    // Clear the applied effect before tearing the manager down — destroying it
+    // alone leaves the effect stuck on the pawn until its lifetime expires.
+    if (!((AActor*)s.ownMgr)->bDeleteMe) {
+        s.ownMgr->ClearEffectRep(kCandidates[s.index].egId, -1);
+        ((AActor*)s.ownMgr)->bNetDirty       = 1;
+        ((AActor*)s.ownMgr)->bForceNetUpdate = 1;
+    }
+    MarkersCmd::UnregisterMarkerEffectManager((const void*)s.ownMgr);
+    if (!((AActor*)s.ownMgr)->bDeleteMe) ((AActor*)s.ownMgr)->Destroy();
+    s.ownMgr = nullptr;
+}
+
+} // namespace
+
+void Execute(const std::string& session_guid, Action action, int index) {
+    // Spectator-only, no exceptions — see IsSpectatorSession.
+    if (!IsSpectatorSession(session_guid)) {
+        Logger::Log("markers",
+            "[FxBrowse] guid=%s: rejected, session is not a spectator\n",
+            session_guid.c_str());
+        IpcClient::SendChatCommandAudit(session_guid, "-fx", "ignored", "not a spectator");
+        return;
+    }
+
+    if (action == Action::Off) {
+        auto it = g_active.find(session_guid);
+        if (it == g_active.end()) return;
+        // Clear on the pawn route too — DestroyOwnMgr only covers "own".
+        if (it->second.mode == DeliveryMode::Pawn && it->second.pc) {
+            ClearCurrent(it->second, CurrentTarget(it->second.pc));
+        }
+        DestroyOwnMgr(it->second);
+        g_active.erase(it);
+        Reply(session_guid, L"[fx] browser off");
+        IpcClient::SendChatCommandAudit(session_guid, "-fx", "restored", "browser off");
+        return;
+    }
+
+    APlayerController* pc = FindControllerForSession(session_guid);
+    if (!pc) {
+        Logger::Log("markers", "[FxBrowse] guid=%s: no PlayerController\n", session_guid.c_str());
+        IpcClient::SendChatCommandAudit(session_guid, "-fx", "ignored", "no player controller");
+        return;
+    }
+
+    Session& s = g_active[session_guid];
+    s.pc = pc;
+
+    switch (action) {
+        // Clear the outgoing entry before switching, so stepping doesn't stack
+        // the previous look on top of the next one.
+        case Action::Next:
+            ClearCurrent(s, CurrentTarget(pc));
+            s.index = (s.index + 1) % kCandidateCount;
+            break;
+        case Action::Prev:
+            ClearCurrent(s, CurrentTarget(pc));
+            s.index = (s.index + kCandidateCount - 1) % kCandidateCount;
+            break;
+        case Action::Jump:
+            if (index < 1 || index > kCandidateCount) {
+                Reply(session_guid, L"[fx] index out of range 1-"
+                                    + std::to_wstring(kCandidateCount));
+                return;
+            }
+            s.index = index - 1;
+            break;
+        case Action::ModePawn:
+            s.mode = DeliveryMode::Pawn;
+            DestroyOwnMgr(s);
+            break;
+        case Action::ModeOwn:
+            s.mode = DeliveryMode::Own;
+            break;
+        default: break;  // Show
+    }
+
+    ATgPawn* target = CurrentTarget(pc);
+    if (!target) {
+        Reply(session_guid, L"[fx] no live player pawn in this instance");
+        return;
+    }
+
+    s.lastTarget = target;
+    s.lastPushMs = GetTickCount();
+    s.repushesLeft = kRepushCount;
+    Push(session_guid, s, target);
+    // Name the pawn in the reply — with the free-look fallback you can't
+    // otherwise tell which player is being painted.
+    Reply(session_guid, DescribeEntry(s) + L" -> " + Widen(((UObject*)target)->GetName()));
+    IpcClient::SendChatCommandAudit(session_guid, "-fx", "activated",
+        "idx=" + std::to_string(s.index + 1));
+}
+
+void Tick() {
+    if (g_active.empty()) return;
+    const DWORD now = GetTickCount();
+
+    for (auto it = g_active.begin(); it != g_active.end(); ) {
+        Session& s = it->second;
+        if (!s.pc || ((AActor*)s.pc)->bDeleteMe) {
+            DestroyOwnMgr(s);
+            it = g_active.erase(it);
+            continue;
+        }
+
+        ATgPawn* target = CurrentTarget(s.pc);
+        if (target) {
+            // Re-push immediately when the spectator switches who they follow,
+            // so the look moves with the camera instead of waiting a step.
+            const bool switched = (target != s.lastTarget);
+            const DWORD interval = (s.repushesLeft > 0) ? kRepushMs : StepFor(s);
+            if (switched || now - s.lastPushMs >= interval) {
+                if (switched) s.repushesLeft = kRepushCount;
+                else if (s.repushesLeft > 0) --s.repushesLeft;
+                s.lastTarget = target;
+                s.lastPushMs = now;
+                Push(it->first, s, target);
+            }
+        }
+        ++it;
+    }
+}
+
+void ForgetSession(const std::string& session_guid) {
+    auto it = g_active.find(session_guid);
+    if (it == g_active.end()) return;
+    DestroyOwnMgr(it->second);
+    g_active.erase(it);
+}
+
+} // namespace TgPlayerActions::FxBrowseCmd

--- a/src/GameServer/TgGame/TgPlayerActions/FxBrowse/FxBrowse.hpp
+++ b/src/GameServer/TgGame/TgPlayerActions/FxBrowse/FxBrowse.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <string>
+
+namespace TgPlayerActions::FxBrowseCmd {
+
+// -fx: step through candidate special-FX so a suitable marker look can be
+// picked by eye. The FX assets live in the client's packages and cannot be
+// previewed any other way.
+//
+// WHAT IS ON THE MENU
+// -------------------
+// asm_data_set_effect_groups.target_fx_id reaches 428 distinct FX, of which
+// 254 have NO row in asm_data_set_special_fx_sounds (i.e. are silent) and do
+// have particles and/or materials. The table in the .cpp is a curated subset,
+// filtered to the ones plausibly usable as a persistent player marker:
+// long-lifetime auras, body loops, and the material-swap (team-coloured)
+// entries. Sorted longest-lifetime first, because lifetime is what determines
+// how often the effect must be re-pushed — and every re-push replays the
+// effect's intro animation, which is the visible "pulse" on the current
+// scanbot marker.
+//
+// DELIVERY MODE — THIS IS ALSO A TEST
+// -----------------------------------
+// Two routes, selectable at runtime so we can find out which works without a
+// rebuild:
+//
+//   -fx pawn   Push SetEffectRep on the TARGET's own r_EffectManager. Known
+//              to be the route the game itself uses, but the manager belongs
+//              to the target pawn, so the FX is broadcast to everyone the
+//              pawn is relevant to. Fine for browsing on a quiet instance.
+//
+//   -fx own    Push on a TgEffectManager WE spawn, with r_Owner = the target
+//              pawn but network Owner = the browsing session's
+//              PlayerController and bOnlyRelevantToOwner = 1. If the client's
+//              native UpdateEffectForms resolves the form's owner from the
+//              manager's r_Owner (TgEffectManager.uc:61 + TgEffectForm.c_Owner
+//              suggest it does), this yields ARBITRARY FX, PER VIEWER — which
+//              would supersede the scanbot/foreman route entirely: any of the
+//              254 silent FX, seen only by the spectator, with none of the
+//              1163 beep.
+//
+// UNPROVEN: the "own" route depends on native behaviour I could not confirm
+// by static reading. If nothing renders in that mode, the route is dead and
+// browsing should continue in "pawn" mode. The `markers` log channel records
+// which mode each push used.
+
+enum class Action {
+    Show,     // no arg — report current entry
+    Next,
+    Prev,
+    Jump,     // index in arg
+    Off,
+    ModePawn,
+    ModeOwn,
+};
+
+// index is only read for Action::Jump.
+void Execute(const std::string& session_guid, Action action, int index);
+
+// Per-frame refresh (GameEngine__Tick). No-op unless a session is browsing.
+void Tick();
+
+void ForgetSession(const std::string& session_guid);
+
+} // namespace TgPlayerActions::FxBrowseCmd

--- a/src/GameServer/TgGame/TgPlayerActions/Markers/Markers.cpp
+++ b/src/GameServer/TgGame/TgPlayerActions/Markers/Markers.cpp
@@ -1,0 +1,664 @@
+#include "src/GameServer/TgGame/TgPlayerActions/Markers/Markers.hpp"
+
+#include <map>
+#include <set>
+#include <vector>
+
+#include "src/GameServer/Globals.hpp"
+#include "src/GameServer/Storage/ClientConnectionsData/ClientConnectionsData.hpp"
+#include "src/GameServer/Storage/TeamsData/TeamsData.hpp"
+#include "src/GameServer/TgGame/TgEffectManager/SetEffectRep/TgEffectManager__SetEffectRep.hpp"
+#include "src/GameServer/Utils/ClassPreloader/ClassPreloader.hpp"
+#include "src/GameServer/Utils/ObjectClassCache/ObjectClassCache.hpp"
+#include "src/IpcClient/IpcClient.hpp"
+#include "src/Utils/Logger/Logger.hpp"
+
+namespace TgPlayerActions::MarkersCmd {
+
+namespace {
+
+// ── glow route ──────────────────────────────────────────────────────────────
+// Re-push at ~80% of the 30s lifetime so the skin swap never lapses.
+constexpr DWORD kGlowRefreshMs = 24000;
+
+// The FIRST push into a freshly-spawned manager is always lost. Client-side,
+// the initial replication fires ReplicatedEvent('r_bRelevancyNotify'), whose
+// handler does `c_nLastQueueIndex = r_nNextQueueIndex - 1` — marking the entry
+// we just wrote as already consumed. Only a LATER push, which bumps the index
+// again and fires ReplicatedEvent('r_nNextQueueIndex'), renders.
+//
+// So a new manager gets a short warm-up cadence until it has landed a few
+// pushes, then settles to kGlowRefreshMs. Without this the marker takes a full
+// refresh interval to appear.
+constexpr DWORD kWarmupRefreshMs = 1500;
+constexpr int   kWarmupPushes    = 3;
+
+// Destroying a manager does NOT remove an already-applied skin swap — the
+// effect form lives on the target pawn, not on the manager. So teardown is two
+// phase: push ClearEffectRep and leave the manager alive long enough for that
+// to replicate, then destroy it on a later tick.
+constexpr DWORD kClearLingerMs = 1000;
+
+// How often to look for spectators who should have markers but don't. Cheap:
+// a walk of GClientConnectionsData.
+constexpr DWORD kAutoScanMs = 3000;
+
+// ── foreman route ───────────────────────────────────────────────────────────
+// FX 1163's own timer is 7s (TgPawn.uc:9919); complete a full round inside 6s.
+constexpr DWORD kSweepWindowMs = 6000;
+constexpr DWORD kMinStepMs     = 250;
+constexpr DWORD kMaxStepMs     = 3000;
+
+enum class Route { Glow, Foreman };
+enum class TeamFilter { All, Attackers, Defenders, Friendly, Enemy };
+
+struct Session {
+    APlayerController* pc    = nullptr;
+    Route              route = Route::Glow;
+    TeamFilter         team  = TeamFilter::All;
+    float              minDistanceUU = kDefaultMinDistanceUU;
+
+    // glow route: one owned manager per marked pawn. pushes counts how many
+    // SetEffectRep calls that manager has had, so we know when it is past the
+    // swallowed-first-push warm-up.
+    struct GlowEntry {
+        ATgEffectManager* mgr    = nullptr;
+        int               pushes = 0;
+    };
+    std::map<ATgPawn*, GlowEntry> glowMgrs;
+    DWORD glowLastPushMs = 0;
+
+    // foreman route
+    ATgPawn_SupportForeman* foreman = nullptr;
+    int                     cursor  = 0;
+    DWORD                   lastStepMs = 0;
+};
+
+std::map<std::string, Session> g_active;
+
+// Managers awaiting destruction after their ClearEffectRep has had time to
+// replicate. Keyed by actor, valued by the tick at which it is safe to destroy.
+std::map<ATgEffectManager*, DWORD> g_pendingDestroy;
+
+// Sessions that explicitly turned markers OFF. Without this the auto-enable
+// scan below would immediately turn them back on.
+std::set<std::string> g_optedOut;
+
+DWORD g_lastAutoScanMs = 0;
+
+// Every live glow-route manager, across all sessions. Consulted by the
+// replication hook — see IsMarkerEffectManager in the header for why.
+std::set<const void*> g_markerMgrs;
+
+// The GClientConnectionsData key IS the UNetConnection pointer (see
+// UdpNetDriver__TickDispatch.cpp:204).
+UNetConnection* ConnectionForSession(const std::string& guid) {
+    for (auto& kv : GClientConnectionsData) {
+        if (kv.second.SessionGuid == guid && !kv.second.bClosed) {
+            return (UNetConnection*)(uintptr_t)(uint32_t)kv.first;
+        }
+    }
+    return nullptr;
+}
+
+// HARD GATE. Every -markers form is spectator-only.
+//
+// Without this a live player could run `-markers all` and give themselves a
+// see-through-the-team highlight on every enemy — a wallhack, self-served from
+// chat. PlayerInfo.is_spectator is set authoritatively by the control server
+// from the ga_user_roles "spectator" role at PLAYER_REGISTER; it is never
+// supplied by the connecting client.
+bool IsSpectatorSession(const std::string& guid) {
+    for (auto& kv : GClientConnectionsData) {
+        if (kv.second.SessionGuid == guid && !kv.second.bClosed) {
+            return kv.second.PlayerInfo.is_spectator;
+        }
+    }
+    return false;
+}
+
+AWorldInfo* World() {
+    AActor* game = (AActor*)Globals::Get().GGameInfo;
+    return game ? game->WorldInfo : nullptr;
+}
+
+// Spectators have no pawn, so resolve the controller from the connection by
+// walking WorldInfo.ControllerList rather than from a pawn lookup.
+APlayerController* FindControllerForSession(const std::string& guid) {
+    UNetConnection* conn = ConnectionForSession(guid);
+    if (!conn) return nullptr;
+    AWorldInfo* wi = World();
+    if (!wi) return nullptr;
+    for (AController* c = wi->ControllerList; c; c = c->NextController) {
+        if (!ObjectClassCache::ClassNameContains(c, "PlayerController")) continue;
+        APlayerController* pc = (APlayerController*)c;
+        // Pointer identity only — UNetConnection derives from UPlayer at
+        // offset 0, so compare as void* rather than assume the downcast.
+        if ((void*)pc->Player == (void*)conn) return pc;
+    }
+    return nullptr;
+}
+
+// 1 = attackers, 2 = defenders, 0 = unknown. Same resolution as
+// ChangeTeam.cpp: compare the PRI's r_TaskForce against the global team
+// rep-info pointers.
+int TaskForceNumber(ATgPawn* pawn) {
+    if (!pawn || !pawn->PlayerReplicationInfo) return 0;
+    ATgRepInfo_Player* repinfo = (ATgRepInfo_Player*)pawn->PlayerReplicationInfo;
+    ATgRepInfo_TaskForce* tf = repinfo->r_TaskForce;
+    if (!tf) return 0;
+    if (tf == GTeamsData.Attackers) return 1;
+    if (tf == GTeamsData.Defenders) return 2;
+    return 0;
+}
+
+// The spectator's own cosmetic side, as seeded by `-spectate <id> <team>`
+// (UObject__ProcessEvent.cpp:1119-1128). 0 = teamless.
+int SpectatorTaskForce(APlayerController* pc) {
+    if (!pc || !pc->PlayerReplicationInfo) return 0;
+    ATgRepInfo_Player* repinfo = (ATgRepInfo_Player*)pc->PlayerReplicationInfo;
+    ATgRepInfo_TaskForce* tf = repinfo->r_TaskForce;
+    if (!tf) return 0;
+    if (tf == GTeamsData.Attackers) return 1;
+    if (tf == GTeamsData.Defenders) return 2;
+    return 0;
+}
+
+// Collapse the filter to the concrete task force it selects this sweep.
+// Returns 0 for "no filter" — either TeamFilter::All, or a relative filter on
+// a teamless spectator, which degrades to All rather than marking nobody.
+int ResolveWantedTaskForce(const Session& s);
+
+void Audit(const std::string& guid,
+           const std::string& outcome, const std::string& details) {
+    IpcClient::SendChatCommandAudit(guid, "-markers", outcome, details);
+}
+
+FVector ViewLocation(APlayerController* pc) {
+    if (pc->ViewTarget && !pc->ViewTarget->bDeleteMe) return pc->ViewTarget->Location;
+    return ((AActor*)pc)->Location;
+}
+
+bool WithinNearCull(const FVector& view, ATgPawn* pawn, float minDistUU) {
+    if (minDistUU <= 0.0f) return false;
+    const float dx = pawn->Location.X - view.X;
+    const float dy = pawn->Location.Y - view.Y;
+    const float dz = pawn->Location.Z - view.Z;
+    return (dx * dx + dy * dy + dz * dz) < (minDistUU * minDistUU);
+}
+
+// Live player pawns, unfiltered by team or distance.
+void CollectCandidates(std::vector<ATgPawn*>& out) {
+    for (auto& kv : GClientConnectionsData) {
+        ClientConnectionData& data = kv.second;
+        if (data.bClosed) continue;
+
+        ATgPawn_Character* pawn = data.Pawn;
+        if (!pawn || pawn->bDeleteMe) continue;
+        if (pawn->Health <= 0) continue;  // don't highlight corpses
+
+        // Real players only. bIsPlayer is unreliable on this build (AI bots
+        // default it true), so test the controller class instead.
+        if (!pawn->Controller ||
+            !ObjectClassCache::ClassNameContains(pawn->Controller, "PlayerController")) {
+            continue;
+        }
+        out.push_back((ATgPawn*)pawn);
+    }
+}
+
+int ResolveWantedTaskForce(const Session& s) {
+    switch (s.team) {
+        case TeamFilter::Attackers: return 1;
+        case TeamFilter::Defenders: return 2;
+        case TeamFilter::Friendly:  return SpectatorTaskForce(s.pc);
+        case TeamFilter::Enemy: {
+            const int own = SpectatorTaskForce(s.pc);
+            // Teamless -> 0, which the caller treats as "no filter".
+            return (own == 1) ? 2 : (own == 2 ? 1 : 0);
+        }
+        default: return 0;  // All
+    }
+}
+
+// Per-session view: team filter always; near-cull only on the foreman route,
+// which is the one with the close-range scaling problem.
+void FilterForSession(const Session& s, const std::vector<ATgPawn*>& candidates,
+                      std::vector<ATgPawn*>& out) {
+    if (!s.pc) return;
+    const int wantTf = ResolveWantedTaskForce(s);
+    const FVector view = ViewLocation(s.pc);
+    for (ATgPawn* p : candidates) {
+        if (wantTf != 0 && TaskForceNumber(p) != wantTf) continue;
+        if (s.route == Route::Foreman && WithinNearCull(view, p, s.minDistanceUU)) continue;
+        out.push_back(p);
+    }
+}
+
+DWORD StepIntervalMs(size_t target_count) {
+    if (target_count == 0) return kMaxStepMs;
+    DWORD step = (DWORD)(kSweepWindowMs / target_count);
+    if (step < kMinStepMs) step = kMinStepMs;
+    if (step > kMaxStepMs) step = kMaxStepMs;
+    return step;
+}
+
+// ── glow route ──────────────────────────────────────────────────────────────
+
+ATgEffectManager* SpawnOwnedManager(APlayerController* pc) {
+    UClass* cls = ClassPreloader::GetClass("Class TgGame.TgEffectManager");
+    if (!cls) {
+        Logger::Log("markers", "[Markers] TgEffectManager class not resolved\n");
+        return nullptr;
+    }
+    FRotator rot; rot.Pitch = 0; rot.Yaw = 0; rot.Roll = 0;
+    ATgEffectManager* m = (ATgEffectManager*)((AActor*)pc)->Spawn(
+        cls, (AActor*)pc, FName(), ((AActor*)pc)->Location, rot, nullptr, 1);
+    if (!m) {
+        Logger::Log("markers", "[Markers] effect manager Spawn returned null\n");
+        return nullptr;
+    }
+    // Owner + bOnlyRelevantToOwner is what makes this per-viewer: the actor
+    // channel opens for this one connection and no other.
+    //
+    // The client must NOT see this Owner value — it would resolve the effect
+    // target as the PlayerController instead of falling through to r_Owner.
+    // Registering here makes the replication hook send Owner as null. See
+    // IsMarkerEffectManager in the header.
+    ((AActor*)m)->Owner                = (AActor*)pc;
+    ((AActor*)m)->bOnlyRelevantToOwner = 1;
+    ((AActor*)m)->bAlwaysRelevant      = 0;
+    ((AActor*)m)->bHidden              = 1;
+    ((AActor*)m)->bCollideActors       = 0;
+    ((AActor*)m)->bCollideWorld        = 0;
+    g_markerMgrs.insert((const void*)m);
+    return m;
+}
+
+// Clear the applied effect, then queue the manager for destruction once the
+// clear has had a chance to reach the client. Destroying outright leaves the
+// skin swap stuck on the pawn until its own lifetime expires.
+void ReleaseGlowMgr(ATgEffectManager* mgr) {
+    if (!mgr || ((AActor*)mgr)->bDeleteMe) return;
+    mgr->ClearEffectRep(kGlowEffectGroupId, -1);
+    ((AActor*)mgr)->bNetDirty       = 1;
+    ((AActor*)mgr)->bForceNetUpdate = 1;
+    g_pendingDestroy[mgr] = GetTickCount() + kClearLingerMs;
+}
+
+void DestroyGlowMgrs(Session& s) {
+    for (auto& kv : s.glowMgrs) {
+        ReleaseGlowMgr(kv.second.mgr);
+    }
+    s.glowMgrs.clear();
+}
+
+// Second phase of teardown — run every tick.
+void ReapPendingDestroys() {
+    const DWORD now = GetTickCount();
+    for (auto it = g_pendingDestroy.begin(); it != g_pendingDestroy.end(); ) {
+        if ((int)(now - it->second) < 0) { ++it; continue; }
+        ATgEffectManager* mgr = it->first;
+        g_markerMgrs.erase((const void*)mgr);
+        if (!((AActor*)mgr)->bDeleteMe) ((AActor*)mgr)->Destroy();
+        it = g_pendingDestroy.erase(it);
+    }
+}
+
+// True while any manager is still inside its warm-up, i.e. has not yet landed
+// enough pushes to be sure one survived the channel-open swallow.
+bool SessionIsWarmingUp(const Session& s) {
+    for (const auto& kv : s.glowMgrs) {
+        if (kv.second.mgr && kv.second.pushes < kWarmupPushes) return true;
+    }
+    return s.glowMgrs.empty();
+}
+
+// A target with no manager yet: someone joined, respawned, or moved into the
+// team filter since the last sweep. Waiting out the 24s refresh before noticing
+// would leave late joiners — and every respawn, which is constant in a real
+// match — unmarked for most of a minute.
+bool HasUnmarkedTarget(const Session& s, const std::vector<ATgPawn*>& targets) {
+    for (ATgPawn* p : targets) {
+        auto it = s.glowMgrs.find(p);
+        if (it == s.glowMgrs.end() || !it->second.mgr) return true;
+    }
+    return false;
+}
+
+void GlowSweep(const std::string& guid, Session& s, const std::vector<ATgPawn*>& targets) {
+    // Retire managers whose pawn is no longer a target (died, left, team
+    // filter changed). The skin swap lapses on its own within kGlowLifetimeSec
+    // once we stop pushing, so no explicit clear is needed.
+    for (auto it = s.glowMgrs.begin(); it != s.glowMgrs.end(); ) {
+        bool still = false;
+        for (ATgPawn* p : targets) { if (p == it->first) { still = true; break; } }
+        if (!still) {
+            // Pawn died / left / fell out of the team filter — clear its glow
+            // now rather than letting it linger for the effect's lifetime.
+            ReleaseGlowMgr(it->second.mgr);
+            it = s.glowMgrs.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    int pushed = 0;
+    for (ATgPawn* p : targets) {
+        Session::GlowEntry& e = s.glowMgrs[p];
+        if (!e.mgr || ((AActor*)e.mgr)->bDeleteMe) {
+            e.mgr    = SpawnOwnedManager(s.pc);
+            e.pushes = 0;
+        }
+        ATgEffectManager* mgr = e.mgr;
+        if (!mgr) continue;
+
+        mgr->r_Owner = (AActor*)p;
+        ((AActor*)mgr)->bNetDirty       = 1;
+        ((AActor*)mgr)->bForceNetUpdate = 1;
+
+        const int ret = TgEffectManager__SetEffectRep::Call(
+            mgr, nullptr, kGlowEffectGroupId, kGlowLifetimeSec,
+            /*bIsBuff=*/0, /*nHealthChange=*/0);
+        ++e.pushes;
+        ++pushed;
+
+        if (Logger::IsChannelEnabled("markers")) {
+            Logger::Log("markers", "[Markers] guid=%s glow eg=%d -> %s ret=%s(%d)\n",
+                guid.c_str(), kGlowEffectGroupId, ((UObject*)p)->GetName(),
+                (ret == -1) ? "A:queue" : "B:managed", ret);
+        }
+    }
+    Logger::Log("markers", "[Markers] guid=%s glow sweep: %d pawn(s)\n",
+        guid.c_str(), pushed);
+}
+
+// ── foreman route ───────────────────────────────────────────────────────────
+
+ATgPawn_SupportForeman* SpawnForeman(APlayerController* pc) {
+    UClass* cls = ClassPreloader::GetClass("Class TgGame.TgPawn_SupportForeman");
+    if (!cls) {
+        Logger::Log("markers", "[Markers] TgPawn_SupportForeman class not resolved\n");
+        return nullptr;
+    }
+    FRotator rot; rot.Pitch = 0; rot.Yaw = 0; rot.Roll = 0;
+    ATgPawn_SupportForeman* f = (ATgPawn_SupportForeman*)((AActor*)pc)->Spawn(
+        cls, (AActor*)pc, FName(), ((AActor*)pc)->Location, rot, nullptr, 1);
+    if (!f) {
+        Logger::Log("markers", "[Markers] foreman Spawn returned null\n");
+        return nullptr;
+    }
+    ((AActor*)f)->Owner                = (AActor*)pc;
+    ((AActor*)f)->bOnlyRelevantToOwner = 1;
+    ((AActor*)f)->bAlwaysRelevant      = 0;
+    // IsNetRelevantFor short-circuits on IsOwnedBy before the bHidden reject,
+    // so hiding it costs us nothing with the owner.
+    ((AActor*)f)->bHidden              = 1;
+    ((AActor*)f)->bCollideActors       = 0;
+    ((AActor*)f)->bCollideWorld        = 0;
+    ((AActor*)f)->bBlockActors         = 0;
+    ((AActor*)f)->Physics              = 0;   // PHYS_None
+    ((APawn*)f)->bSimulateGravity      = 0;
+    return f;
+}
+
+void ForemanStep(const std::string& guid, Session& s, const std::vector<ATgPawn*>& targets) {
+    if (!s.foreman || ((AActor*)s.foreman)->bDeleteMe) return;
+    if (targets.empty()) return;
+
+    if (s.cursor < 0 || (size_t)s.cursor >= targets.size()) s.cursor = 0;
+    ATgPawn* next = targets[s.cursor];
+
+    // repnotify only fires on CHANGE. With a single target the same pointer
+    // would be written twice in a row and CheckBeingTargeted would never
+    // re-run, so blank the slot on alternate steps.
+    if (s.foreman->r_Target == next) {
+        s.foreman->r_Target = nullptr;
+    } else {
+        s.foreman->r_Target = next;
+        s.cursor = (s.cursor + 1) % (int)targets.size();
+    }
+    ((AActor*)s.foreman)->bNetDirty       = 1;
+    ((AActor*)s.foreman)->bForceNetUpdate = 1;
+
+    if (Logger::IsChannelEnabled("markers")) {
+        Logger::Log("markers", "[Markers] guid=%s foreman mark=%s cursor=%d/%d\n",
+            guid.c_str(),
+            s.foreman->r_Target ? ((UObject*)s.foreman->r_Target)->GetName() : "<clear>",
+            s.cursor, (int)targets.size());
+    }
+}
+
+void DestroyForeman(Session& s) {
+    if (s.foreman && !((AActor*)s.foreman)->bDeleteMe) ((AActor*)s.foreman)->Destroy();
+    s.foreman = nullptr;
+}
+
+void TeardownRouteActors(Session& s) {
+    DestroyGlowMgrs(s);
+    DestroyForeman(s);
+}
+
+const char* TeamName(TeamFilter t) {
+    switch (t) {
+        case TeamFilter::Attackers: return "attackers";
+        case TeamFilter::Defenders: return "defenders";
+        case TeamFilter::Friendly:  return "friendly";
+        case TeamFilter::Enemy:     return "enemy";
+        default: return "all";
+    }
+}
+
+} // namespace
+
+bool IsMarkerEffectManager(const void* actor) {
+    return actor && g_markerMgrs.count(actor) != 0;
+}
+
+void RegisterMarkerEffectManager(const void* actor) {
+    if (actor) g_markerMgrs.insert(actor);
+}
+
+void UnregisterMarkerEffectManager(const void* actor) {
+    if (actor) g_markerMgrs.erase(actor);
+}
+
+void Execute(const std::string& session_guid, Mode mode, float distance_uu) {
+    // Spectator-only, no exceptions — see IsSpectatorSession.
+    if (!IsSpectatorSession(session_guid)) {
+        Logger::Log("markers",
+            "[Markers] guid=%s: rejected, session is not a spectator\n",
+            session_guid.c_str());
+        Audit(session_guid, "ignored", "not a spectator");
+        return;
+    }
+
+    if (mode == Mode::Off) {
+        // Remember the opt-out so the spectator auto-enable scan doesn't just
+        // switch it straight back on.
+        g_optedOut.insert(session_guid);
+        auto it = g_active.find(session_guid);
+        if (it == g_active.end()) {
+            Audit(session_guid, "no-op", "already off");
+            return;
+        }
+        TeardownRouteActors(it->second);
+        g_active.erase(it);
+        Logger::Log("markers", "[Markers] guid=%s: disabled\n", session_guid.c_str());
+        Audit(session_guid, "restored", "markers off");
+        return;
+    }
+
+    auto it = g_active.find(session_guid);
+    const bool was_on = (it != g_active.end());
+
+    // Bare -markers with markers already on is the off switch.
+    if (mode == Mode::Toggle && was_on) {
+        g_optedOut.insert(session_guid);
+        TeardownRouteActors(it->second);
+        g_active.erase(it);
+        Logger::Log("markers", "[Markers] guid=%s: toggled off\n", session_guid.c_str());
+        Audit(session_guid, "restored", "markers off");
+        return;
+    }
+
+    APlayerController* pc = FindControllerForSession(session_guid);
+    if (!pc) {
+        Logger::Log("markers",
+            "[Markers] guid=%s: no PlayerController for this connection; dropping\n",
+            session_guid.c_str());
+        Audit(session_guid, "ignored", "no player controller");
+        return;
+    }
+
+    // Any explicit enable clears a previous opt-out.
+    g_optedOut.erase(session_guid);
+
+    Session& s = g_active[session_guid];
+    s.pc = pc;
+
+    const Route prevRoute = s.route;
+    switch (mode) {
+        case Mode::All:          s.team  = TeamFilter::All;       break;
+        case Mode::Attackers:    s.team  = TeamFilter::Attackers; break;
+        case Mode::Defenders:    s.team  = TeamFilter::Defenders; break;
+        case Mode::Friendly:     s.team  = TeamFilter::Friendly;  break;
+        case Mode::Enemy:        s.team  = TeamFilter::Enemy;     break;
+        case Mode::RouteGlow:    s.route = Route::Glow;           break;
+        case Mode::RouteForeman: s.route = Route::Foreman;        break;
+        case Mode::SetDistance:
+            if (distance_uu > 0.0f) s.minDistanceUU = distance_uu;
+            break;
+        default: break;  // Toggle on a fresh session — keep defaults
+    }
+
+    // Switching route tears down the other route's actors so we never have a
+    // foreman and a manager set fighting over the same pawns.
+    if (s.route != prevRoute) TeardownRouteActors(s);
+
+    if (s.route == Route::Foreman && !s.foreman) {
+        s.foreman = SpawnForeman(pc);
+        if (!s.foreman) {
+            g_active.erase(session_guid);
+            Audit(session_guid, "ignored", "foreman spawn failed");
+            return;
+        }
+    }
+
+    std::vector<ATgPawn*> candidates, targets;
+    CollectCandidates(candidates);
+    FilterForSession(s, candidates, targets);
+
+    const DWORD now = GetTickCount();
+    if (s.route == Route::Glow) {
+        s.glowLastPushMs = now;
+        GlowSweep(session_guid, s, targets);
+    } else {
+        s.lastStepMs = now;
+        ForemanStep(session_guid, s, targets);
+    }
+
+    // A relative filter on a teamless spectator resolves to 0 (= no filter),
+    // so say so rather than let it look like the filter silently did nothing.
+    const int ownTf  = SpectatorTaskForce(pc);
+    const bool relative = (s.team == TeamFilter::Friendly || s.team == TeamFilter::Enemy);
+    const bool degraded = relative && ownTf == 0;
+
+    Logger::Log("markers",
+        "[Markers] guid=%s: on route=%s team=%s ownTf=%d wantTf=%d%s targets=%d/%d nearcull=%.0fuu\n",
+        session_guid.c_str(), s.route == Route::Glow ? "glow" : "foreman",
+        TeamName(s.team), ownTf, ResolveWantedTaskForce(s),
+        degraded ? " (teamless spectator -> falling back to all)" : "",
+        (int)targets.size(), (int)candidates.size(), s.minDistanceUU);
+    Audit(session_guid, "activated",
+        std::string("route=") + (s.route == Route::Glow ? "glow" : "foreman")
+        + " team=" + TeamName(s.team)
+        + (degraded ? " (teamless->all)" : "")
+        + " targets=" + std::to_string(targets.size()));
+}
+
+// Turn markers on automatically for any spectator that doesn't have them and
+// hasn't explicitly opted out. This is what makes the feature need ZERO
+// commands in normal use: joining as a spectator is the whole interaction.
+//
+// Runs on a scan rather than off the join event because it is self-healing —
+// it also covers map changes, reconnects, and a spectator whose controller
+// wasn't resolvable at PostLogin time.
+static void AutoEnableForSpectators() {
+    const DWORD now = GetTickCount();
+    if (now - g_lastAutoScanMs < kAutoScanMs) return;
+    g_lastAutoScanMs = now;
+
+    for (auto& kv : GClientConnectionsData) {
+        ClientConnectionData& data = kv.second;
+        if (data.bClosed) continue;
+        if (!data.PlayerInfo.is_spectator) continue;
+        if (data.SessionGuid.empty()) continue;
+        if (g_active.count(data.SessionGuid)) continue;
+        if (g_optedOut.count(data.SessionGuid)) continue;
+
+        Logger::Log("markers", "[Markers] guid=%s: auto-enabling for spectator\n",
+            data.SessionGuid.c_str());
+        Execute(data.SessionGuid, Mode::Enemy, 0.0f);
+    }
+}
+
+void Tick() {
+    ReapPendingDestroys();
+    AutoEnableForSpectators();
+    if (g_active.empty()) return;
+
+    std::vector<ATgPawn*> candidates;
+    CollectCandidates(candidates);
+    const DWORD now = GetTickCount();
+
+    for (auto it = g_active.begin(); it != g_active.end(); ) {
+        Session& s = it->second;
+
+        // Controller gone (map change, disconnect racing cleanup) — drop the
+        // entry rather than keep driving dangling actors.
+        if (!s.pc || ((AActor*)s.pc)->bDeleteMe) {
+            TeardownRouteActors(s);
+            it = g_active.erase(it);
+            continue;
+        }
+
+        std::vector<ATgPawn*> targets;
+        FilterForSession(s, candidates, targets);
+
+        if (s.route == Route::Glow) {
+            // Fast cadence until every manager has landed past the swallowed
+            // first push, then settle to the lifetime-driven refresh. A newly
+            // appeared target short-circuits the wait entirely.
+            const DWORD interval = SessionIsWarmingUp(s) ? kWarmupRefreshMs : kGlowRefreshMs;
+            if (HasUnmarkedTarget(s, targets) || now - s.glowLastPushMs >= interval) {
+                s.glowLastPushMs = now;
+                GlowSweep(it->first, s, targets);
+            }
+        } else {
+            if (!s.foreman || ((AActor*)s.foreman)->bDeleteMe) {
+                Logger::Log("markers",
+                    "[Markers] guid=%s: foreman gone; disabling\n", it->first.c_str());
+                s.foreman = nullptr;
+                TeardownRouteActors(s);
+                it = g_active.erase(it);
+                continue;
+            }
+            if (now - s.lastStepMs >= StepIntervalMs(targets.size())) {
+                s.lastStepMs = now;
+                ForemanStep(it->first, s, targets);
+            }
+        }
+        ++it;
+    }
+}
+
+void ForgetSession(const std::string& session_guid) {
+    g_optedOut.erase(session_guid);
+    auto it = g_active.find(session_guid);
+    if (it == g_active.end()) return;
+    TeardownRouteActors(it->second);
+    g_active.erase(it);
+}
+
+} // namespace TgPlayerActions::MarkersCmd

--- a/src/GameServer/TgGame/TgPlayerActions/Markers/Markers.hpp
+++ b/src/GameServer/TgGame/TgPlayerActions/Markers/Markers.hpp
@@ -1,0 +1,160 @@
+#pragma once
+
+#include <string>
+
+namespace TgPlayerActions::MarkersCmd {
+
+// -markers: highlight players for the spectator who enabled it, and ONLY for
+// that spectator. Two delivery routes, because they have different strengths
+// and only one of them is proven.
+//
+// ── ROUTE "glow" (default) ──────────────────────────────────────────────────
+// Effect group 1469 -> FX 131, a pure MATERIAL swap with no particles at all:
+//     asm_data_set_special_fx_psc    (fx 131) -> 0 rows
+//     asm_data_set_special_fx_sounds (fx 131) -> 0 rows
+//     asm_data_set_special_fx_materials       -> 3 rows, all same_team_flag=0
+//         EFX_Agent_Materials.ColorGlow.MIC_PCAgent_ColorGlow_Gold_hair
+//                                              ..._Gold_head
+//                                              ..._Gold_suit
+// The whole player model turns gold. Because it is a skin swap and not a
+// particle system, nothing can balloon into the camera at close range — which
+// is exactly the failure the scanbot FX has. Silent, and 30s lifetime, so it
+// needs re-pushing only every ~24s (vs 6s for the scanbot).
+//
+// Per-viewer delivery: for each marked pawn we spawn our own TgEffectManager
+// with r_Owner = that pawn but network Owner = the spectator's
+// PlayerController and bOnlyRelevantToOwner = 1, then push SetEffectRep on it.
+// The manager's channel opens for that one connection, so no other client ever
+// receives the effect entry.
+//
+// ONE MANAGER PER MARKED PAWN, not one shared manager: r_Owner is a single
+// Actor ref, so a shared manager could only ever point at one pawn. With <=16
+// players that is <=16 hidden, owner-only actors pushing one entry each per
+// ~24s — negligible traffic.
+//
+// *** UNPROVEN ***  This route depends on the client's native
+// UpdateEffectForms resolving the effect form's owner from the manager's
+// r_Owner (TgEffectManager.uc:61 declares r_Owner as a replicated Actor;
+// TgEffectForm carries c_Owner). That wiring is native and could not be
+// confirmed by static reading. Verify with `-fx own` first — if that renders,
+// this route works. If it does not, use the foreman route below.
+//
+// Second caveat specific to FX 131: all three material rows are
+// same_team_flag=0 (enemy-side). The client picks rows by matching
+// bApplyIfSameTeam against IsFriendlyWithLocalPawn(). A spectator has no pawn,
+// so that predicate most likely returns false and the enemy rows apply — which
+// is what we want — but it is an assumption until seen.
+//
+// ── ROUTE "foreman" ─────────────────────────────────────────────────────────
+// The scanbot route: a hidden, controller-less TgPawn_SupportForeman owned by
+// the spectator's PlayerController with bOnlyRelevantToOwner=1, round-robining
+// its r_Target. Each change fires TgPawn_SupportForeman.CheckBeingTargeted ->
+// r_Target.OnDetectedByAnAlarmBot() (TgPawn.uc:9908), attaching FX 1163 at
+// SDPG_Foreground — the only through-wall highlight in the shipped script.
+//
+// PROVEN to reach a spectator, but: FX 1163 carries sound cue res 5843
+// (SND_B_UI.A_CUE_UI_Foreman_Detected), played by the intact native
+// UTgSpecialFx::Activate on an FX object the client builds inside
+// OnDetectedByAnAlarmBot — unreachable from the server, so the beep cannot be
+// muted. Owner-only relevancy at least confines it to the one spectator. Its
+// world-scaled sprites also fill the screen at close range, hence the
+// near-cull (see min_distance_uu).
+//
+// Trade: glow is silent and close-range-safe but occluded by geometry;
+// foreman draws through walls but beeps. Nothing in the data does both.
+
+// ── TEAM SELECTION AND -spectate ────────────────────────────────────────────
+// `-spectate <id> attackers|defenders` is a cosmetic assignment: the DLL sets
+// the SPECTATOR'S OWN PRI.r_TaskForce to that task force
+// (UObject__ProcessEvent.cpp:1119-1128) without clearing bOnlySpectator, so no
+// pawn ever spawns. A teamless `-spectate <id>` leaves r_TaskForce null.
+//
+// That gives two ways to pick who gets highlighted:
+//
+//   ABSOLUTE  -markers attackers | defenders
+//             Always that side, regardless of how you joined. Works for a
+//             teamless spectator.
+//
+//   RELATIVE  -markers friendly | enemy
+//             Resolved against your own PRI.r_TaskForce each sweep, so it
+//             follows the side you joined as and keeps working if that
+//             assignment changes mid-session. Requires a team: a teamless
+//             spectator has no r_TaskForce, so these fall back to All and say
+//             so in the audit/log.
+//
+// CAVEAT specific to FX 131 (the glow route's default): all three of its
+// material rows are same_team_flag=0, i.e. enemy-side only. The client picks
+// rows by matching bApplyIfSameTeam against IsFriendlyWithLocalPawn(), which
+// compares against the local PAWN — and a spectator has none. If that
+// predicate falls back to the PRI team rather than the pawn, then
+// `-markers friendly` will render NOTHING for a team-assigned spectator,
+// because FX 131 has no same-team rows to apply. `-markers enemy` would still
+// work. If you see that asymmetry, this is why — and it is a property of FX
+// 131, not of the team filter.
+
+// ── ACCESS ──────────────────────────────────────────────────────────────────
+// SPECTATOR-ONLY. Execute() rejects any session whose PlayerInfo.is_spectator
+// is false, and the auto-enable scan only ever considers spectator
+// connections. A live player must never reach this: it is a see-through-team
+// highlight on every enemy, i.e. a wallhack if self-served from chat.
+// is_spectator is set by the control server from the ga_user_roles "spectator"
+// role at PLAYER_REGISTER and is never supplied by the connecting client.
+
+enum class Mode {
+    Toggle,
+    Off,
+    All,        // every live player
+    Attackers,  // task force 1 only
+    Defenders,  // task force 2 only
+    Friendly,   // same task force as the spectator's own PRI
+    Enemy,      // the opposing task force
+    RouteGlow,
+    RouteForeman,
+    SetDistance,
+};
+
+// Effect group / FX / lifetime for the glow route.
+constexpr int   kGlowEffectGroupId = 1469;
+constexpr int   kGlowFxId          = 131;
+constexpr float kGlowLifetimeSec   = 30.0f;
+
+// Default near-cull for the foreman route, in UE3 world units (cm). Ignored by
+// the glow route, which has no close-range scaling problem.
+constexpr float kDefaultMinDistanceUU = 1500.0f;
+
+// True for the effect managers the glow route spawns.
+//
+// Actor__GetOptimizedRepListV2 uses this to suppress replication of AActor::Owner
+// for these actors ONLY. The client's effect-form updater (FUN_10a70a70)
+// resolves its target as `Owner ?: r_Owner`:
+//
+//     piVar9 = *(int **)(param_1 + 0x98);          // AActor::Owner
+//     if ((piVar9 != 0) || (piVar9 = *(int **)(param_1 + 0x480), piVar9 != 0))
+//                                                  // ^ r_Owner, only if Owner null
+//
+// We must keep Owner = the spectator's PlayerController on the SERVER, because
+// that is what drives bOnlyRelevantToOwner and bNetOwner. But if that value
+// reaches the client, the native resolves the target as the PlayerController —
+// which has no mesh — and never consults r_Owner. Replicating Owner as null
+// makes the client fall through to r_Owner (the pawn we want painted) while
+// the server keeps its relevancy gate. Verified failure mode: `-fx own`
+// rendered nothing while `-fx pawn` rendered correctly.
+bool IsMarkerEffectManager(const void* actor);
+
+// Register/unregister an effect manager for the Owner-suppression above.
+// Shared with the -fx browser's "own" mode so both routes behave identically;
+// the registry lives here because Markers is the primary consumer.
+void RegisterMarkerEffectManager(const void* actor);
+void UnregisterMarkerEffectManager(const void* actor);
+
+// distance_uu is only read for Mode::SetDistance.
+void Execute(const std::string& session_guid, Mode mode, float distance_uu);
+
+// Per-frame entry point (GameEngine__Tick). Returns immediately when no
+// session has markers enabled.
+void Tick();
+
+// Tear down a session's actors. Called from connection cleanup.
+void ForgetSession(const std::string& session_guid);
+
+} // namespace TgPlayerActions::MarkersCmd

--- a/src/IpcClient/IpcClient.cpp
+++ b/src/IpcClient/IpcClient.cpp
@@ -14,6 +14,8 @@
 #include "src/GameServer/TgGame/TgPlayerActions/Coords/Coords.hpp"
 #include "src/GameServer/TgGame/TgPlayerActions/FullHeal/FullHeal.hpp"
 #include "src/GameServer/TgGame/TgPlayerActions/ToggleBrokenSuits/ToggleBrokenSuits.hpp"
+#include "src/GameServer/TgGame/TgPlayerActions/Markers/Markers.hpp"
+#include "src/GameServer/TgGame/TgPlayerActions/FxBrowse/FxBrowse.hpp"
 #include "src/GameServer/Storage/ClientConnectionsData/ClientConnectionsData.hpp"
 #include "src/GameServer/Storage/UserPreferences/UserPreferences.hpp"
 #include "src/GameServer/IpDrv/NetConnection/Cleanup/NetConnection__Cleanup.hpp"
@@ -670,6 +672,43 @@ void IpcClient::DrainInbound() {
                 }
                 TgPlayerActions::ToggleBrokenSuitsCmd::Execute(
                     guid, mode, action == "toggle_all_suits");
+            } else if (action == "fx_browse") {
+                std::string fx_action = "show";
+                int fx_index = 0;
+                if (j.contains("args") && j["args"].is_object()) {
+                    fx_action = j["args"].value("fx_action", std::string("show"));
+                    fx_index  = j["args"].value("index", 0);
+                }
+                using A = TgPlayerActions::FxBrowseCmd::Action;
+                A a = A::Show;
+                if (fx_action == "next")      a = A::Next;
+                else if (fx_action == "prev") a = A::Prev;
+                else if (fx_action == "jump") a = A::Jump;
+                else if (fx_action == "off")  a = A::Off;
+                else if (fx_action == "pawn") a = A::ModePawn;
+                else if (fx_action == "own")  a = A::ModeOwn;
+                TgPlayerActions::FxBrowseCmd::Execute(guid, a, fx_index);
+            } else if (action == "markers") {
+                // Visual-only; safe in PvP (no gameplay state touched), so
+                // unlike -topdown this is NOT behind CurrentMatchIsPVP().
+                std::string mode_s = "toggle";
+                float min_distance_uu = 0.0f;
+                if (j.contains("args") && j["args"].is_object()) {
+                    mode_s = j["args"].value("mode", std::string("toggle"));
+                    min_distance_uu = j["args"].value("min_distance_uu", 0.0f);
+                }
+                using M = TgPlayerActions::MarkersCmd::Mode;
+                M mode = M::Toggle;
+                if (mode_s == "off")            mode = M::Off;
+                else if (mode_s == "all")       mode = M::All;
+                else if (mode_s == "attackers") mode = M::Attackers;
+                else if (mode_s == "defenders") mode = M::Defenders;
+                else if (mode_s == "friendly")  mode = M::Friendly;
+                else if (mode_s == "enemy")     mode = M::Enemy;
+                else if (mode_s == "glow")      mode = M::RouteGlow;
+                else if (mode_s == "foreman")   mode = M::RouteForeman;
+                else if (mode_s == "distance")  mode = M::SetDistance;
+                TgPlayerActions::MarkersCmd::Execute(guid, mode, min_distance_uu);
             } else if (action == "topdown") {
                 if (CurrentMatchIsPVP()) {
                     Logger::Log("chat-command",


### PR DESCRIPTION
# Spectator team highlight

Gives a spectator a per-viewer highlight on one team. The marked players glow on the spectator's screen and on **no other client**. Silent, and readable at any camera distance.

**In live this needs no commands.** `-spectate <instance> attackers|defenders` auto-enables it; the opposing team glows.

---

## Access control

**Every command added here is spectator-only.**

`MarkersCmd::Execute` and `FxBrowseCmd::Execute` both reject any session whose `PlayerInfo.is_spectator` is false, before doing anything else. The auto-enable scan only ever considers spectator connections.

`is_spectator` is set by the control server from the `ga_user_roles` "spectator" role at `PLAYER_REGISTER`. It is never supplied by the connecting client, so it cannot be spoofed.

This matters: without the gate a live player could run `-markers all` and give themselves a see-through-team highlight on every enemy — a wallhack, self-served from chat. Rejections are logged and audited.

---

## Existing game functions: used, not changed

**No UnrealScript is modified. No native is replaced, stubbed, or patched. No existing hook's behaviour is altered.** Everything below is called exactly as the game itself calls it.

| Function | How we use it |
|---|---|
| `TgEffectManager::SetEffectRep(egId, fTime, bIsBuff, hpDelta)` | Intact native @ `0x10a6ffe0`. Called with the same arguments the game uses. We only ever take **Branch A** (queue push, returns `-1`), because we never add a clone to `s_AppliedEffectGroups`. Nothing touches the buff aggregator, HUD slots, the property system, or death cleanup — it is a pure visual push. |
| `TgEffectManager::ClearEffectRep(egId, -1)` | Teardown, so a removed marker clears rather than waiting out its lifetime. |
| `TgPawn.r_Target` → `CheckBeingTargeted` → `OnDetectedByAnAlarmBot` (`TgPawn.uc:9908`) | The alternate "foreman" route only. Driven purely by replicating `r_Target`, exactly as the scanbot does. |
| `AActor::Spawn` | Spawning our own hidden actors. |

### Shipped data used

**Effect group 1469 → FX 131.** Chosen from the shipped asm data, not authored:

```
asm_data_set_special_fx_psc    (fx 131) → 0 rows   no particles
asm_data_set_special_fx_sounds (fx 131) → 0 rows   no sound
asm_data_set_special_fx_materials       → 3 rows
    EFX_Agent_Materials.ColorGlow.MIC_PCAgent_ColorGlow_Gold_hair / _head / _suit
```

A pure material swap. Silent by construction, and with no particle system there is nothing that can scale into the camera at close range — the failure mode the scanbot FX has.

---

## What we create at runtime

Both are hidden, non-colliding, `PHYS_None`, and torn down on disable, map change, and disconnect.

**One `TgEffectManager` per marked pawn.** Owner = the spectator's `PlayerController`, `bOnlyRelevantToOwner = 1`, `r_Owner` = the target pawn. One per pawn rather than one shared, because `r_Owner` is a single `Actor` reference and cannot address several pawns.

**One `TgPawn_SupportForeman` per spectator** — foreman route only, not the default. No controller is ever assigned, so the AI that would otherwise overwrite `r_Target` (`TgPawn.uc:6654` sets it on device fire, `:6212` clears it) never runs.

---

## The one change to shared code

`Actor__GetOptimizedRepListV2.cpp` — isolated in its own commit.

The client resolves which pawn an effect form paints from the manager, and the native (`FUN_10a70a70`) reads:

```c
piVar9 = *(int **)(param_1 + 0x98);          // AActor::Owner
if ((piVar9 != 0) || (piVar9 = *(int **)(param_1 + 0x480), piVar9 != 0))
                                             // ^ r_Owner, ONLY if Owner is null
```

`Owner` first, `r_Owner` only as fallback. Our managers must set `Owner` = the spectator's `PlayerController`, because that is what drives `bOnlyRelevantToOwner` and therefore per-viewer delivery. But if that value reaches the client, the native paints the PlayerController — which has no mesh — and never consults `r_Owner`.

**Fix:** null `AActor::Owner` around the `CallOriginal` base-property pass for these actors only, then restore. Server keeps its real Owner (relevancy is decided before `ReplicateActor`, so it is unaffected); the client receives null and falls through to `r_Owner`.

**Scope:** guarded by `MarkersCmd::IsMarkerEffectManager`, a set lookup returning false for every actor in the game except the managers this feature spawns. The set is empty whenever no spectator has markers active.

Verified empirically before and after: `-fx own` rendered nothing while `-fx pawn` rendered on all clients; after the fix `-fx own` renders on the spectator only.

---

## Behaviour

| Event | Time to glow |
|---|---|
| Spectator joins | ≤3s scan + ~1.5s |
| Player joins mid-match | ~1.5s |
| Respawn | ~1.5s |
| Steady-state refresh | every 24s, not visible |

The ~1.5s is a deliberate warm-up. The **first** push into a freshly-spawned manager is always discarded: the client's initial-replication handler runs `c_nLastQueueIndex = r_nNextQueueIndex - 1`, marking the entry we just wrote as consumed. New managers therefore push every 1.5s until three have landed, then settle.

Teamless spectator (`-spectate <id>` with no team): `enemy` has no `r_TaskForce` to resolve against and falls back to marking **all** players. Logged explicitly.

---

## Commands

Live needs none of these. They exist for tuning and debugging.

| Command | Purpose |
|---|---|
| `-markers off` | Opt out (remembered; auto-enable won't override) |
| `-markers all` / `attackers` / `defenders` / `friendly` / `enemy` | Override who glows |
| `-markers glow` / `foreman` | Swap delivery route |
| `-markers <uu>` | Near-cull radius (foreman route only) |
| `-fx own` / `pawn` | Preview delivery route |
| `-fx next` / `prev` / `<n>` / `off` | Step 42 candidate effects |

`-fx` exists so a different look can be chosen by eye — the FX live in client packages and cannot be previewed any other way. The 42 candidates are all silent (zero rows in `asm_data_set_special_fx_sounds`).

---

## Files

**New:** `TgPlayerActions/Markers/Markers.{hpp,cpp}`, `TgPlayerActions/FxBrowse/FxBrowse.{hpp,cpp}` (both added to `Makefile` in the same commit).

**Modified:** `GameEngine__Tick.cpp` (refresh tick), `IpcClient.cpp` (action dispatch), `ChatCommand.{hpp,cpp}` + `ChatSession.cpp` (parse + dispatch), `NetConnection__Cleanup.cpp` (disconnect teardown), `Actor__GetOptimizedRepListV2.cpp` (see above).

---

## Known limitations

- **Occluded by geometry.** The glow route renders in the world depth-priority group. The only through-wall highlight in the shipped script is FX 1163, which carries an unsuppressable sound cue — kept as the `foreman` route but not the default.
- **`ClearEffectRep` on the queue path is unverified.** It is designed for the managed-list path; if it does not clear, a removed marker fades over its 30s lifetime instead of vanishing. Does not affect normal use, where markers are never turned off manually.
- The gold material reads as near-white on screen. `-fx 40` (FX 847) is the team-coloured alternative if a different look is wanted later.
