### PR TITLE
Server-side device-usage stats: per-device effectiveness metrics, events, and recording toggle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,6 +256,8 @@ SOURCE_FILES= \
 			  $(SRC_DIR)/GameServer/TgGame/TgDevice/PopulateInstigatorEquippedDevices/TgDevice__PopulateInstigatorEquippedDevices.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/TgDevice_Morale/SendMoraleBoostMessage/TgDevice_Morale__SendMoraleBoostMessage.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/Morale/MoraleCredit.cpp \
+			  $(SRC_DIR)/GameServer/TgGame/_effect_core/BuffWindowTracking.cpp \
+			  $(SRC_DIR)/GameServer/TgGame/_effect_core/CleanseTracking.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/_effect_core/DeviceCategorySkill.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/_effect_core/HitSituationalMitigation.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/_effect_core/ScaleTargetProperties.cpp \

--- a/docs/claude/device-stats-mmr-handoff.md
+++ b/docs/claude/device-stats-mmr-handoff.md
@@ -1,0 +1,166 @@
+# Device-usage stats → ga-mm integration handoff
+
+For the MMR-rework work on the **`ga-mm` branch**. This doc lives on the
+**`device-usage-metrics` branch** — if you are reading from ga-mm, fetch it from
+there (`git show device-usage-metrics:docs/claude/device-stats-mmr-handoff.md`).
+It is written to be self-contained: everything the perf engine needs to consume
+the new data is here, including the traps.
+
+**The problem this solves for ga-mm:** the perf engine's medic signal today is
+raw `healing` from `ga_match_player_stats`, which cannot distinguish a
+wave-spammer from a rescue medic. The device-usage branch records per-device
+effectiveness server-side; this doc says what exists, what it means, and how to
+fold it into the per-archetype performance model.
+
+---
+
+## 1. What exists
+
+### 1a. `ga_match_device_stats` — per-device aggregates
+
+Keyed `(instance_id, character_id, task_force, device_id)`. Written by the game
+DLL over IPC: every 60s during the match (safety flush), at player leave, and at
+mission end. Upserts of absolute totals — resend-safe, survives reconnects
+(keyed by character, not connection), uncapped row count.
+
+| Column | Meaning | Trust notes |
+|---|---|---|
+| `uses` | activations (per hold for continuous fire; boost casts detected via effect application, since morale abilities never enter DeviceFiring) | high for activatables; ≈shots for semi-auto weapons |
+| `damage` | post-mitigation damage to enemies | team damage excluded |
+| `healing` | HP actually restored **on others** (clamped to missing health) | self-heal and own pets/gear excluded |
+| `player_kills` / `bot_kills` | killing blows, device-attributed | |
+| `debuffs_removed` | effect groups stripped by this device's cleanses | provenance-gated: the per-impact mitigation bracket, Rest/stealth housekeeping polls, and invuln refcounting can never count. Self-cleanse **counts** (Sealed Systems is self-target by design) |
+| `overheal` | heal magnitude clamped away on topped-up targets | `healing + overheal` = total heal output. CAUTION: includes on-hit heal riders (e.g. the Death-Medic backstab heal recorded ~14k overheal on a poison dagger in testing) — filter by device class if using as a medic-discipline signal |
+| `power_restored` / `power_wasted` | Power Pool (prop 243) split at the pool cap | Triage Wave is exempt (its +250 rider always overflows the 160-max pool; a designed rescue, not waste) |
+| `rescues` | under-25% conditional deliveries: Triage's own conditional group + Group Heal Savior triggers on the delivering group heal | **self-rescues excluded** (own grenade while low) |
+| `buffed_damage_dealt` | damage dealt by pawns while under this device's offensive buff (Frenzy Wave) | credited to the buff's caster; the shooter's weapon row is separate — no double counting |
+| `protected_damage_taken` | damage taken by pawns under this device's defensive buff (Protection Wave, Protection Boost, Group Heal Savior) | self-protection counts here (unlike `rescues`) — it measures the buff's work, not altruism |
+| `boost_targets` | distinct boost applications (reach). `÷ uses` = players caught per cast | Healing Boost currently; extend in `BuffWindowTracking.cpp` / `MatchStats.cpp` tables |
+| `boost_overwrites` / `boost_wasted_secs` | times this medic's **live** boost was replaced by another caster (newest-wins), and the lifetime lost | lands on the *victim* medic's row — descriptive, not blame (see §3) |
+
+Joins: `user_id` → `ga_users.id` (**use `ga_users.username` for names** —
+`ga_players` is a session table, cleared on restart). Device names:
+`asm_data_set_items.item_id = device_id` → `name_msg_id` →
+`asm_data_set_msg_translations.message` (note: `item_id`, NOT `ref_device_id`).
+
+### 1b. `ga_match_events` — new event types
+
+All timestamped (`game_time`), same identity columns as existing KILL/DEATH rows.
+
+| event_type | actor | target | owner | device_id | detail | flags |
+|---|---|---|---|---|---|---|
+| `CLEANSE` | cleanser | cleansed pawn | — | cleansing device | category purged (join `asm_data_set_valid_values.value_id`) | strip count |
+| `SAVIOR` | medic | rescued pawn | — | delivering group heal | 852 | — |
+| `DEVICE_USED` | user | — | — | device | — | — |
+| `BOOST_APPLY` | caster | recipient | — | boost | — | — |
+| `BOOST_OVERWRITE` | the overwriter | recipient | **the medic whose ticks were lost** | the wasted boost | seconds remaining | — |
+
+`DEVICE_USED` is allowlisted (Group Heals family from data + the three boosts) so
+weapons never flood the table. A cast's `BOOST_APPLY` rows minus its
+`BOOST_OVERWRITE` rows = fresh coverage — the "was the second medic's cast
+justified" ratio. `SAVIOR` with actor == target is a self-rescue (evented,
+excluded from the counter).
+
+---
+
+## 2. Gating — why ga-mm can trust the data
+
+Recording resolves per instance at IPC HELLO, as
+`global AND per-queue`:
+
+- master `stats_enabled` — false on home maps (nothing records there, ever)
+- global `device_stats_enabled` / `effectiveness_enabled` — `control-server.json`, default true
+- per-queue `ga_queues.record_device_stats` / `record_effectiveness` — **default 0; seeded 1 only for `merc` and `1v1`** (one-time seed on column creation; later manual toggles survive restarts)
+
+**Consequence for ga-mm: device stats exist only for competitive queues by
+construction.** PvE farming can't reach this data, so no bot-inflation
+filtering is needed on the consumption side. (This mirrors the perf engine's
+existing choice to read matches, and is stricter.) `queue_id = 0` ad-hoc
+instances fall back to the globals — dev-test data; exclude by joining
+`ga_instances.queue_id != 0` if it matters.
+
+Also excluded at source: all jetpacks (asm slot 806), Bionics, Regeneration,
+Power Stim (+ tier variants) — extension point in `MatchStats.cpp`
+(`g_excludedDevices`).
+
+---
+
+## 3. Candidate medic signals for the perf model
+
+The archetype-premium structure in `MmrService` ("signals that don't matter
+within a class drop out") is exactly where these belong. Suggested per-player
+per-match features, all derivable from `ga_match_device_stats` aggregated over
+the player's rows:
+
+| Signal | Formula | What it separates |
+|---|---|---|
+| effective-heal ratio | `SUM(healing) / NULLIF(SUM(healing + overheal), 0)` over medic-kit devices | discipline vs wave-spam (filter to heal-class devices to dodge the rider-heal caveat) |
+| rescues | `SUM(rescues)` | clutch play under pressure; already self-excluded |
+| cleanses | `SUM(debuffs_removed)` | counterplay awareness |
+| damage enabled | `SUM(buffed_damage_dealt)` | Frenzy timing/targeting |
+| damage absorbed | `SUM(protected_damage_taken)` | Protection timing/targeting |
+| boost efficiency | reach `SUM(boost_targets)/SUM(uses)`; freshness from events: `(APPLY − OVERWRITE) / APPLY` per cast | placement + inter-medic coordination |
+| boost victimhood | `boost_overwrites` / `boost_wasted_secs` | NOT a skill signal for the row's owner — being stomped is the *other* medic's timing. Use as a match-context covariate or ignore; do not penalize |
+
+Aggregation shape (mirrors how the engine already reads
+`ga_match_player_stats`):
+
+```sql
+SELECT ds.instance_id, ds.user_id, ds.character_id,
+       SUM(ds.healing) heal, SUM(ds.overheal) overheal,
+       SUM(ds.rescues) rescues, SUM(ds.debuffs_removed) cleansed,
+       SUM(ds.buffed_damage_dealt) dmg_enabled,
+       SUM(ds.protected_damage_taken) dmg_absorbed,
+       SUM(ds.boost_targets) boost_reach, SUM(ds.uses) uses
+FROM ga_match_device_stats ds
+GROUP BY ds.instance_id, ds.user_id, ds.character_id;
+```
+
+`LEFT JOIN` this against the engine's match rows on
+`(instance_id, character_id)`; absent rows = zeros (older matches predate
+recording — treat as missing, not zero, when normalizing).
+
+---
+
+## 4. Caveats the model must respect
+
+1. **Neutral counters, judgment in events.** `boost_overwrites` on A's row is a
+   fact about what happened TO A. The fairness metric for B lives in the event
+   stream (fresh-coverage ratio). Do not turn either into a naive penalty.
+2. **Waves never affect their caster** (game rule) — a solo-queue medic's heal
+   numbers depend on having teammates near; normalize by match context.
+3. **`uses` semantics vary by device class** — activations for waves/boosts,
+   ≈shots for weapons. Only ratio within a device, never across classes.
+4. **Cleanse misses are invisible for waves** (the game pre-filters
+   non-matching remove-groups upstream — measured), but visible for
+   self-cleansers. "Cast but nothing to cure" needs `DEVICE_USED` joins, not
+   counters.
+5. **Triage vs Savior**: Triage never procs Group Heal Savior (measured,
+   single-cast tests). Triage rescues arrive via its own conditional;
+   wave/grenade rescues via SAVIOR. `rescues` already unifies both — don't
+   double-count by also counting SAVIOR events.
+6. **Rows can lag up to 60s** mid-match (flush cadence); events are immediate.
+   Final totals land at mission end — the engine's post-match consumption
+   pattern is unaffected.
+7. Skill-sourced oddities recorded faithfully but worth knowing: Combat
+   Off-Hand Utility buffs the *target* of Area Poisons (confirmed live, design
+   intent unknown); the Death-Medic backstab heal rider lands on the enemy and
+   shows as overheal on daggers.
+
+---
+
+## 5. Where the code is
+
+Branch `device-usage-metrics` (fork), all pushed. Recording:
+`src/GameServer/Stats/MatchStats.{hpp,cpp}` (entry points, registries,
+exclusions, toggles), `src/GameServer/Stats/DeviceStats.cpp` (baseline mirror),
+`src/GameServer/TgGame/_effect_core/{CleanseTracking,BuffWindowTracking,EffectCredit}`
+(provenance + windows), hook sites in `TgEffect__TrackStats.cpp` /
+`TgEffect__CheckEffectBuffModifier.cpp` /
+`TgEffectManager__RemoveEffectGroupsByCategory.cpp`. Control-server side:
+`IpcServer.cpp` (HELLO_ACK toggles, MATCH_DEVICE_STATS handler),
+`Database.{hpp,cpp}` (schema, upsert, queue toggles). Protocol:
+`src/Shared/IpcProtocol.hpp`.
+
+Verification record: instances 202–213 in the dev DB, plus
+`docs/claude/effective-device-use.md` (measured corrections flagged inline).

--- a/docs/claude/effective-device-use.md
+++ b/docs/claude/effective-device-use.md
@@ -10,9 +10,10 @@ parentheses after names only where you will need them to query.
 **Verification status.** Effect-group anatomy, property ids and device/skill names are read
 directly from `gaa.db` (not the repo's `server.db` — that one does not have the populated
 `asm_data_set_*` tables). Code paths are read from `src/`. The `ApplyHit` dispatch order in §2 is
-quoted from [`issues/killer-instinct-diag.md`](theorycraft-console/issues/killer-instinct-diag.md),
-which read it from the UnrealScript source and verified the behaviour in game on 2026-08-02 — I did
-not re-derive it. Three things I could **not** verify are flagged inline as ⚠ and collected in §8.
+quoted from `docs/claude/theorycraft-console/issues/killer-instinct-diag.md`, **which lives on the
+`theorycraft-console` branch, not on `master`** — check that branch out to read it. It took the
+order from the UnrealScript source and verified the resulting behaviour in game on 2026-08-02; I
+did not re-derive it. Three things I could **not** verify are flagged inline as ⚠ and collected in §8.
 
 ---
 
@@ -145,10 +146,17 @@ as a player action:
 
 - **Category 862 (Invulnerable)** — the function decrements `r_nInvulnerableCount` as a special
   case. That is refcount bookkeeping.
-- **`RemoveEffectGroupsByCategory(431, 99)`** is used by `HitSituationalMitigation` as the
-  *closing bracket of damage mitigation* (see the Killer Instinct fix, §6 of that doc). It fires on
-  **every single damaging impact in the game**. If you instrument the function's entry point
-  naively you will log a "cleanse" for every bullet that lands anywhere on the server.
+- **`RemoveEffectGroupsByCategory(431, 99)`** is used by
+  `src/GameServer/TgGame/_effect_core/HitSituationalMitigation.cpp` as the *closing bracket of
+  damage mitigation*. It fires on **every single damaging impact in the game**. If you instrument
+  the function's entry point naively you will log a "cleanse" for every bullet that lands anywhere
+  on the server.
+
+  ⚠ **Check your branch base for this one.** `HitSituationalMitigation` arrived with the Killer
+  Instinct fix (upstream PR #65) and is present on `upstream/master`, but **not** on the fork's
+  `master` at the time of writing — the fork was 9 commits behind. So the 431 caller may or may not
+  exist in your tree. It is a trap the moment you rebase onto upstream, so write the instrumentation
+  as though it is there regardless.
 
 Gate your instrumentation on the call arriving from the property-140 path, not on the function
 being entered. If that is awkward to detect from inside, pass a flag from `ApplyEffect`, or

--- a/docs/claude/effective-device-use.md
+++ b/docs/claude/effective-device-use.md
@@ -273,10 +273,14 @@ That is the mechanism — the skill effect group rides along on any hit, and `re
 filters it to hits delivered by a device in that family. Same mechanism scopes Killer Instinct to
 Recon Rifles (327).
 
-Note the overlap: **Triage Wave is itself a Group Heal**, so a Triage Wave landing on a team-mate
-under 25% triggers *both* its own conditional group *and* Group Heal Savior, from the same impact,
-at dispatch sites 1409 and 1411 respectively. If you count "effective conditional triggers" as one
-number, that single impact contributes two.
+> **CORRECTED 2026-08-04 (measured, instances 204/205/207/208).** The overlap this section
+> originally asserted — Triage Wave triggering *both* its own conditional *and* Group Heal Savior
+> from one impact — is **wrong**. Single-cast tests show **Triage Wave never procs Group Heal
+> Savior**: a solo Triage rescue applies eg 22375 and no 16587; a solo Healing Wave rescue applies
+> 16587 and nothing else. Healing Wave and Healing Grenade both proc it. Mechanism unestablished
+> (the three devices carry identical family-252 linkage in the data); the behaviour is measured,
+> not explained. Also measured: a skill-sourced instance's `m_nSourceDeviceInstId` reliably carries
+> the **delivering** device's inventory id, so GHS triggers are device-attributable after all.
 
 ### Recording it
 

--- a/docs/claude/effective-device-use.md
+++ b/docs/claude/effective-device-use.md
@@ -248,8 +248,13 @@ There are only five, which makes this a small and testable surface:
 
 > The Combat Off-Hand Utility row is odd: that skill's description is *"Increases the explosion
 > radius of Combat Offhands"*, which has nothing to do with a protection-and-speed buff gated on
-> target health. It is scoped to Area Poisons (skill 336). Treat it as a suspected authoring
-> leftover, not as a feature to instrument, until someone confirms it does anything in game.
+> target health. It is scoped to Area Poisons (skill 336).
+>
+> **CONFIRMED LIVE 2026-08-04 (instance 212):** not a leftover — eg 26474 fires constantly on a
+> poison build, applying +5 Phys/+10% speed per Area Poison hit against targets above 75% HP,
+> `srcSkillId=336` exactly as authored. The buff lands on the TARGET of the poison (observed on
+> enemy bots), which is even stranger than the description mismatch — buffing the enemy you
+> poison. Mechanically real; design intent still unexplained.
 
 ---
 

--- a/docs/claude/effective-device-use.md
+++ b/docs/claude/effective-device-use.md
@@ -1,0 +1,383 @@
+# Effective vs. ineffective device use — how the game decides, and where to observe it
+
+Handoff for the device-usage metrics work. Covers four things the current per-instance device
+stats do not record: **cleanses**, **Triage Wave's conditional half**, **Group Heal Savior**, and
+**boost activations**.
+
+Everything here is about the **server**, not the theorycrafting console. Ids are given in
+parentheses after names only where you will need them to query.
+
+**Verification status.** Effect-group anatomy, property ids and device/skill names are read
+directly from `gaa.db` (not the repo's `server.db` — that one does not have the populated
+`asm_data_set_*` tables). Code paths are read from `src/`. The `ApplyHit` dispatch order in §2 is
+quoted from [`issues/killer-instinct-diag.md`](theorycraft-console/issues/killer-instinct-diag.md),
+which read it from the UnrealScript source and verified the behaviour in game on 2026-08-02 — I did
+not re-derive it. Three things I could **not** verify are flagged inline as ⚠ and collected in §8.
+
+---
+
+## 1. The two recording surfaces you already have
+
+| | `DeviceStats` | `MatchStats` |
+|---|---|---|
+| Where | `src/GameServer/Stats/DeviceStats.{hpp,cpp}` | `src/GameServer/Stats/MatchStats.hpp` |
+| Shape | counters on a per-device row | discrete event rows over IPC |
+| Storage | `ATgRepInfo_Player::r_DeviceStats[9]`, replicated owner-only | `ga_match_events` via the control server |
+| Reaches the client | yes, end-of-mission Device Stats tab | no |
+| Cost per record | none (an `int +=`) | an IPC message |
+
+**`FDeviceStatInfo::Stats` is 11 ints wide (`Stats[0xB]`). The server writes 0–6.**
+
+```
+0 device id   1 damage   2 healing   3 player kills   4 bot kills   5 DPM   6 HPM
+7 8 9 10  ← unused, already replicating
+```
+
+So there are **four free replicated slots per device row** and you do not need to touch the struct
+or the replication list to start counting. The catch is the other end: the client's row builder
+(`UTgUIDeviceStats` vtable +0x130 → 0x11463870) walks the first 8 rows and prints `Stats[1..6]`
+verbatim. Slots 7–10 will replicate and arrive intact but render nowhere without client-side work.
+
+Rough guidance:
+
+- **A counter that belongs next to damage/healing on the device tab** → `DeviceStats`, slots 7–10.
+- **"this specific thing happened, with context"** → `MatchStats`. It carries `event_type`,
+  `detail` and `flags`, so it can hold "which category was purged" or "target was at 18%" in a way
+  a bare counter cannot.
+
+Both are per-instance already, and `MatchStats` no-ops entirely unless `SetEnabled(true)` arrived
+in `INSTANCE_HELLO_ACK` — home maps are off, which is almost certainly what you want.
+
+---
+
+## 2. The pipeline, once, because all four features hang off it
+
+A device firing resolves synchronously, all the way to the property write:
+
+```
+TgDeviceFire.ApplyHit
+  └─ SubmitHitEffects(instigator, impact, eSource, nType, nSituationalType)
+       ├─ eSource 0 → TgDeviceFire.GetEffectGroup          (the device's own groups)
+       └─ eSource 1 → TgEffectManager.GetSkillBasedEffectGroup  (the player's slotted skills)
+            └─ SubmitEffect → TgEffectManager.ProcessEffect
+                 └─ TgEffectGroup.ApplyEffects
+                      └─ TgEffect.ApplyEffect → ApplyToProperty
+```
+
+`ApplyHit`'s dispatch order — this matters because it tells you *when* in a single impact each
+thing is decided:
+
+```
+1404   SubmitHitEffects(.., 0, 272)             HIT_IN_AIR
+1409   SubmitHitEffects(.., 0, 505, 1270)       device,  HP-below     ← Triage Wave
+1410   SubmitHitEffects(.., 0, 505, 1271)       device,  HP-above
+1411   SubmitHitEffects(.., 1, 505, 1270)       skill,   HP-below     ← Group Heal Savior
+1412   SubmitHitEffects(.., 1, 505, 1271)       skill,   HP-above     ← Killer Instinct
+1445   SubmitHitEffects(.., 0, 264)             device: base damage/heal, then device debuffs
+1480   SubmitHitEffects(.., 0, 505, 509)        backstab
+1491   SubmitHitEffects(.., 1, 505, melee)      situational melee
+1495   SubmitHitEffects(.., 1, 264)             skill
+```
+
+Two consequences worth internalising:
+
+1. **The HP-gated block runs BEFORE the damage/heal submit at 1445.** So when a Group Heal Savior
+   or Triage Wave gate is evaluated, the target's health is still its *pre-heal* value. A target
+   at 20% that your wave is about to heal to 60% is judged at 20% — which is the behaviour you
+   want, but it means you cannot reconstruct the decision after the fact from post-impact health.
+   **Record at decision time or not at all.**
+2. Every other situational dispatch sits *after* the damage submit. Only the HP-gated block is
+   ahead of it. That asymmetry was the root of the Killer Instinct self-shot bug and is documented
+   as an authoring slip in the original data, not a design.
+
+**Effect group types** (`effect_group_type_value_id`): 261 Equip · 263 Fire · **264 Hit** · 266 Aim
+· 283 Equip Mode · **505 Hit Situational** · 759 Successful Hit · 1104 Reactive (skills only).
+
+**Situational types** (`situational_type_value_id`): 506 Crouch · 507 Jump · 508 Sprint · 509
+Backstab · 718 Block Breaker · **1270 Health-Below** · **1271 Health-Above**.
+
+> ⚠ **Trap.** `situational_type_value_id` is populated on nearly every effect group row, including
+> ones that are not situational at all — plain type-264 groups almost all read 509 (Backstab)
+> because that is the column's default. **The field is only meaningful when
+> `effect_group_type_value_id = 505`.** Filtering on `situational_type_value_id` alone will give
+> you hundreds of false positives.
+
+---
+
+## 3. Cleanses
+
+### What one is
+
+Property **140, "Remove Effect"**. One effect row per category purged, sitting in its own effect
+group. `base_value` is the quantity — in practice always **99** or 100, i.e. "all of them".
+
+The category to purge comes from the effect's `property_value_id`, and the quantity from
+`base_value`. `TgEffect.ApplyEffect` sees `m_nPropertyId == 140` and calls:
+
+```
+TgEffectManager::RemoveEffectGroupsByCategory(nCategoryCode, nQuantity)
+```
+
+⚠ The category ← `property_value_id` and quantity ← `base_value` mapping is inferred from the data
+shape (the values are exactly `Poison`/`Ignite`/… and 99) plus the header comment on our
+reimplementation. I did not read the UnrealScript for `ApplyEffect` — see §8.
+
+### The count you want already exists and is being thrown away
+
+`src/GameServer/TgGame/TgEffectManager/RemoveEffectGroupsByCategory/TgEffectManager__RemoveEffectGroupsByCategory.cpp`
+is **our code** (the shipped native is a stub at `0x10a6ef20`). It already maintains a local
+`removed` counter as it walks `s_AppliedEffectGroups` backwards, and then discards it:
+
+```cpp
+int removed = 0;
+for (...) { ...; removed++; }
+if (removed > 0) Manager->bNetDirty = 1;
+return removed > 0;          // ← the count dies here
+```
+
+This is the cheapest win in the whole document. `Manager->r_Owner` is the pawn that got cleansed;
+`removed` is exactly "how many debuffs this wave stripped off this target".
+
+### ⚠⚠ The one trap that will wreck your numbers
+
+**Not every call to this function is a cleanse.** Two internal callers use it as a mechanism, not
+as a player action:
+
+- **Category 862 (Invulnerable)** — the function decrements `r_nInvulnerableCount` as a special
+  case. That is refcount bookkeeping.
+- **`RemoveEffectGroupsByCategory(431, 99)`** is used by `HitSituationalMitigation` as the
+  *closing bracket of damage mitigation* (see the Killer Instinct fix, §6 of that doc). It fires on
+  **every single damaging impact in the game**. If you instrument the function's entry point
+  naively you will log a "cleanse" for every bullet that lands anywhere on the server.
+
+Gate your instrumentation on the call arriving from the property-140 path, not on the function
+being entered. If that is awkward to detect from inside, pass a flag from `ApplyEffect`, or
+instrument at the `ApplyEffect` site instead and read the return value.
+
+### Who actually cleanses
+
+Player-equippable, from `gaa.db`:
+
+| Device | Categories it removes |
+|---|---|
+| **Healing Wave** | Poison, Ignite, Disease, Slow, Stun, Power Pool Debuff, General Debuff |
+| **Neutralize Wave** | Damage Reflect, Ability, Morale Buff, General Buff, Personal Damage Buff, Personal Shield, Shield Movement Penalty, Proximity Damage Buff, Proximity Shield, Regeneration, Regen Damage Penalty, Stim Boost, Stim Resistance, Self Heal, Power Pool Buff |
+| **Sealed Systems** | Stun, Poison, Ignite, Additional Damage, Disease |
+| **Healing Grenade** | Poison, Ignite, Disease |
+| **Purity** | Poison, Ignite, Disease |
+| **Detoxicant Device** | Poison, Disease |
+| **Bionics** | Slow |
+| Burst Nanite (dev) | Regeneration |
+
+Note **Neutralize Wave strips buffs off enemies** — it is offensive cleansing. If "effective
+cleanse" is going to be a single metric, it will be averaging two quite different actions.
+
+### Counting it
+
+**One Healing Wave cast produces seven separate calls per target hit** — one per category, each
+its own effect group (eg 7956, 7957, 16651, 18931–18934). So:
+
+- *used* = the wave fired.
+- *effective* = `removed > 0` on at least one of the seven, for at least one target.
+- *debuffs removed* = the sum of `removed` across all seven, across all targets.
+
+These are three different numbers and they will diverge a lot. A wave that hits five clean
+team-mates is "used, ineffective, 0 removed". A wave that hits one team-mate carrying poison and
+burn is "used, effective, 2 removed".
+
+Since waves are area effects, **decide up front whether your unit is the cast or the target**. I
+would record per target and aggregate, because per-cast throws away the thing that makes the stat
+interesting.
+
+---
+
+## 4. Triage Wave
+
+Device **5808**. Two effect groups, and this is the whole story:
+
+| Effect group | Type | Gate | Gives |
+|---|---|---|---|
+| **22392** | 264 Hit | none — always | Health 600 |
+| **22375** | **505 Hit Situational** | **Health-Below 25%** | Health 600 **+ Power Pool 250** |
+
+So:
+
+- **Baseline:** every target hit gets 600 health, unconditionally.
+- **Effective use:** the target was under 25% health, so 22375 *also* applied — a second 600 health
+  (1200 total) **and all 250 power**.
+
+**This answers the power question directly: the power restore lives only in the conditional group.**
+A Triage Wave that hits nobody under 25% restores no power at all. That makes "did any power land"
+a clean, unambiguous proxy for effective use — arguably a better signal than the health, because
+the health is ambiguous between the two groups.
+
+Application rule is **Stackable** (`application_value_id` 155), so the conditional half does not
+displace or refresh the unconditional half; both land.
+
+### Where the decision is made
+
+`UTgDeviceFire::ShouldSituationalApplyEffect(ATgPawn* TargetPawn, UTgEffectGroup* EffectGroup)`
+returns bool and is the single chokepoint for **every** 505 group in the game. It has everything
+you need in its arguments: the target, and the group (which carries `m_nSituationalType` and
+`m_fSituationalValue`).
+
+⚠ **I have not verified whether this function is intact in our binary or stripped.** We do not
+currently hook it and there is no reimplementation in `src/`. Confirm this before designing around
+it — see §8. If it is intact, hooking it is the cleanest possible instrumentation point for both
+Triage Wave and Group Heal Savior at once.
+
+### Every HP-gated effect group in the game
+
+There are only five, which makes this a small and testable surface:
+
+| Effect group | Gate | Owner | Effect | Life |
+|---|---|---|---|---|
+| 22375 | Below 25% | **Triage Wave** | Health 600 + Power Pool 250 | instant |
+| 16587 | Below 25% | skill **Group Heal Savior** (852) | Protection-Physical +10, GroundSpeed +10% | 5s |
+| 16596 | Above 75% | skill **Killer Instinct** (836) | Protection-Physical −10 | 3s |
+| 26474 | Above 75% | skill **Combat Off-Hand Utility** (806) | Protection-Physical +5, GroundSpeed +10% | 5s |
+| 27595 | Below 25% | zzHeavy Ion Sword (dev) | Health 800 | instant |
+
+> The Combat Off-Hand Utility row is odd: that skill's description is *"Increases the explosion
+> radius of Combat Offhands"*, which has nothing to do with a protection-and-speed buff gated on
+> target health. It is scoped to Area Poisons (skill 336). Treat it as a suspected authoring
+> leftover, not as a feature to instrument, until someone confirms it does anything in game.
+
+---
+
+## 5. Group Heal Savior
+
+Skill **852**, effect group **16587**, type **505**, gate **Health-Below 25%**. Grants
+Protection-Physical +10 and GroundSpeed +10% for **5 seconds**. Application rule **Refresh** (836),
+so re-triggering on an already-buffed target extends rather than stacks.
+
+In-game description: *"When you hit a teammate with a group heal and his health is under 25%, you
+provide the target with a 10% Protection and GroundSpeed bonus for 5 seconds."*
+
+### How "with a group heal" is enforced
+
+Via `required_skill_id = 252` on the effect group. Skill 252 is the **Group Heals** device family:
+
+> Healing Wave · Healing Grenade · Protection Wave · Frenzy Wave · Power Wave · **Triage Wave** ·
+> Purity
+
+That is the mechanism — the skill effect group rides along on any hit, and `required_skill_id`
+filters it to hits delivered by a device in that family. Same mechanism scopes Killer Instinct to
+Recon Rifles (327).
+
+Note the overlap: **Triage Wave is itself a Group Heal**, so a Triage Wave landing on a team-mate
+under 25% triggers *both* its own conditional group *and* Group Heal Savior, from the same impact,
+at dispatch sites 1409 and 1411 respectively. If you count "effective conditional triggers" as one
+number, that single impact contributes two.
+
+### Recording it
+
+Dispatch site is `SubmitHitEffects(.., 1, 505, 1270)` — eSource **1** (skill), not 0. The predicate
+is the same `ShouldSituationalApplyEffect`. If you instrument at that predicate you get Triage Wave
+and Group Heal Savior from one hook, distinguished by the effect group id in the argument.
+
+Attribution needs care: the *credited player* is the instigator (the medic), but the *target* is
+the team-mate. Follow the existing convention in `TgEffect__TrackStats` — pet → owner resolution
+via `r_Owner`, and skip self-effects (`Instigator == Target`, and the indirect deployable case
+`Instigator->r_Owner == Target`). Group Heal Savior on yourself should almost certainly not count.
+
+---
+
+## 6. Boosts
+
+These are structurally different from the three above: **there is no gate**. They are plain type-264
+Hit groups with a lifetime.
+
+| Device | Effect group | Life | Gives | Application rule |
+|---|---|---|---|---|
+| **Protection Boost** (2838) | 8964 | 10s | Protection-AOE +25, Protection-Ranged +25, Protection-Melee +25 | Newest Wins (156) |
+| **Healing Boost** (2773) | 8690 | 10s | Health 200 | Strongest Wins (157), priority 2000 |
+| **Fashion Boost** (7559) | 27646 | 30s | Health Max +20%, Power Pool Max +40, Effect Damage +15%, Effect Healing +15%, Power Pool Recharge +20% | — |
+
+So "activation" is not a conditional question. What varies, and what is worth measuring, is
+**reach and waste**:
+
+- **How many targets did one activation land on?** A Protection Boost that catches five team-mates
+  is doing five times the work of one that catches one. This is the number I would prioritise.
+- **Was it wasted?** Two distinct kinds:
+  - *Healing Boost on a full-health target* — the 200 health is clamped away. `TgEffect__TrackStats`
+    already computes exactly this: `effectiveHeal = min(magnitude, fMissingHealth)`. If that comes
+    out zero, the boost did nothing for that target. **You can get this for free from the existing
+    heal path** without touching the effect system at all.
+  - *Protection Boost on someone who then takes no damage for 10s* — genuinely useful, genuinely
+    harder, needs a windowed lookback. Probably phase two.
+
+⚠ **Protection Boost's three properties are an OR, not a sum.** `CalcAttackTypeProtection` is a
+switch — exactly one attack-type axis ever applies per impact (AOE *or* Melee *or* Ranged, never
+combined). So +25/+25/+25 is "+25 against whatever type this hit was", not +75. Do not report it as
+75 anywhere.
+
+The **Strongest Wins on Healing Boost** is worth a flag: per measurements taken on 2026-08-03,
+application rule 157 behaves as **newest-wins in practice** — the priority value does not block a
+later application, contradicting `TgEffectManager::IsStrongest`. So a second Healing Boost
+overriding a first is expected behaviour, not a bug, and "boost overwritten before it expired"
+would be a legitimate waste metric.
+
+---
+
+## 7. Where to hook
+
+- **UC functions** → the existing `UObject::ProcessEvent` hook,
+  `src/GameServer/Core/UObject/ProcessEvent/UObject__ProcessEvent.cpp`. It classifies once per
+  unique `UFunction*` into a `DispatchTag` and caches on the pointer, so adding a tag costs one
+  `strcmp` on first sight and a switch lookup thereafter. Add to the ladder in
+  `ClassifyFunction`, not to a per-call `strcmp`.
+- **Functions we already reimplemented** → just edit them. `RemoveEffectGroupsByCategory` is ours.
+- **Intact natives** → a `HookBase` under `src/GameServer/<Subsystem>/<Class>/<Native>/`. Note the
+  stub-vs-intact rule: if the native is a stub, `CallOriginal` is a no-op and does **not** chain to
+  parent overrides — call the parent hook explicitly. Decision is per hook.
+
+Two house rules that will save you a round trip:
+
+- **Every new `.cpp` goes into `Makefile` in the same change.** It is an explicit source list, not
+  a wildcard. Forgetting gives you an `undefined reference` at link time.
+- **Diagnostics go on a dedicated named channel** — `Logger::Log("devusage", ...)`, never
+  `GetLogChannel()` (that one drives the call-tree visualiser). Consolidate everything for this
+  work onto **one** channel before asking anyone to capture logs.
+
+---
+
+## 8. What I could not verify — check these first
+
+1. **Is `UTgDeviceFire::ShouldSituationalApplyEffect` intact or stripped in our binary?** The whole
+   of §4 and §5 assumes it is the chokepoint. We neither hook nor reimplement it today, and the
+   HP-gated features do demonstrably work in game (the Killer Instinct testing on 2026-08-02
+   exercised the same predicate and the gate behaved correctly), so *something* is evaluating it —
+   but "intact native" and "UC implementation" lead to different hooking approaches. Confirm before
+   building.
+2. **How the health percentage is computed inside that predicate.** There is a known
+   integer-division trap immediately adjacent: `ApplyHit:1287` computes
+   `(TargetPawn.Health / TargetPawn.r_nHealthMaximum) > (90 / 100)` where both sides are integer
+   division, so `90/100` folds to **0** and the left side is 0 unless the target is at *exactly*
+   full health. That bug arms the anti-one-shot health cap only at exactly 100%. If the 25%/75%
+   gates are computed the same way they would be similarly broken — and "Triage Wave never triggers
+   its conditional half" would be a much more interesting finding than a metrics gap. Worth ten
+   minutes with a test target at 24%.
+3. **The property-140 argument mapping** (category ← `property_value_id`, quantity ←
+   `base_value`). Inferred from data shape and our own header comment, not read from source.
+
+I could not read the UnrealScript for any of these: `github.com/commonwealthga/ga-source` returned
+404 unauthenticated from this machine and there is no `gh` CLI here. Anyone with repo access can
+settle all three from `TgDeviceFire.uc` and `TgEffect.uc` in about fifteen minutes.
+
+---
+
+## 9. Suggested minimum viable set
+
+If the goal is "mark effective vs ineffective use", the smallest thing that delivers real signal:
+
+| Metric | Source | Cost |
+|---|---|---|
+| Debuffs removed, per device, per player | `removed` in `RemoveEffectGroupsByCategory` | trivial — the number already exists |
+| Heal wasted on full-health targets | `effectiveHeal` clamp already in `TgEffect__TrackStats` | trivial — already computed |
+| Triage Wave conditional triggers | power landing, or `ShouldSituationalApplyEffect` returning true for eg 22375 | needs §8.1 answered |
+| Group Heal Savior triggers | same predicate, eg 16587 | same hook as above |
+| Boost targets reached per activation | count distinct targets per effect-group application | moderate |
+
+The first two need no new hooks and no answered questions. I would ship those first and treat the
+situational ones as a second pass behind the §8 checks.

--- a/docs/claude/effective-device-use.md
+++ b/docs/claude/effective-device-use.md
@@ -229,10 +229,19 @@ returns bool and is the single chokepoint for **every** 505 group in the game. I
 you need in its arguments: the target, and the group (which carries `m_nSituationalType` and
 `m_fSituationalValue`).
 
-⚠ **I have not verified whether this function is intact in our binary or stripped.** We do not
-currently hook it and there is no reimplementation in `src/`. Confirm this before designing around
-it — see §8. If it is intact, hooking it is the cleanest possible instrumentation point for both
-Triage Wave and Group Heal Savior at once.
+> **RESOLVED — and the original advice here was wrong.** This section used to say that if the
+> function were intact, hooking it would be the cleanest instrumentation point for both features.
+> It is **not hookable at all**. The SDK dump gives its flags as `[0x00020002]`; bit `0x400`
+> (`FUNC_Native`) is clear, so it is **pure UnrealScript bytecode**, neither an intact native nor a
+> stripped stub. And in this build intra-UC calls do not route through `UObject::ProcessEvent` —
+> ProcessEvent sees client RPCs, engine-timer dispatches, events, `super.` calls and native→script
+> transitions, not a script function called from another script function. So the predicate is
+> invisible to every hook we own.
+>
+> The correct approach, and the one the shipped implementation takes, is to **instrument a native
+> downstream of the decision** — `TgEffect::CheckEffectBuffModifier` runs on every effect before its
+> value is consumed and still knows the group, instigator, target and source device. Read the
+> outcome, not the decision.
 
 ### Every HP-gated effect group in the game
 
@@ -240,21 +249,35 @@ There are only five, which makes this a small and testable surface:
 
 | Effect group | Gate | Owner | Effect | Life |
 |---|---|---|---|---|
-| 22375 | Below 25% | **Triage Wave** | Health 600 + Power Pool 250 | instant |
-| 16587 | Below 25% | skill **Group Heal Savior** (852) | Protection-Physical +10, GroundSpeed +10% | 5s |
-| 16596 | Above 75% | skill **Killer Instinct** (836) | Protection-Physical −10 | 3s |
-| 26474 | Above 75% | skill **Combat Off-Hand Utility** (806) | Protection-Physical +5, GroundSpeed +10% | 5s |
-| 27595 | Below 25% | zzHeavy Ion Sword (dev) | Health 800 | instant |
+**Read the calc method, never the bare `base_value`** — every row below stores a positive number and
+the sign lives in `calc_method_value_id` (67 Add / 68 Increase +% / 69 Decrease −% / 70 Subtract):
 
-> The Combat Off-Hand Utility row is odd: that skill's description is *"Increases the explosion
-> radius of Combat Offhands"*, which has nothing to do with a protection-and-speed buff gated on
-> target health. It is scoped to Area Poisons (skill 336).
+| Effect group | Gate | Owner | Effect | Life |
+|---|---|---|---|---|
+| 22375 | Below 25% | **Triage Wave** | Health **+600** (67) + Power Pool **+250** (67) | instant |
+| 16587 | Below 25% | skill **Group Heal Savior** (852) | Protection-Physical **+10** (67), GroundSpeed **+10%** (68) — buff on the team-mate | 5s |
+| 16596 | Above 75% | skill **Killer Instinct** (836) | Protection-Physical **−10** (70) — debuff on the enemy | 3s |
+| 26474 | Above 75% | skill **Combat Off-Hand Utility** (806) | Protection-Physical **−5** (70), GroundSpeed **−10%** (69) — debuff on the enemy | 5s |
+| 27595 | Below 25% | zzHeavy Ion Sword (dev) | Health **−800** (70) — execute damage, not a heal | instant |
+
+> **Combat Off-Hand Utility is not an anomaly — two earlier readings of it here were wrong, both
+> from the same mistake.** This file first called it a suspected authoring leftover, then
+> "CONFIRMED LIVE … buffing the enemy you poison … design intent still unexplained". Both read
+> `base_value` without `calc_method_value_id`. It is calc **70 Subtract** and **69 Decrease −%** —
+> a *debuff*, and the in-game tooltip states it plainly:
 >
-> **CONFIRMED LIVE 2026-08-04 (instance 212):** not a leftover — eg 26474 fires constantly on a
-> poison build, applying +5 Phys/+10% speed per Area Poison hit against targets above 75% HP,
-> `srcSkillId=336` exactly as authored. The buff lands on the TARGET of the poison (observed on
-> enemy bots), which is even stranger than the description mismatch — buffing the enemy you
-> poison. Mechanically real; design intent still unexplained.
+> > "Increases the effect radius of Combat Off-Hands. When you hit someone with a Combat Offhand and
+> > they are over 75% health, the target's Protection is reduced by 5% and GroundSpeed by 10% for 5
+> > seconds."
+>
+> So the live observation was right — it fires constantly on a poison build, lands on the target,
+> `srcSkillId=336` — and only the interpretation was wrong. It is Killer Instinct's shape at lower
+> numbers on a different weapon family, and there is nothing left to explain.
+>
+> Two data caveats behind the confusion. `asm_data_set_skill_group_skills.desc_msg_translated`
+> carries only the first clause ("Increases the explosion radius of Combat Offhands"); the client
+> tooltip carries both, so the DB description is **not** the full skill text and a mismatch against
+> it means nothing. And a positive `base_value` on a protection effect says nothing about direction.
 
 ---
 
@@ -290,8 +313,9 @@ Recon Rifles (327).
 ### Recording it
 
 Dispatch site is `SubmitHitEffects(.., 1, 505, 1270)` — eSource **1** (skill), not 0. The predicate
-is the same `ShouldSituationalApplyEffect`. If you instrument at that predicate you get Triage Wave
-and Group Heal Savior from one hook, distinguished by the effect group id in the argument.
+is the same `ShouldSituationalApplyEffect`, which is **not instrumentable** (see the resolved note
+in §4) — observe the applied effect group downstream instead, and distinguish the two features by
+effect group id: 22375 Triage Wave, 16587 Group Heal Savior.
 
 Attribution needs care: the *credited player* is the instigator (the medic), but the *target* is
 the team-mate. Follow the existing convention in `TgEffect__TrackStats` — pet → owner resolution
@@ -357,26 +381,58 @@ Two house rules that will save you a round trip:
   `GetLogChannel()` (that one drives the call-tree visualiser). Consolidate everything for this
   work onto **one** channel before asking anyone to capture logs.
 
+### ⚠ Two poison protections, and the names lie
+
+There are **two** poison-shaped protection properties on two different axes, and `TgProperties.h`
+and `gaa.db` label them in opposite ways:
+
+| Prop | Axis | Consulted by | `TgProperties.h` | `gaa.db` |
+|---|---|---|---|---|
+| **159** | status **category** (Poison, cat 303) | `CalcCategoryProtection` | `TGPID_PROTECTION_POISON` | "Protection - Biological" |
+| **324** | damage **type** (Poison, type 897) | `CalcDamageTypeProtection` | `TGPID_PROTECTION_BIO` | "Protection - Poison" |
+
+Whichever source you trust, the other looks like the error. The engine only ever sees the id, so
+neither label is authoritative — the split is established from how the data groups them:
+
+- `HUMAN BASE ATTRIBUTES` (device 864) moves **155/156/157/324** as a quartet, matching the four
+  damage types exactly: Physical, Fire, Energy, Poison.
+- Every device that grants 159 pairs it with *category* protections — Sealed Systems (159 with
+  Disease/Stun/Ignite), Scorpion Shell, Perfect Target, Super Shell (159 with Ignite/Bleed).
+- The Invulnerable Volume (eg 8698) raises **both in one group at different tiers**: 155/156/157/324
+  and the attack types at 100, 159 and Ignite at 200.
+
+Reach for **159** when you mean a poison DoT, **324** when you mean poison-typed damage. Same
+comment now sits on both constants in `src/GameServer/Constants/TgProperties.h`.
+
+Harmless today — `TgPawn__InitializeDefaultProps` seeds both identically (raw 0, min 0, max 1000)
+and every consumer reads by id — but it is live the first time someone writes category code and
+picks the constant by its name.
+
+There is **no protection property of any kind for category 986 (Additional Damage)**. Ten status
+categories have one; that one does not. So an Additional-Damage debuff can be cleansed but never
+refused — which is why Sealed Systems strips the Pain Gun's +30% amplifier and cannot block it.
+
 ---
 
 ## 8. What I could not verify — check these first
 
-1. **Is `UTgDeviceFire::ShouldSituationalApplyEffect` intact or stripped in our binary?** The whole
-   of §4 and §5 assumes it is the chokepoint. We neither hook nor reimplement it today, and the
-   HP-gated features do demonstrably work in game (the Killer Instinct testing on 2026-08-02
-   exercised the same predicate and the gate behaved correctly), so *something* is evaluating it —
-   but "intact native" and "UC implementation" lead to different hooking approaches. Confirm before
-   building.
-2. **How the health percentage is computed inside that predicate.** There is a known
-   integer-division trap immediately adjacent: `ApplyHit:1287` computes
-   `(TargetPawn.Health / TargetPawn.r_nHealthMaximum) > (90 / 100)` where both sides are integer
-   division, so `90/100` folds to **0** and the left side is 0 unless the target is at *exactly*
-   full health. That bug arms the anti-one-shot health cap only at exactly 100%. If the 25%/75%
-   gates are computed the same way they would be similarly broken — and "Triage Wave never triggers
-   its conditional half" would be a much more interesting finding than a metrics gap. Worth ten
-   minutes with a test target at 24%.
+1. ~~**Is `UTgDeviceFire::ShouldSituationalApplyEffect` intact or stripped?**~~ **RESOLVED: neither
+   — it is pure UnrealScript** (`[0x00020002]`, no `FUNC_Native`), and intra-UC calls are invisible
+   to `UObject::ProcessEvent` in this build, so it cannot be hooked. Instrument a native downstream
+   of it. See the resolved note in §4.
+2. ~~**How the health percentage is computed inside that predicate.**~~ **RESOLVED by measurement.**
+   The worry was that the gates might use the integer-division pattern at `ApplyHit:1287` —
+   `(TargetPawn.Health / TargetPawn.r_nHealthMaximum) > (90 / 100)`, where `90/100` folds to **0**
+   and the left side is 0 unless the target is at *exactly* full health, which is why the
+   anti-one-shot health cap only arms at 100%. The situational gates do **not** behave that way:
+   Triage Wave's eg 22375 fires on real sub-25% rescues, and Combat Off-Hand Utility's above-75%
+   gate fires constantly (instances 204/205/207/208/212). Both directions work. The `ApplyHit:1287`
+   integer-division bug is still real and still only affects the health cap.
 3. **The property-140 argument mapping** (category ← `property_value_id`, quantity ←
-   `base_value`). Inferred from data shape and our own header comment, not read from source.
+   `base_value`). Inferred from data shape and our own header comment, not read from source. Still
+   open — `CleanseTracking` notes the same gap for the ordering of the 140 branch relative to
+   `TgEffect.uc:115`, and degrades to "unattributed" rather than miscounting if the assumption is
+   wrong.
 
 I could not read the UnrealScript for any of these: `github.com/commonwealthga/ga-source` returned
 404 unauthenticated from this machine and there is no `gh` CLI here. Anyone with repo access can
@@ -392,8 +448,8 @@ If the goal is "mark effective vs ineffective use", the smallest thing that deli
 |---|---|---|
 | Debuffs removed, per device, per player | `removed` in `RemoveEffectGroupsByCategory` | trivial — the number already exists |
 | Heal wasted on full-health targets | `effectiveHeal` clamp already in `TgEffect__TrackStats` | trivial — already computed |
-| Triage Wave conditional triggers | power landing, or `ShouldSituationalApplyEffect` returning true for eg 22375 | needs §8.1 answered |
-| Group Heal Savior triggers | same predicate, eg 16587 | same hook as above |
+| Triage Wave conditional triggers | eg 22375 applying (or its Power Pool restore landing) | native downstream of the gate |
+| Group Heal Savior triggers | eg 16587 applying | same hook as above |
 | Boost targets reached per activation | count distinct targets per effect-group application | moderate |
 
 The first two need no new hooks and no answered questions. I would ship those first and treat the

--- a/src/ControlServer/Config/ControlServerConfig.cpp
+++ b/src/ControlServer/Config/ControlServerConfig.cpp
@@ -105,6 +105,10 @@ ControlServerConfig ControlServerConfig::Load(const std::string& path) {
     if (j.contains("show_game_console"))  cfg.show_game_console  = j["show_game_console"].get<bool>();
     if (j.contains("allow_duplicate_account_logins"))
         cfg.allow_duplicate_account_logins = j["allow_duplicate_account_logins"].get<bool>();
+    if (j.contains("device_stats_enabled"))
+        cfg.device_stats_enabled = j["device_stats_enabled"].get<bool>();
+    if (j.contains("effectiveness_enabled"))
+        cfg.effectiveness_enabled = j["effectiveness_enabled"].get<bool>();
     if (j.contains("require_password_verification"))
         cfg.require_password_verification = j["require_password_verification"].get<bool>();
 

--- a/src/ControlServer/Config/ControlServerConfig.hpp
+++ b/src/ControlServer/Config/ControlServerConfig.hpp
@@ -85,6 +85,14 @@ struct ControlServerConfig {
     bool        clear_logs         = false;  // truncate per-channel files at boot for repeated tests
     bool        show_game_console  = false;  // Windows native debug: show spawned game commandlet consoles
     bool        allow_duplicate_account_logins = false;
+    // Per-instance stats recording toggles, forwarded to game instances in
+    // INSTANCE_HELLO_ACK. device_stats = the server-side mirror of the
+    // client Device Stats tab counters (ga_match_device_stats baseline);
+    // effectiveness = everything layered on top (cleanse/boost/power/savior
+    // tracking, buff windows, uses, DEVICE_USED events). The client's own
+    // tab is unaffected by either. Flip + restart control server; no rebuild.
+    bool        device_stats_enabled  = true;
+    bool        effectiveness_enabled = true;
     // When true (default), the login handler verifies the RC4 credential blob
     // against the account's stored verifier (first login registers it). Set
     // false to fall back to the old username-only behavior — an emergency

--- a/src/ControlServer/Database/Database.cpp
+++ b/src/ControlServer/Database/Database.cpp
@@ -2140,6 +2140,9 @@ void Database::Init() {
 			"  buffed_damage_dealt    INTEGER NOT NULL DEFAULT 0,"
 			"  protected_damage_taken INTEGER NOT NULL DEFAULT 0,"
 			"  rescues         INTEGER NOT NULL DEFAULT 0,"
+			"  boost_targets     INTEGER NOT NULL DEFAULT 0,"
+			"  boost_overwrites  INTEGER NOT NULL DEFAULT 0,"
+			"  boost_wasted_secs INTEGER NOT NULL DEFAULT 0,"
 			"  PRIMARY KEY (instance_id, character_id, task_force, device_id)"
 			");",
 			nullptr, nullptr, &err);
@@ -2159,6 +2162,9 @@ void Database::Init() {
 			"ALTER TABLE ga_match_device_stats ADD COLUMN buffed_damage_dealt INTEGER NOT NULL DEFAULT 0;",
 			"ALTER TABLE ga_match_device_stats ADD COLUMN protected_damage_taken INTEGER NOT NULL DEFAULT 0;",
 			"ALTER TABLE ga_match_device_stats ADD COLUMN rescues INTEGER NOT NULL DEFAULT 0;",
+			"ALTER TABLE ga_match_device_stats ADD COLUMN boost_targets INTEGER NOT NULL DEFAULT 0;",
+			"ALTER TABLE ga_match_device_stats ADD COLUMN boost_overwrites INTEGER NOT NULL DEFAULT 0;",
+			"ALTER TABLE ga_match_device_stats ADD COLUMN boost_wasted_secs INTEGER NOT NULL DEFAULT 0;",
 		}) {
 			result = sqlite3_exec(db, alter, nullptr, nullptr, &err);
 			if (result != SQLITE_OK) { sqlite3_free(err); err = nullptr; }
@@ -3635,8 +3641,9 @@ void Database::UpsertMatchDeviceStats(const MatchDeviceStatsRow& row) {
 		"INSERT INTO ga_match_device_stats (instance_id, user_id, character_id,"
 		" task_force, device_id, damage, healing, player_kills, bot_kills,"
 		" debuffs_removed, overheal, uses, power_restored, power_wasted,"
-		" buffed_damage_dealt, protected_damage_taken, rescues)"
-		" VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
+		" buffed_damage_dealt, protected_damage_taken, rescues,"
+		" boost_targets, boost_overwrites, boost_wasted_secs)"
+		" VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
 		" ON CONFLICT(instance_id, character_id, task_force, device_id) DO UPDATE SET"
 		"  user_id=excluded.user_id, damage=excluded.damage,"
 		"  healing=excluded.healing, player_kills=excluded.player_kills,"
@@ -3646,7 +3653,9 @@ void Database::UpsertMatchDeviceStats(const MatchDeviceStatsRow& row) {
 		"  power_wasted=excluded.power_wasted,"
 		"  buffed_damage_dealt=excluded.buffed_damage_dealt,"
 		"  protected_damage_taken=excluded.protected_damage_taken,"
-		"  rescues=excluded.rescues",
+		"  rescues=excluded.rescues, boost_targets=excluded.boost_targets,"
+		"  boost_overwrites=excluded.boost_overwrites,"
+		"  boost_wasted_secs=excluded.boost_wasted_secs",
 		-1, &stmt, nullptr);
 	if (rc != SQLITE_OK || !stmt) {
 		Logger::Log("matchstats", "[DB] UpsertMatchDeviceStats prepare failed: %s\n",
@@ -3670,6 +3679,9 @@ void Database::UpsertMatchDeviceStats(const MatchDeviceStatsRow& row) {
 	sqlite3_bind_int(stmt, 15, row.buffed_damage_dealt);
 	sqlite3_bind_int(stmt, 16, row.protected_damage_taken);
 	sqlite3_bind_int(stmt, 17, row.rescues);
+	sqlite3_bind_int(stmt, 18, row.boost_targets);
+	sqlite3_bind_int(stmt, 19, row.boost_overwrites);
+	sqlite3_bind_int(stmt, 20, row.boost_wasted_secs);
 	rc = sqlite3_step(stmt);
 	sqlite3_finalize(stmt);
 	if (rc != SQLITE_DONE) {

--- a/src/ControlServer/Database/Database.cpp
+++ b/src/ControlServer/Database/Database.cpp
@@ -2118,6 +2118,61 @@ void Database::Init() {
 			sqlite3_free(err); err = nullptr;
 		}
 
+		// Per-device breakdown of the same counters ga_match_player_stats
+		// totals. No DPM/HPM columns — rates derive from
+		// ga_match_player_stats.time_played_seconds.
+		result = sqlite3_exec(db,
+			"CREATE TABLE IF NOT EXISTS ga_match_device_stats ("
+			"  instance_id  INTEGER NOT NULL,"
+			"  user_id      INTEGER NOT NULL,"
+			"  character_id INTEGER NOT NULL,"
+			"  task_force   INTEGER NOT NULL,"
+			"  device_id    INTEGER NOT NULL,"
+			"  damage       INTEGER NOT NULL DEFAULT 0,"
+			"  healing      INTEGER NOT NULL DEFAULT 0,"
+			"  player_kills INTEGER NOT NULL DEFAULT 0,"
+			"  bot_kills    INTEGER NOT NULL DEFAULT 0,"
+			"  debuffs_removed INTEGER NOT NULL DEFAULT 0,"
+			"  overheal        INTEGER NOT NULL DEFAULT 0,"
+			"  uses            INTEGER NOT NULL DEFAULT 0,"
+			"  power_restored  INTEGER NOT NULL DEFAULT 0,"
+			"  power_wasted    INTEGER NOT NULL DEFAULT 0,"
+			"  buffed_damage_dealt    INTEGER NOT NULL DEFAULT 0,"
+			"  protected_damage_taken INTEGER NOT NULL DEFAULT 0,"
+			"  PRIMARY KEY (instance_id, character_id, task_force, device_id)"
+			");",
+			nullptr, nullptr, &err);
+		if (result != SQLITE_OK) {
+			Logger::Log("db", "Failed to create ga_match_device_stats table: %s\n", err);
+			sqlite3_free(err); err = nullptr;
+		}
+
+		// Effectiveness columns for DBs whose table predates them.
+		// ALTER failure tolerated (column already exists).
+		for (const char* alter : {
+			"ALTER TABLE ga_match_device_stats ADD COLUMN debuffs_removed INTEGER NOT NULL DEFAULT 0;",
+			"ALTER TABLE ga_match_device_stats ADD COLUMN overheal INTEGER NOT NULL DEFAULT 0;",
+			"ALTER TABLE ga_match_device_stats ADD COLUMN uses INTEGER NOT NULL DEFAULT 0;",
+			"ALTER TABLE ga_match_device_stats ADD COLUMN power_restored INTEGER NOT NULL DEFAULT 0;",
+			"ALTER TABLE ga_match_device_stats ADD COLUMN power_wasted INTEGER NOT NULL DEFAULT 0;",
+			"ALTER TABLE ga_match_device_stats ADD COLUMN buffed_damage_dealt INTEGER NOT NULL DEFAULT 0;",
+			"ALTER TABLE ga_match_device_stats ADD COLUMN protected_damage_taken INTEGER NOT NULL DEFAULT 0;",
+		}) {
+			result = sqlite3_exec(db, alter, nullptr, nullptr, &err);
+			if (result != SQLITE_OK) { sqlite3_free(err); err = nullptr; }
+		}
+
+		result = sqlite3_exec(db,
+			"CREATE INDEX IF NOT EXISTS idx_ga_match_device_stats_user "
+			"ON ga_match_device_stats(user_id);"
+			"CREATE INDEX IF NOT EXISTS idx_ga_match_device_stats_device "
+			"ON ga_match_device_stats(device_id);",
+			nullptr, nullptr, &err);
+		if (result != SQLITE_OK) {
+			Logger::Log("db", "Failed to create ga_match_device_stats indexes: %s\n", err);
+			sqlite3_free(err); err = nullptr;
+		}
+
 		// Outcome columns. ALTER failure tolerated (column already exists).
 		result = sqlite3_exec(db,
 			"ALTER TABLE ga_instances ADD COLUMN outcome TEXT;",
@@ -3566,6 +3621,55 @@ void Database::UpsertMatchPlayerStats(const MatchPlayerStatsRow& row) {
 	sqlite3_finalize(stmt);
 	if (rc != SQLITE_DONE) {
 		Logger::Log("matchstats", "[DB] UpsertMatchPlayerStats step failed: %s\n",
+			sqlite3_errmsg(db));
+	}
+}
+
+void Database::UpsertMatchDeviceStats(const MatchDeviceStatsRow& row) {
+	sqlite3* db = GetConnection();
+	if (!db) return;
+	sqlite3_stmt* stmt = nullptr;
+	int rc = sqlite3_prepare_v2(db,
+		"INSERT INTO ga_match_device_stats (instance_id, user_id, character_id,"
+		" task_force, device_id, damage, healing, player_kills, bot_kills,"
+		" debuffs_removed, overheal, uses, power_restored, power_wasted,"
+		" buffed_damage_dealt, protected_damage_taken)"
+		" VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
+		" ON CONFLICT(instance_id, character_id, task_force, device_id) DO UPDATE SET"
+		"  user_id=excluded.user_id, damage=excluded.damage,"
+		"  healing=excluded.healing, player_kills=excluded.player_kills,"
+		"  bot_kills=excluded.bot_kills,"
+		"  debuffs_removed=excluded.debuffs_removed, overheal=excluded.overheal,"
+		"  uses=excluded.uses, power_restored=excluded.power_restored,"
+		"  power_wasted=excluded.power_wasted,"
+		"  buffed_damage_dealt=excluded.buffed_damage_dealt,"
+		"  protected_damage_taken=excluded.protected_damage_taken",
+		-1, &stmt, nullptr);
+	if (rc != SQLITE_OK || !stmt) {
+		Logger::Log("matchstats", "[DB] UpsertMatchDeviceStats prepare failed: %s\n",
+			sqlite3_errmsg(db));
+		return;
+	}
+	sqlite3_bind_int64(stmt, 1, row.instance_id);
+	sqlite3_bind_int64(stmt, 2, row.user_id);
+	sqlite3_bind_int64(stmt, 3, row.character_id);
+	sqlite3_bind_int(stmt, 4, row.task_force);
+	sqlite3_bind_int(stmt, 5, row.device_id);
+	sqlite3_bind_int(stmt, 6, row.damage);
+	sqlite3_bind_int(stmt, 7, row.healing);
+	sqlite3_bind_int(stmt, 8, row.player_kills);
+	sqlite3_bind_int(stmt, 9, row.bot_kills);
+	sqlite3_bind_int(stmt, 10, row.debuffs_removed);
+	sqlite3_bind_int(stmt, 11, row.overheal);
+	sqlite3_bind_int(stmt, 12, row.uses);
+	sqlite3_bind_int(stmt, 13, row.power_restored);
+	sqlite3_bind_int(stmt, 14, row.power_wasted);
+	sqlite3_bind_int(stmt, 15, row.buffed_damage_dealt);
+	sqlite3_bind_int(stmt, 16, row.protected_damage_taken);
+	rc = sqlite3_step(stmt);
+	sqlite3_finalize(stmt);
+	if (rc != SQLITE_DONE) {
+		Logger::Log("matchstats", "[DB] UpsertMatchDeviceStats step failed: %s\n",
 			sqlite3_errmsg(db));
 	}
 }

--- a/src/ControlServer/Database/Database.cpp
+++ b/src/ControlServer/Database/Database.cpp
@@ -2139,6 +2139,7 @@ void Database::Init() {
 			"  power_wasted    INTEGER NOT NULL DEFAULT 0,"
 			"  buffed_damage_dealt    INTEGER NOT NULL DEFAULT 0,"
 			"  protected_damage_taken INTEGER NOT NULL DEFAULT 0,"
+			"  rescues         INTEGER NOT NULL DEFAULT 0,"
 			"  PRIMARY KEY (instance_id, character_id, task_force, device_id)"
 			");",
 			nullptr, nullptr, &err);
@@ -2157,6 +2158,7 @@ void Database::Init() {
 			"ALTER TABLE ga_match_device_stats ADD COLUMN power_wasted INTEGER NOT NULL DEFAULT 0;",
 			"ALTER TABLE ga_match_device_stats ADD COLUMN buffed_damage_dealt INTEGER NOT NULL DEFAULT 0;",
 			"ALTER TABLE ga_match_device_stats ADD COLUMN protected_damage_taken INTEGER NOT NULL DEFAULT 0;",
+			"ALTER TABLE ga_match_device_stats ADD COLUMN rescues INTEGER NOT NULL DEFAULT 0;",
 		}) {
 			result = sqlite3_exec(db, alter, nullptr, nullptr, &err);
 			if (result != SQLITE_OK) { sqlite3_free(err); err = nullptr; }
@@ -3633,8 +3635,8 @@ void Database::UpsertMatchDeviceStats(const MatchDeviceStatsRow& row) {
 		"INSERT INTO ga_match_device_stats (instance_id, user_id, character_id,"
 		" task_force, device_id, damage, healing, player_kills, bot_kills,"
 		" debuffs_removed, overheal, uses, power_restored, power_wasted,"
-		" buffed_damage_dealt, protected_damage_taken)"
-		" VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
+		" buffed_damage_dealt, protected_damage_taken, rescues)"
+		" VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
 		" ON CONFLICT(instance_id, character_id, task_force, device_id) DO UPDATE SET"
 		"  user_id=excluded.user_id, damage=excluded.damage,"
 		"  healing=excluded.healing, player_kills=excluded.player_kills,"
@@ -3643,7 +3645,8 @@ void Database::UpsertMatchDeviceStats(const MatchDeviceStatsRow& row) {
 		"  uses=excluded.uses, power_restored=excluded.power_restored,"
 		"  power_wasted=excluded.power_wasted,"
 		"  buffed_damage_dealt=excluded.buffed_damage_dealt,"
-		"  protected_damage_taken=excluded.protected_damage_taken",
+		"  protected_damage_taken=excluded.protected_damage_taken,"
+		"  rescues=excluded.rescues",
 		-1, &stmt, nullptr);
 	if (rc != SQLITE_OK || !stmt) {
 		Logger::Log("matchstats", "[DB] UpsertMatchDeviceStats prepare failed: %s\n",
@@ -3666,6 +3669,7 @@ void Database::UpsertMatchDeviceStats(const MatchDeviceStatsRow& row) {
 	sqlite3_bind_int(stmt, 14, row.power_wasted);
 	sqlite3_bind_int(stmt, 15, row.buffed_damage_dealt);
 	sqlite3_bind_int(stmt, 16, row.protected_damage_taken);
+	sqlite3_bind_int(stmt, 17, row.rescues);
 	rc = sqlite3_step(stmt);
 	sqlite3_finalize(stmt);
 	if (rc != SQLITE_DONE) {

--- a/src/ControlServer/Database/Database.cpp
+++ b/src/ControlServer/Database/Database.cpp
@@ -2170,6 +2170,33 @@ void Database::Init() {
 			if (result != SQLITE_OK) { sqlite3_free(err); err = nullptr; }
 		}
 
+		// Per-queue stats recording toggles. Device-stats recording should
+		// follow COMPETITIVE queues — PvE farming would poison every
+		// MMR-facing signal — so both default 0 and only PvP queues are
+		// seeded on. The seed runs ONLY when the column is newly created
+		// (ALTER succeeded): later manual toggles survive restarts.
+		result = sqlite3_exec(db,
+			"ALTER TABLE ga_queues ADD COLUMN record_device_stats INTEGER NOT NULL DEFAULT 0;",
+			nullptr, nullptr, &err);
+		const bool queue_stats_cols_fresh = (result == SQLITE_OK);
+		if (result != SQLITE_OK) { sqlite3_free(err); err = nullptr; }
+		result = sqlite3_exec(db,
+			"ALTER TABLE ga_queues ADD COLUMN record_effectiveness INTEGER NOT NULL DEFAULT 0;",
+			nullptr, nullptr, &err);
+		if (result != SQLITE_OK) { sqlite3_free(err); err = nullptr; }
+		if (queue_stats_cols_fresh) {
+			result = sqlite3_exec(db,
+				"UPDATE ga_queues SET record_device_stats = 1, record_effectiveness = 1 "
+				"WHERE name IN ('merc', '1v1');",
+				nullptr, nullptr, &err);
+			if (result != SQLITE_OK) {
+				Logger::Log("db", "Failed to seed queue stats toggles: %s\n", err);
+				sqlite3_free(err); err = nullptr;
+			} else {
+				Logger::Log("db", "Seeded stats recording ON for queues: merc, 1v1\n");
+			}
+		}
+
 		result = sqlite3_exec(db,
 			"CREATE INDEX IF NOT EXISTS idx_ga_match_device_stats_user "
 			"ON ga_match_device_stats(user_id);"
@@ -3688,6 +3715,27 @@ void Database::UpsertMatchDeviceStats(const MatchDeviceStatsRow& row) {
 		Logger::Log("matchstats", "[DB] UpsertMatchDeviceStats step failed: %s\n",
 			sqlite3_errmsg(db));
 	}
+}
+
+void Database::GetQueueStatsToggles(uint32_t queue_id,
+                                    bool& device_stats, bool& effectiveness) {
+	device_stats = false;
+	effectiveness = false;
+	sqlite3* db = GetConnection();
+	if (!db) return;
+	sqlite3_stmt* stmt = nullptr;
+	if (sqlite3_prepare_v2(db,
+			"SELECT record_device_stats, record_effectiveness "
+			"FROM ga_queues WHERE queue_id = ?",
+			-1, &stmt, nullptr) != SQLITE_OK || !stmt) {
+		return;
+	}
+	sqlite3_bind_int(stmt, 1, (int)queue_id);
+	if (sqlite3_step(stmt) == SQLITE_ROW) {
+		device_stats  = sqlite3_column_int(stmt, 0) != 0;
+		effectiveness = sqlite3_column_int(stmt, 1) != 0;
+	}
+	sqlite3_finalize(stmt);
 }
 
 void Database::SetInstanceOutcomeIfNull(int64_t instance_id,

--- a/src/ControlServer/Database/Database.hpp
+++ b/src/ControlServer/Database/Database.hpp
@@ -213,6 +213,12 @@ public:
     // device_id). device_id keys asm_data_set_devices.device_id.
     static void UpsertMatchDeviceStats(const MatchDeviceStatsRow& row);
 
+    // Per-queue stats recording toggles (ga_queues.record_device_stats /
+    // record_effectiveness). Returns false/false when the queue row is
+    // missing — an unknown queue records nothing.
+    static void GetQueueStatsToggles(uint32_t queue_id,
+                                     bool& device_stats, bool& effectiveness);
+
     // Write-once outcome stamp (WHERE outcome IS NULL AND is_home_map=0).
     // winning_task_force 0 = NULL.
     static void SetInstanceOutcomeIfNull(int64_t instance_id,

--- a/src/ControlServer/Database/Database.hpp
+++ b/src/ControlServer/Database/Database.hpp
@@ -206,6 +206,7 @@ public:
         int     debuffs_removed = 0, overheal = 0;
         int     uses = 0, power_restored = 0, power_wasted = 0;
         int     buffed_damage_dealt = 0, protected_damage_taken = 0;
+        int     rescues = 0;
     };
     // Absolute totals; upsert on (instance_id, character_id, task_force,
     // device_id). device_id keys asm_data_set_devices.device_id.

--- a/src/ControlServer/Database/Database.hpp
+++ b/src/ControlServer/Database/Database.hpp
@@ -207,6 +207,7 @@ public:
         int     uses = 0, power_restored = 0, power_wasted = 0;
         int     buffed_damage_dealt = 0, protected_damage_taken = 0;
         int     rescues = 0;
+        int     boost_targets = 0, boost_overwrites = 0, boost_wasted_secs = 0;
     };
     // Absolute totals; upsert on (instance_id, character_id, task_force,
     // device_id). device_id keys asm_data_set_devices.device_id.

--- a/src/ControlServer/Database/Database.hpp
+++ b/src/ControlServer/Database/Database.hpp
@@ -198,6 +198,19 @@ public:
     // Absolute totals; upsert on (instance_id, character_id, task_force).
     static void UpsertMatchPlayerStats(const MatchPlayerStatsRow& row);
 
+    struct MatchDeviceStatsRow {
+        int64_t instance_id = 0, user_id = 0, character_id = 0;
+        int     task_force = 0, device_id = 0;
+        int     damage = 0, healing = 0;
+        int     player_kills = 0, bot_kills = 0;
+        int     debuffs_removed = 0, overheal = 0;
+        int     uses = 0, power_restored = 0, power_wasted = 0;
+        int     buffed_damage_dealt = 0, protected_damage_taken = 0;
+    };
+    // Absolute totals; upsert on (instance_id, character_id, task_force,
+    // device_id). device_id keys asm_data_set_devices.device_id.
+    static void UpsertMatchDeviceStats(const MatchDeviceStatsRow& row);
+
     // Write-once outcome stamp (WHERE outcome IS NULL AND is_home_map=0).
     // winning_task_force 0 = NULL.
     static void SetInstanceOutcomeIfNull(int64_t instance_id,

--- a/src/ControlServer/IpcServer/IpcServer.cpp
+++ b/src/ControlServer/IpcServer/IpcServer.cpp
@@ -492,6 +492,7 @@ private:
             row.power_wasted    = j.value("power_wasted", 0);
             row.buffed_damage_dealt    = j.value("buffed_damage_dealt", 0);
             row.protected_damage_taken = j.value("protected_damage_taken", 0);
+            row.rescues                = j.value("rescues", 0);
             Database::UpsertMatchDeviceStats(row);
         }
         else if (type == IpcProtocol::MSG_MISSION_ENDED) {

--- a/src/ControlServer/IpcServer/IpcServer.cpp
+++ b/src/ControlServer/IpcServer/IpcServer.cpp
@@ -493,6 +493,9 @@ private:
             row.buffed_damage_dealt    = j.value("buffed_damage_dealt", 0);
             row.protected_damage_taken = j.value("protected_damage_taken", 0);
             row.rescues                = j.value("rescues", 0);
+            row.boost_targets          = j.value("boost_targets", 0);
+            row.boost_overwrites       = j.value("boost_overwrites", 0);
+            row.boost_wasted_secs      = j.value("boost_wasted_secs", 0);
             Database::UpsertMatchDeviceStats(row);
         }
         else if (type == IpcProtocol::MSG_MISSION_ENDED) {

--- a/src/ControlServer/IpcServer/IpcServer.cpp
+++ b/src/ControlServer/IpcServer/IpcServer.cpp
@@ -220,6 +220,23 @@ private:
             ack["type"]          = IpcProtocol::MSG_INSTANCE_HELLO_ACK;
             ack["accepted"]      = true;
             ack["stats_enabled"] = !is_home_map_;
+            // Finer-grained recording toggles: global (control-server.json)
+            // AND per-queue (ga_queues.record_*). Queue rows default OFF —
+            // recording follows competitive queues so PvE farming can't
+            // reach MMR-facing data. queue_id 0 (ad-hoc / admin-spawned
+            // instance) has no queue row and falls back to the globals,
+            // which keeps test instances recordable.
+            bool q_dev = true, q_eff = true;
+            if (info && info->queue_id != 0) {
+                Database::GetQueueStatsToggles(info->queue_id, q_dev, q_eff);
+            }
+            ack["device_stats_enabled"]  = IpcServer::stats_device_enabled_ && q_dev;
+            ack["effectiveness_enabled"] = IpcServer::stats_effectiveness_enabled_ && q_eff;
+            Logger::Log("ipc",
+                "[IpcServer] stats toggles for instance %lld: queue=%u device_stats=%d effectiveness=%d\n",
+                (long long)inst_id, info ? info->queue_id : 0,
+                (int)(IpcServer::stats_device_enabled_ && q_dev),
+                (int)(IpcServer::stats_effectiveness_enabled_ && q_eff));
             send(ack.dump());
             Logger::Log("ipc", "[IpcServer] INSTANCE_HELLO_ACK sent to instance_id=%lld\n",
                 (long long)inst_id);
@@ -816,6 +833,13 @@ std::map<std::string, std::function<void(bool, int)>> IpcServer::pending_acks_;
 IpcServer::SuccessorSpawner IpcServer::successor_spawner_;
 std::string IpcServer::admin_token_;
 IpcServer::AdminActionHandler IpcServer::admin_action_handler_;
+bool IpcServer::stats_device_enabled_        = true;
+bool IpcServer::stats_effectiveness_enabled_ = true;
+
+void IpcServer::SetStatsToggles(bool device_stats, bool effectiveness) {
+    stats_device_enabled_        = device_stats;
+    stats_effectiveness_enabled_ = effectiveness;
+}
 
 void IpcServer::SetSuccessorSpawner(SuccessorSpawner cb) {
     successor_spawner_ = std::move(cb);

--- a/src/ControlServer/IpcServer/IpcServer.cpp
+++ b/src/ControlServer/IpcServer/IpcServer.cpp
@@ -472,6 +472,28 @@ private:
             row.time_played_seconds    = j.value("time_played_seconds", 0.0);
             Database::UpsertMatchPlayerStats(row);
         }
+        else if (type == IpcProtocol::MSG_MATCH_DEVICE_STATS) {
+            if (is_home_map_) return;
+            Database::MatchDeviceStatsRow row;
+            row.instance_id  = j.value("instance_id", instance_id_);
+            row.user_id      = j.value("user_id", (int64_t)0);
+            row.character_id = j.value("character_id", (int64_t)0);
+            row.task_force   = j.value("task_force", 0);
+            row.device_id    = j.value("device_id", 0);
+            if (row.character_id == 0 || row.device_id == 0) return;
+            row.damage          = j.value("damage", 0);
+            row.healing         = j.value("healing", 0);
+            row.player_kills    = j.value("player_kills", 0);
+            row.bot_kills       = j.value("bot_kills", 0);
+            row.debuffs_removed = j.value("debuffs_removed", 0);
+            row.overheal        = j.value("overheal", 0);
+            row.uses            = j.value("uses", 0);
+            row.power_restored  = j.value("power_restored", 0);
+            row.power_wasted    = j.value("power_wasted", 0);
+            row.buffed_damage_dealt    = j.value("buffed_damage_dealt", 0);
+            row.protected_damage_taken = j.value("protected_damage_taken", 0);
+            Database::UpsertMatchDeviceStats(row);
+        }
         else if (type == IpcProtocol::MSG_MISSION_ENDED) {
             // BeginEndMission fired on the mission instance. Stamp end_mission_at
             // on the parent row AND promote any DRAFTING successor to READY in

--- a/src/ControlServer/IpcServer/IpcServer.hpp
+++ b/src/ControlServer/IpcServer/IpcServer.hpp
@@ -50,6 +50,10 @@ public:
     static void SetAdminToken(std::string token);
     static void SetAdminActionHandler(AdminActionHandler cb);
 
+    // Per-instance stats toggles forwarded in INSTANCE_HELLO_ACK. Set once
+    // at startup from control-server.json (both default true).
+    static void SetStatsToggles(bool device_stats, bool effectiveness);
+
 private:
     friend class IpcSession;
 
@@ -60,6 +64,8 @@ private:
     static SuccessorSpawner successor_spawner_;
     static std::string admin_token_;
     static AdminActionHandler admin_action_handler_;
+    static bool stats_device_enabled_;
+    static bool stats_effectiveness_enabled_;
 
     asio::io_context& io_;
     std::unique_ptr<asio::ip::tcp::acceptor> acceptor_;

--- a/src/ControlServer/main.cpp
+++ b/src/ControlServer/main.cpp
@@ -403,6 +403,8 @@ int main(int argc, char* argv[]) {
     TcpSession::SetNetworkConfig(cfg.host, cfg.chat_port);
     TcpSession::SetLoginPolicy(cfg.allow_duplicate_account_logins,
                                cfg.require_password_verification);
+    IpcServer::SetStatsToggles(cfg.device_stats_enabled,
+                               cfg.effectiveness_enabled);
     TcpSession::SetModerationConfig(cfg.ban_spoof.mode,
                                     cfg.ban_spoof.fallback_close_sec,
                                     cfg.kick.fallback_close_sec);

--- a/src/GameServer/Constants/TgProperties.h
+++ b/src/GameServer/Constants/TgProperties.h
@@ -120,6 +120,17 @@ namespace GA_PROPERTY {
 		TGPID_PROTECTION_DISEASE = 160,
 		TGPID_PROTECTION_ENERGY = 157,
 		TGPID_PROTECTION_PHYSICAL = 155,
+		// Two poison protections on two different axes, and the names here
+		// disagree with gaa.db. 159 is the STATUS-CATEGORY one (Poison, cat 303,
+		// via CalcCategoryProtection); 324 is the DAMAGE-TYPE one (Poison, type
+		// 897, via CalcDamageTypeProtection). The DB calls 159 "Protection -
+		// Biological" and 324 "Protection - Poison", so whichever source you
+		// trust, the other looks wrong. Evidence for the split: 155/156/157/324
+		// move as a quartet matching the four damage types, while 159 rides with
+		// Ignite/Disease/Stun on every device that grants it (Sealed Systems,
+		// Scorpion Shell, Perfect Target). The Invulnerable Volume raises both in
+		// one group at different tiers. Reach for 159 when you mean a poison DoT,
+		// 324 when you mean poison-typed damage.
 		TGPID_PROTECTION_POISON = 159,
 		TGPID_PROTECTION_SLOW = 158,
 		TGPID_PROTECTION_THERMAL = 156,
@@ -132,6 +143,7 @@ namespace GA_PROPERTY {
 		TGPID_PROTECTION_KNOCKBACK = 233,
 		TGPID_PROTECTION_EMP_STUN = 235,
 		TGPID_PROTECTION_IGNITE = 266,
+		// Misnamed: 324 is damage-type Poison, not "Bio". See TGPID_PROTECTION_POISON.
 		TGPID_PROTECTION_BIO = 324,
 		TGPID_PROTECTION_EMP_BURN = 328,
 		TGPID_PROTECTION_BLEED = 371,

--- a/src/GameServer/Core/UObject/ProcessEvent/UObject__ProcessEvent.cpp
+++ b/src/GameServer/Core/UObject/ProcessEvent/UObject__ProcessEvent.cpp
@@ -1481,6 +1481,13 @@ void __fastcall UObject__ProcessEvent::Call(UObject* Object, void* edx, UFunctio
 			if (Dev && Dev->m_bIsRestDevice && Dev->Instigator) {
 				((ATgPawn*)Dev->Instigator)->r_nRestDeviceSlot = (int)Dev->r_eEquippedAt;
 			}
+			// Device-usage stats: one "use" per DeviceFiring activation
+			// (per hold for continuous fire, per activation for one-shots
+			// like waves/boosts — the denominator for effectiveness rates).
+			if (Dev && Dev->Instigator &&
+			    ObjectClassCache::ClassNameContains(Dev->Instigator, "TgPawn")) {
+				MatchStats::OnDeviceUsed((ATgPawn*)Dev->Instigator, Dev->r_nDeviceId);
+			}
 		}
 		DoCatchAll();
 		break;

--- a/src/GameServer/Stats/DeviceStats.cpp
+++ b/src/GameServer/Stats/DeviceStats.cpp
@@ -1,4 +1,5 @@
 #include "src/GameServer/Stats/DeviceStats.hpp"
+#include "src/GameServer/Stats/MatchStats.hpp"
 #include "src/GameServer/Engine/World/GetWorldInfo/World__GetWorldInfo.hpp"
 #include "src/GameServer/Globals.hpp"
 #include "src/Database/Database.hpp"
@@ -104,6 +105,10 @@ int DeviceStats::DeviceIdFromDeployableId(int deployableId) {
 
 void DeviceStats::Credit(ATgPawn* CreditPawn, int deviceId, int field, int amount) {
 	if (CreditPawn == nullptr || deviceId <= 0 || amount <= 0) return;
+
+	// Server-side record first: it must see credits the PRI row below drops
+	// (the 9-row cap, and any credit landing while the PRI is missing).
+	MatchStats::OnDeviceCredit(CreditPawn, deviceId, field, amount);
 
 	ATgRepInfo_Player* PRI = (ATgRepInfo_Player*)CreditPawn->PlayerReplicationInfo;
 	if (PRI == nullptr) return;

--- a/src/GameServer/Stats/MatchStats.cpp
+++ b/src/GameServer/Stats/MatchStats.cpp
@@ -19,6 +19,10 @@ namespace {
 
 bool g_enabled = false;
 
+// Recording toggles (see MatchStats.hpp). Default true = record everything.
+bool g_deviceStatsEnabled   = true;
+bool g_effectivenessEnabled = true;
+
 // user_id → per-match stint banking.
 std::map<int64_t, Stats::UserMatchStats> g_users;
 
@@ -338,6 +342,20 @@ void MatchStats::SetEnabled(bool enabled) {
 
 bool MatchStats::Enabled() { return g_enabled; }
 
+void MatchStats::SetDeviceStatsEnabled(bool enabled) {
+    g_deviceStatsEnabled = enabled;
+    Logger::Log("matchstats", "[MatchStats] device_stats_enabled=%d\n", (int)enabled);
+}
+
+void MatchStats::SetEffectivenessEnabled(bool enabled) {
+    g_effectivenessEnabled = enabled;
+    Logger::Log("matchstats", "[MatchStats] effectiveness_enabled=%d\n", (int)enabled);
+}
+
+bool MatchStats::EffectivenessEnabled() {
+    return g_enabled && g_effectivenessEnabled;
+}
+
 void MatchStats::OnPlayerJoined(ATgPawn* Pawn, int64_t user_id,
                                 int64_t character_id, int task_force) {
     if (!g_enabled || !Pawn || user_id == 0 || character_id == 0) return;
@@ -584,7 +602,8 @@ void MatchStats::OnDeployableDestroyed(ATgPawn* Destroyer,
 
 void MatchStats::OnDeviceCredit(ATgPawn* CreditPawn, int device_id,
                                 int field, int amount) {
-    if (!g_enabled || !CreditPawn || device_id <= 0 || amount <= 0) return;
+    if (!g_enabled || !g_deviceStatsEnabled) return;  // toggle A
+    if (!CreditPawn || device_id <= 0 || amount <= 0) return;
     if (DeviceExcluded(device_id)) return;
     LivePlayer lp;
     if (!ResolveLive(CreditPawn, lp)) return;  // bots have no persisted row
@@ -602,7 +621,8 @@ void MatchStats::OnDeviceCredit(ATgPawn* CreditPawn, int device_id,
 
 void MatchStats::OnDeviceCleanse(ATgPawn* CreditPawn, ATgPawn* TargetPawn,
                                  int device_id, int category, int removed) {
-    if (!g_enabled || !CreditPawn || removed <= 0) return;
+    if (!g_enabled || !g_effectivenessEnabled) return;  // toggle B
+    if (!CreditPawn || removed <= 0) return;
     if (DeviceExcluded(device_id)) return;  // no row AND no event
     LivePlayer lp;
     if (!ResolveLive(CreditPawn, lp)) return;  // bot cleanses: no record
@@ -628,7 +648,8 @@ void MatchStats::OnDeviceCleanse(ATgPawn* CreditPawn, ATgPawn* TargetPawn,
 
 void MatchStats::OnDeviceOverheal(ATgPawn* CreditPawn, int device_id,
                                   int amount) {
-    if (!g_enabled || !CreditPawn || device_id <= 0 || amount <= 0) return;
+    if (!g_enabled || !g_effectivenessEnabled) return;  // toggle B
+    if (!CreditPawn || device_id <= 0 || amount <= 0) return;
     if (DeviceExcluded(device_id)) return;
     LivePlayer lp;
     if (!ResolveLive(CreditPawn, lp)) return;
@@ -639,7 +660,8 @@ void MatchStats::OnDeviceOverheal(ATgPawn* CreditPawn, int device_id,
 }
 
 void MatchStats::OnDeviceUsed(ATgPawn* UserPawn, int device_id) {
-    if (!g_enabled || !UserPawn || device_id <= 0) return;
+    if (!g_enabled || !g_effectivenessEnabled) return;  // toggle B
+    if (!UserPawn || device_id <= 0) return;
     if (DeviceExcluded(device_id)) return;  // jetpacks land here constantly
     LivePlayer lp;
     if (!ResolveLive(UserPawn, lp)) return;
@@ -662,7 +684,8 @@ void MatchStats::OnDeviceUsed(ATgPawn* UserPawn, int device_id) {
 
 void MatchStats::OnDevicePowerRestore(ATgPawn* CreditPawn, int device_id,
                                       int restored, int wasted) {
-    if (!g_enabled || !CreditPawn || device_id <= 0) return;
+    if (!g_enabled || !g_effectivenessEnabled) return;  // toggle B
+    if (!CreditPawn || device_id <= 0) return;
     if (restored <= 0 && wasted <= 0) return;
     if (DeviceExcluded(device_id)) return;
     LivePlayer lp;
@@ -689,7 +712,8 @@ void MatchStats::OnDevicePowerRestore(ATgPawn* CreditPawn, int device_id,
 
 void MatchStats::OnSaviorTrigger(ATgPawn* CreditPawn, ATgPawn* TargetPawn,
                                  int device_id) {
-    if (!g_enabled || !CreditPawn) return;
+    if (!g_enabled || !g_effectivenessEnabled) return;  // toggle B
+    if (!CreditPawn) return;
     LivePlayer lp;
     if (!ResolveLive(CreditPawn, lp)) return;  // bot-cast heals: no record
     // Savior firing = an under-25% rescue delivered by this device.
@@ -713,7 +737,8 @@ void MatchStats::OnSaviorTrigger(ATgPawn* CreditPawn, ATgPawn* TargetPawn,
 }
 
 void MatchStats::OnBoostApply(UTgEffectGroup* g) {
-    if (!g_enabled || !g || !g->m_Target) return;
+    if (!g_enabled || !g_effectivenessEnabled) return;  // toggle B
+    if (!g || !g->m_Target) return;
     const float lifetime = BoostLifetime(g->m_nEffectGroupId);
     if (lifetime <= 0.0f) return;
     if (!ObjectClassCache::ClassNameContains(g->m_Target, "TgPawn")) return;
@@ -799,7 +824,8 @@ void MatchStats::OnBoostApply(UTgEffectGroup* g) {
 
 void MatchStats::OnBuffWindowDamage(ATgPawn* CreditPawn, int device_id,
                                     bool offensive, int amount) {
-    if (!g_enabled || !CreditPawn || device_id <= 0 || amount <= 0) return;
+    if (!g_enabled || !g_effectivenessEnabled) return;  // toggle B
+    if (!CreditPawn || device_id <= 0 || amount <= 0) return;
     if (DeviceExcluded(device_id)) return;
     LivePlayer lp;
     if (!ResolveLive(CreditPawn, lp)) return;

--- a/src/GameServer/Stats/MatchStats.cpp
+++ b/src/GameServer/Stats/MatchStats.cpp
@@ -1,4 +1,7 @@
 #include "src/GameServer/Stats/MatchStats.hpp"
+#include "src/GameServer/Stats/DeviceStats.hpp"
+#include "src/Database/Database.hpp"
+#include "sqlite3.h"
 #include "src/GameServer/Globals.hpp"
 #include "src/GameServer/Storage/PawnSessions/PawnSessions.hpp"
 #include "src/GameServer/Utils/ActorCache/ActorCache.hpp"
@@ -32,6 +35,75 @@ std::map<int, LivePlayer> g_live;
 // (NetConnection__Cleanup's has_other_connection case) — closing the
 // fresh stint with a dead pawn's zeroed scores would bank negative deltas.
 std::map<int64_t, int> g_userCurrentPawn;
+
+// Per-device totals for the whole match, keyed by (character, task force,
+// device). Not keyed by pawn or connection: a reconnect must keep adding to
+// the same row, and the PRI's r_DeviceStats cannot express that.
+struct DeviceKey {
+    int64_t character_id = 0;
+    int     task_force   = 0;
+    int     device_id    = 0;
+    bool operator<(const DeviceKey& o) const {
+        if (character_id != o.character_id) return character_id < o.character_id;
+        if (task_force   != o.task_force)   return task_force   < o.task_force;
+        return device_id < o.device_id;
+    }
+};
+struct DeviceTotals {
+    int64_t user_id         = 0;
+    int     damage          = 0;
+    int     healing         = 0;
+    int     player_kills    = 0;
+    int     bot_kills       = 0;
+    int     debuffs_removed = 0;  // cleanse strips (CleanseTracking)
+    int     overheal        = 0;  // heal clamped away on full-health targets
+    int     uses            = 0;  // DeviceFiring activations
+    int     power_restored  = 0;  // prop-243 power that fit in the pool
+    int     power_wasted    = 0;  // prop-243 power clamped away
+    int     buffed_damage_dealt    = 0;  // dealt under this device's buff
+    int     protected_damage_taken = 0;  // taken under this device's buff
+};
+std::map<DeviceKey, DeviceTotals> g_deviceStats;
+
+// Devices the server-side table must not carry. Two sources:
+//   * every jetpack (asm slot 806) — with up to 20 players boosting
+//     constantly, per-use rows would bloat the table with zero signal;
+//   * an explicit list of self-maintenance devices the user ruled out of
+//     performance tracking (with their tier variants): Bionics 2368,
+//     Regeneration 2246/1950/2067/2068, Power Stim 3699/3696/3697/3698.
+// Full exclusion — no row, no CLEANSE event. Extend the list here.
+std::set<int> g_excludedDevices;
+bool g_excludedLoaded = false;
+
+bool DeviceExcluded(int device_id) {
+    if (!g_excludedLoaded) {
+        g_excludedLoaded = true;
+        for (int id : {2368, 2246, 1950, 2067, 2068, 3699, 3696, 3697, 3698}) {
+            g_excludedDevices.insert(id);
+        }
+        sqlite3* db = Database::GetConnection();
+        if (db != nullptr) {
+            sqlite3_stmt* stmt = nullptr;
+            if (sqlite3_prepare_v2(db,
+                    "SELECT device_id FROM asm_data_set_devices "
+                    "WHERE slot_used_value_id = 806",
+                    -1, &stmt, nullptr) == SQLITE_OK) {
+                while (sqlite3_step(stmt) == SQLITE_ROW) {
+                    g_excludedDevices.insert(sqlite3_column_int(stmt, 0));
+                }
+            }
+            sqlite3_finalize(stmt);
+        }
+    }
+    return g_excludedDevices.count(device_id) != 0;
+}
+
+// Devices whose prop-243 power rider must not feed the power columns.
+// Triage Wave's +250-on-rescue always overflows any pool (max reachable is
+// 160), so it would read as pure waste when it is in fact the designed
+// get-out-of-jail mechanic. Conditional-trigger tracking moves to the
+// HP-gate / Group Heal Savior pass instead.
+bool PowerStatExempt(int device_id) { return device_id == 5808; }
 
 // Deaths waiting for a KILL to claim them; flushed as DEATH by Tick().
 struct PendingDeath {
@@ -128,6 +200,34 @@ void UpsertUserStints(int64_t user_id) {
         m["beacon_spawns_used"]     = s.beacon_spawns_used;
         m["beacons_destroyed"]      = s.beacons_destroyed;
         m["time_played_seconds"]    = s.seconds_played;
+        IpcClient::Send(m.dump());
+    }
+}
+
+// Send absolute per-device totals (MSG_MATCH_DEVICE_STATS). character_id 0
+// sends every row; otherwise only that character's. Upsert is keyed
+// (instance_id, character_id, task_force, device_id), so resending is safe.
+void UpsertDeviceStats(int64_t character_id) {
+    for (const auto& kv : g_deviceStats) {
+        if (character_id != 0 && kv.first.character_id != character_id) continue;
+        nlohmann::json m;
+        m["type"]         = IpcProtocol::MSG_MATCH_DEVICE_STATS;
+        m["instance_id"]  = IpcClient::GetInstanceId();
+        m["user_id"]      = kv.second.user_id;
+        m["character_id"] = kv.first.character_id;
+        m["task_force"]   = kv.first.task_force;
+        m["device_id"]    = kv.first.device_id;
+        m["damage"]          = kv.second.damage;
+        m["healing"]         = kv.second.healing;
+        m["player_kills"]    = kv.second.player_kills;
+        m["bot_kills"]       = kv.second.bot_kills;
+        m["debuffs_removed"] = kv.second.debuffs_removed;
+        m["overheal"]        = kv.second.overheal;
+        m["uses"]            = kv.second.uses;
+        m["power_restored"]  = kv.second.power_restored;
+        m["power_wasted"]    = kv.second.power_wasted;
+        m["buffed_damage_dealt"]    = kv.second.buffed_damage_dealt;
+        m["protected_damage_taken"] = kv.second.protected_damage_taken;
         IpcClient::Send(m.dump());
     }
 }
@@ -234,6 +334,9 @@ void MatchStats::OnPlayerLeft(ATgPawn* Pawn, int64_t user_id) {
     ReadScores(Pawn, scores);
     uit->second.CloseStint(scores, GameTime());
     UpsertUserStints(user_id);
+    // Device rows survive the disconnect in g_deviceStats (keyed by character,
+    // not connection) — this upsert just banks them early, like the stints.
+    if (live) UpsertDeviceStats(lp.character_id);
     g_live.erase(Pawn->r_nPawnId);
     g_userCurrentPawn.erase(user_id);
 
@@ -397,6 +500,122 @@ void MatchStats::OnDeployableDestroyed(ATgPawn* Destroyer,
     }
 }
 
+void MatchStats::OnDeviceCredit(ATgPawn* CreditPawn, int device_id,
+                                int field, int amount) {
+    if (!g_enabled || !CreditPawn || device_id <= 0 || amount <= 0) return;
+    if (DeviceExcluded(device_id)) return;
+    LivePlayer lp;
+    if (!ResolveLive(CreditPawn, lp)) return;  // bots have no persisted row
+
+    DeviceTotals& t = g_deviceStats[{lp.character_id, lp.task_force, device_id}];
+    t.user_id = lp.user_id;
+    switch (field) {
+        case DeviceStats::kDamage:      t.damage       += amount; break;
+        case DeviceStats::kHealing:     t.healing      += amount; break;
+        case DeviceStats::kPlayerKills: t.player_kills += amount; break;
+        case DeviceStats::kBotKills:    t.bot_kills    += amount; break;
+        default: break;  // kId + the derived DPM/HPM slots aren't counters
+    }
+}
+
+void MatchStats::OnDeviceCleanse(ATgPawn* CreditPawn, ATgPawn* TargetPawn,
+                                 int device_id, int category, int removed) {
+    if (!g_enabled || !CreditPawn || removed <= 0) return;
+    if (DeviceExcluded(device_id)) return;  // no row AND no event
+    LivePlayer lp;
+    if (!ResolveLive(CreditPawn, lp)) return;  // bot cleanses: no record
+
+    // device_id 0 (unresolved origin) still counts on the player via the
+    // event below, but can't take a per-device row.
+    if (device_id > 0) {
+        DeviceTotals& t = g_deviceStats[{lp.character_id, lp.task_force, device_id}];
+        t.user_id = lp.user_id;
+        t.debuffs_removed += removed;
+    }
+
+    nlohmann::json ev;
+    ev["actor_user_id"]      = lp.user_id;
+    ev["actor_character_id"] = lp.character_id;
+    ev["actor_task_force"]   = lp.task_force;
+    FillIdentity(ev, "target", TargetPawn);
+    ev["device_id"] = device_id;
+    ev["detail"]    = (int64_t)category;  // which category came off
+    ev["flags"]     = removed;            // how many groups of it
+    EmitEvent(ev, "CLEANSE");
+}
+
+void MatchStats::OnDeviceOverheal(ATgPawn* CreditPawn, int device_id,
+                                  int amount) {
+    if (!g_enabled || !CreditPawn || device_id <= 0 || amount <= 0) return;
+    if (DeviceExcluded(device_id)) return;
+    LivePlayer lp;
+    if (!ResolveLive(CreditPawn, lp)) return;
+
+    DeviceTotals& t = g_deviceStats[{lp.character_id, lp.task_force, device_id}];
+    t.user_id = lp.user_id;
+    t.overheal += amount;
+}
+
+void MatchStats::OnDeviceUsed(ATgPawn* UserPawn, int device_id) {
+    if (!g_enabled || !UserPawn || device_id <= 0) return;
+    if (DeviceExcluded(device_id)) return;  // jetpacks land here constantly
+    LivePlayer lp;
+    if (!ResolveLive(UserPawn, lp)) return;
+    DeviceTotals& t = g_deviceStats[{lp.character_id, lp.task_force, device_id}];
+    t.user_id = lp.user_id;
+    t.uses++;
+}
+
+void MatchStats::OnDevicePowerRestore(ATgPawn* CreditPawn, int device_id,
+                                      int restored, int wasted) {
+    if (!g_enabled || !CreditPawn || device_id <= 0) return;
+    if (restored <= 0 && wasted <= 0) return;
+    if (DeviceExcluded(device_id)) return;
+    if (PowerStatExempt(device_id)) {
+        // Keep the conditional-fired signal visible in diagnostics even
+        // though it stays out of the stats (see PowerStatExempt).
+        if (Logger::IsChannelEnabled("devusage")) {
+            Logger::Log("devusage",
+                "[TRIAGE-CONDITIONAL] credit=%p restored=%d wasted=%d (power stats exempt)\n",
+                (void*)CreditPawn, restored, wasted);
+        }
+        return;
+    }
+    LivePlayer lp;
+    if (!ResolveLive(CreditPawn, lp)) return;
+    DeviceTotals& t = g_deviceStats[{lp.character_id, lp.task_force, device_id}];
+    t.user_id = lp.user_id;
+    if (restored > 0) t.power_restored += restored;
+    if (wasted > 0)   t.power_wasted   += wasted;
+}
+
+void MatchStats::OnSaviorTrigger(ATgPawn* CreditPawn, ATgPawn* TargetPawn,
+                                 int device_id) {
+    if (!g_enabled || !CreditPawn) return;
+    LivePlayer lp;
+    if (!ResolveLive(CreditPawn, lp)) return;  // bot-cast heals: no record
+    nlohmann::json ev;
+    ev["actor_user_id"]      = lp.user_id;
+    ev["actor_character_id"] = lp.character_id;
+    ev["actor_task_force"]   = lp.task_force;
+    FillIdentity(ev, "target", TargetPawn);
+    if (device_id > 0) ev["device_id"] = device_id;
+    ev["detail"] = (int64_t)852;  // the skill, for symmetry with CLEANSE's category
+    EmitEvent(ev, "SAVIOR");
+}
+
+void MatchStats::OnBuffWindowDamage(ATgPawn* CreditPawn, int device_id,
+                                    bool offensive, int amount) {
+    if (!g_enabled || !CreditPawn || device_id <= 0 || amount <= 0) return;
+    if (DeviceExcluded(device_id)) return;
+    LivePlayer lp;
+    if (!ResolveLive(CreditPawn, lp)) return;
+    DeviceTotals& t = g_deviceStats[{lp.character_id, lp.task_force, device_id}];
+    t.user_id = lp.user_id;
+    if (offensive) t.buffed_damage_dealt    += amount;
+    else           t.protected_damage_taken += amount;
+}
+
 void MatchStats::OnBeaconSpawnUsed(ATgPawn* User, ATgPawn* Deployer) {
     if (!g_enabled || !User || !Deployer) return;
     LivePlayer ulp;
@@ -534,4 +753,7 @@ void MatchStats::FlushAll() {
     for (const auto& kv : g_users) {
         UpsertUserStints(kv.first);
     }
+    Logger::Log("matchstats", "[FlushAll] %zu device row(s)\n",
+        g_deviceStats.size());
+    UpsertDeviceStats(0);
 }

--- a/src/GameServer/Stats/MatchStats.cpp
+++ b/src/GameServer/Stats/MatchStats.cpp
@@ -1,5 +1,6 @@
 #include "src/GameServer/Stats/MatchStats.hpp"
 #include "src/GameServer/Stats/DeviceStats.hpp"
+#include "src/GameServer/TgGame/_effect_core/EffectCredit.hpp"
 #include "src/Database/Database.hpp"
 #include "sqlite3.h"
 #include "src/GameServer/Globals.hpp"
@@ -64,6 +65,9 @@ struct DeviceTotals {
     int     protected_damage_taken = 0;  // taken under this device's buff
     int     rescues         = 0;  // under-25% conditional deliveries:
                                   // Triage's own group + Savior triggers
+    int     boost_targets     = 0;  // distinct boost applications (reach)
+    int     boost_overwrites  = 0;  // live boosts replaced by another caster
+    int     boost_wasted_secs = 0;  // lifetime lost to those overwrites
 };
 std::map<DeviceKey, DeviceTotals> g_deviceStats;
 
@@ -132,6 +136,38 @@ bool CastEventDevice(int device_id) {
     }
     return g_castEventDevices.count(device_id) != 0;
 }
+
+// Boost effect groups under overwrite tracking. Lifetime is carried here
+// (verified against gaa.db) so the registry can tell "replaced early" from
+// "expired then re-applied". Currently just the medic Healing Boost
+// (200 HP/tick, 1s interval, 10s — an overwrite at t=3 costs 7 ticks);
+// add Protection Boost {8964, 10.0f} / Fashion Boost {27646, 30.0f} here
+// if they come into scope.
+float BoostLifetime(int effect_group_id) {
+    switch (effect_group_id) {
+        case 8690: return 10.0f;  // Healing Boost (device 2773)
+        default:   return 0.0f;   // not tracked
+    }
+}
+
+// (caster character, device) → time of their last detected boost cast.
+// Morale boosts never enter the DeviceFiring state (instance-210: two casts,
+// uses=0, no DEVICE_USED), so cast detection lives here instead: a burst of
+// applications shares one game_time, and a same-caster gap > 2s is a new
+// cast (a real re-cast inside the window is morale-impossible anyway).
+std::map<std::pair<int64_t, int>, float> g_lastBoostCast;
+
+// (target r_nPawnId, effect group) → the live boost on that pawn. Caster
+// identity is copied at apply time; no pawn pointers are retained.
+struct BoostRec {
+    int64_t user_id      = 0;
+    int64_t character_id = 0;
+    int     task_force   = 0;
+    int     device_id    = 0;
+    float   applied_at   = 0.0f;
+    float   lifetime     = 0.0f;
+};
+std::map<std::pair<int, int>, BoostRec> g_boosts;
 
 // Devices whose prop-243 power rider must not feed the power columns.
 // Triage Wave's +250-on-rescue always overflows any pool (max reachable is
@@ -264,6 +300,9 @@ void UpsertDeviceStats(int64_t character_id) {
         m["buffed_damage_dealt"]    = kv.second.buffed_damage_dealt;
         m["protected_damage_taken"] = kv.second.protected_damage_taken;
         m["rescues"]                = kv.second.rescues;
+        m["boost_targets"]          = kv.second.boost_targets;
+        m["boost_overwrites"]       = kv.second.boost_overwrites;
+        m["boost_wasted_secs"]      = kv.second.boost_wasted_secs;
         IpcClient::Send(m.dump());
     }
 }
@@ -429,6 +468,13 @@ void MatchStats::OnChatCommand(ATgPawn* Actor, const char* event_type,
 
 void MatchStats::OnDeath(ATgPawn* Victim) {
     if (!g_enabled || !Victim) return;
+    // Death strips effects, so any boost the victim carried ended here —
+    // clear its registry entries (bots included) so a boost applied after
+    // respawn can't read as an overwrite of the pre-death one.
+    for (auto it = g_boosts.begin(); it != g_boosts.end(); ) {
+        if (it->first.first == Victim->r_nPawnId) it = g_boosts.erase(it);
+        else ++it;
+    }
     LivePlayer lp;
     if (!ResolveLive(Victim, lp)) return;  // bot deaths: no DEATH events
     PendingDeath pd;
@@ -647,7 +693,11 @@ void MatchStats::OnSaviorTrigger(ATgPawn* CreditPawn, ATgPawn* TargetPawn,
     LivePlayer lp;
     if (!ResolveLive(CreditPawn, lp)) return;  // bot-cast heals: no record
     // Savior firing = an under-25% rescue delivered by this device.
-    if (device_id > 0 && !DeviceExcluded(device_id)) {
+    // Self-rescue (a grenade at your own feet while low — observed live in
+    // instance 210) emits the event but stays out of the counter, per the
+    // skill's authored "hit a teammate" intent and the same self-exclusion
+    // the heal credit applies. Filter events on actor==target to study them.
+    if (device_id > 0 && !DeviceExcluded(device_id) && CreditPawn != TargetPawn) {
         DeviceTotals& t = g_deviceStats[{lp.character_id, lp.task_force, device_id}];
         t.user_id = lp.user_id;
         t.rescues++;
@@ -660,6 +710,91 @@ void MatchStats::OnSaviorTrigger(ATgPawn* CreditPawn, ATgPawn* TargetPawn,
     if (device_id > 0) ev["device_id"] = device_id;
     ev["detail"] = (int64_t)852;  // the skill, for symmetry with CLEANSE's category
     EmitEvent(ev, "SAVIOR");
+}
+
+void MatchStats::OnBoostApply(UTgEffectGroup* g) {
+    if (!g_enabled || !g || !g->m_Target) return;
+    const float lifetime = BoostLifetime(g->m_nEffectGroupId);
+    if (lifetime <= 0.0f) return;
+    if (!ObjectClassCache::ClassNameContains(g->m_Target, "TgPawn")) return;
+    ATgPawn* target = static_cast<ATgPawn*>(g->m_Target);
+
+    ATgPawn* credit = EffectCredit::ResolveCreditPawn(g->m_Instigator);
+    if (!credit) return;
+    LivePlayer lp;
+    if (!ResolveLive(credit, lp)) return;  // bot-cast boosts: no record
+    const int device_id = EffectCredit::ResolveDeviceId(g, credit);
+    if (device_id <= 0 || DeviceExcluded(device_id)) return;
+
+    const float now = GameTime();
+    const std::pair<int, int> key{target->r_nPawnId, g->m_nEffectGroupId};
+    auto it = g_boosts.find(key);
+    if (it != g_boosts.end() && (now - it->second.applied_at) < it->second.lifetime) {
+        // Same caster + device inside the window: a HoT tick or another
+        // effect of the same application — same record, nothing to count.
+        // A same-caster RE-cast inside the window is mechanically
+        // impossible: boosts are morale-priced with no cooldown, and
+        // morale cannot regenerate while the caster's own boost is live.
+        if (it->second.character_id == lp.character_id &&
+            it->second.device_id == device_id) {
+            return;
+        }
+        // Different caster: newest-wins overwrite. The remaining lifetime
+        // of the old instance is the wasted investment.
+        const int remaining = (int)(it->second.lifetime - (now - it->second.applied_at));
+        DeviceTotals& old_row = g_deviceStats[{it->second.character_id,
+                                               it->second.task_force,
+                                               it->second.device_id}];
+        old_row.user_id = it->second.user_id;
+        old_row.boost_overwrites++;
+        old_row.boost_wasted_secs += remaining > 0 ? remaining : 0;
+
+        nlohmann::json ev;
+        ev["actor_user_id"]      = lp.user_id;             // the overwriter
+        ev["actor_character_id"] = lp.character_id;
+        ev["actor_task_force"]   = lp.task_force;
+        FillIdentity(ev, "target", target);
+        ev["owner_user_id"]      = it->second.user_id;     // the wronged medic
+        ev["owner_character_id"] = it->second.character_id;
+        ev["device_id"]          = it->second.device_id;   // the wasted boost
+        ev["detail"]             = (int64_t)(remaining > 0 ? remaining : 0);
+        EmitEvent(ev, "BOOST_OVERWRITE");
+    }
+
+    // Fresh application (first, post-expiry, or the overwriting one): the
+    // new caster's reach grows and the registry now tracks their instance.
+    DeviceTotals& t = g_deviceStats[{lp.character_id, lp.task_force, device_id}];
+    t.user_id = lp.user_id;
+    t.boost_targets++;
+    g_boosts[key] = BoostRec{lp.user_id, lp.character_id, lp.task_force,
+                             device_id, now, lifetime};
+
+    // Cast detection (see g_lastBoostCast): first application of a burst
+    // counts the use and emits the DEVICE_USED row the DeviceFiring hook
+    // can't provide for morale abilities.
+    float& lastCast = g_lastBoostCast[{lp.character_id, device_id}];
+    if (now - lastCast > 2.0f || lastCast == 0.0f) {
+        lastCast = now;
+        t.uses++;
+        nlohmann::json used;
+        used["actor_user_id"]      = lp.user_id;
+        used["actor_character_id"] = lp.character_id;
+        used["actor_task_force"]   = lp.task_force;
+        used["device_id"]          = device_id;
+        EmitEvent(used, "DEVICE_USED");
+    }
+
+    // Per-application event so a cast's fresh-vs-stomped split is exact:
+    // a cast's BOOST_APPLY rows minus its BOOST_OVERWRITE rows = targets
+    // that had nothing running — the "was this cast justified" numerator.
+    // Morale-priced casts are rare, so the event volume is trivial.
+    nlohmann::json ap;
+    ap["actor_user_id"]      = lp.user_id;
+    ap["actor_character_id"] = lp.character_id;
+    ap["actor_task_force"]   = lp.task_force;
+    FillIdentity(ap, "target", target);
+    ap["device_id"] = device_id;
+    EmitEvent(ap, "BOOST_APPLY");
 }
 
 void MatchStats::OnBuffWindowDamage(ATgPawn* CreditPawn, int device_id,
@@ -714,6 +849,18 @@ void MatchStats::Tick() {
     if (now - g_lastTick < kTickInterval) return;
     const float dt = (g_lastTick > 0.0f) ? (now - g_lastTick) : 0.0f;
     g_lastTick = now;
+
+    // 0. Periodic device-stats safety flush. Rows otherwise persist only at
+    //    clean leave / mission end, and instances torn down without either
+    //    (test sessions, crashes) lost every still-connected player's rows
+    //    (observed instances 204 and 210). Upserts are idempotent, so a
+    //    minute-cadence resend costs a handful of IPC messages and caps the
+    //    loss window at 60s.
+    static float s_lastDeviceFlush = 0.0f;
+    if (now - s_lastDeviceFlush > 60.0f) {
+        s_lastDeviceFlush = now;
+        UpsertDeviceStats(0);
+    }
 
     // 1. Flush pending deaths nothing claimed (environment / fall / team
     //    damage kills) as killer-less DEATH events.

--- a/src/GameServer/Stats/MatchStats.cpp
+++ b/src/GameServer/Stats/MatchStats.cpp
@@ -62,6 +62,8 @@ struct DeviceTotals {
     int     power_wasted    = 0;  // prop-243 power clamped away
     int     buffed_damage_dealt    = 0;  // dealt under this device's buff
     int     protected_damage_taken = 0;  // taken under this device's buff
+    int     rescues         = 0;  // under-25% conditional deliveries:
+                                  // Triage's own group + Savior triggers
 };
 std::map<DeviceKey, DeviceTotals> g_deviceStats;
 
@@ -96,6 +98,39 @@ bool DeviceExcluded(int device_id) {
         }
     }
     return g_excludedDevices.count(device_id) != 0;
+}
+
+// Devices whose activations additionally emit a timestamped DEVICE_USED
+// event (the uses counter has no time axis; these events make per-cast
+// effectiveness and match timelines reconstructable). Deliberately narrow —
+// weapons would flood ga_match_events. Loaded once: the Group Heals family
+// (asm skill 252: Healing/Protection/Frenzy/Power/Triage Wave, Healing
+// Grenade, Purity) plus the three boosts. Extend by adding ids here.
+std::set<int> g_castEventDevices;
+bool g_castEventLoaded = false;
+
+bool CastEventDevice(int device_id) {
+    if (!g_castEventLoaded) {
+        g_castEventLoaded = true;
+        for (int id : {2838, 2773, 7559}) {  // Protection/Healing/Fashion Boost
+            g_castEventDevices.insert(id);
+        }
+        sqlite3* db = Database::GetConnection();
+        if (db != nullptr) {
+            sqlite3_stmt* stmt = nullptr;
+            if (sqlite3_prepare_v2(db,
+                    "SELECT i.item_id FROM asm_data_set_items i "
+                    "JOIN asm_data_set_devices d ON d.device_id = i.item_id "
+                    "WHERE i.skill_id = 252",
+                    -1, &stmt, nullptr) == SQLITE_OK) {
+                while (sqlite3_step(stmt) == SQLITE_ROW) {
+                    g_castEventDevices.insert(sqlite3_column_int(stmt, 0));
+                }
+            }
+            sqlite3_finalize(stmt);
+        }
+    }
+    return g_castEventDevices.count(device_id) != 0;
 }
 
 // Devices whose prop-243 power rider must not feed the power columns.
@@ -228,6 +263,7 @@ void UpsertDeviceStats(int64_t character_id) {
         m["power_wasted"]    = kv.second.power_wasted;
         m["buffed_damage_dealt"]    = kv.second.buffed_damage_dealt;
         m["protected_damage_taken"] = kv.second.protected_damage_taken;
+        m["rescues"]                = kv.second.rescues;
         IpcClient::Send(m.dump());
     }
 }
@@ -564,6 +600,18 @@ void MatchStats::OnDeviceUsed(ATgPawn* UserPawn, int device_id) {
     DeviceTotals& t = g_deviceStats[{lp.character_id, lp.task_force, device_id}];
     t.user_id = lp.user_id;
     t.uses++;
+
+    // Allowlisted activatables also emit a timestamped cast event, so
+    // per-cast effectiveness ("3 casts, which cured?") joins against the
+    // CLEANSE / SAVIOR stream on game_time instead of being inferred.
+    if (CastEventDevice(device_id)) {
+        nlohmann::json ev;
+        ev["actor_user_id"]      = lp.user_id;
+        ev["actor_character_id"] = lp.character_id;
+        ev["actor_task_force"]   = lp.task_force;
+        ev["device_id"]          = device_id;
+        EmitEvent(ev, "DEVICE_USED");
+    }
 }
 
 void MatchStats::OnDevicePowerRestore(ATgPawn* CreditPawn, int device_id,
@@ -571,18 +619,22 @@ void MatchStats::OnDevicePowerRestore(ATgPawn* CreditPawn, int device_id,
     if (!g_enabled || !CreditPawn || device_id <= 0) return;
     if (restored <= 0 && wasted <= 0) return;
     if (DeviceExcluded(device_id)) return;
+    LivePlayer lp;
+    if (!ResolveLive(CreditPawn, lp)) return;
     if (PowerStatExempt(device_id)) {
-        // Keep the conditional-fired signal visible in diagnostics even
-        // though it stays out of the stats (see PowerStatExempt).
+        // Triage: the power rider stays out of the power columns (see
+        // PowerStatExempt), but its firing IS the under-25% conditional —
+        // one power effect per rescue — so it drives the rescues counter.
+        DeviceTotals& t = g_deviceStats[{lp.character_id, lp.task_force, device_id}];
+        t.user_id = lp.user_id;
+        t.rescues++;
         if (Logger::IsChannelEnabled("devusage")) {
             Logger::Log("devusage",
-                "[TRIAGE-CONDITIONAL] credit=%p restored=%d wasted=%d (power stats exempt)\n",
+                "[TRIAGE-CONDITIONAL] credit=%p restored=%d wasted=%d (power stats exempt, rescue counted)\n",
                 (void*)CreditPawn, restored, wasted);
         }
         return;
     }
-    LivePlayer lp;
-    if (!ResolveLive(CreditPawn, lp)) return;
     DeviceTotals& t = g_deviceStats[{lp.character_id, lp.task_force, device_id}];
     t.user_id = lp.user_id;
     if (restored > 0) t.power_restored += restored;
@@ -594,6 +646,12 @@ void MatchStats::OnSaviorTrigger(ATgPawn* CreditPawn, ATgPawn* TargetPawn,
     if (!g_enabled || !CreditPawn) return;
     LivePlayer lp;
     if (!ResolveLive(CreditPawn, lp)) return;  // bot-cast heals: no record
+    // Savior firing = an under-25% rescue delivered by this device.
+    if (device_id > 0 && !DeviceExcluded(device_id)) {
+        DeviceTotals& t = g_deviceStats[{lp.character_id, lp.task_force, device_id}];
+        t.user_id = lp.user_id;
+        t.rescues++;
+    }
     nlohmann::json ev;
     ev["actor_user_id"]      = lp.user_id;
     ev["actor_character_id"] = lp.character_id;

--- a/src/GameServer/Stats/MatchStats.hpp
+++ b/src/GameServer/Stats/MatchStats.hpp
@@ -18,6 +18,20 @@ public:
     static void SetEnabled(bool enabled);
     static bool Enabled();
 
+    // Recording toggles (INSTANCE_HELLO_ACK ← control-server.json, both
+    // default true). Independent of the master enable above, which still
+    // zeroes everything on home maps.
+    //   device stats  — the server-side mirror of the client Device Stats
+    //                   tab counters (damage/healing/kills via OnDeviceCredit)
+    //   effectiveness — everything layered on top: cleanse/boost/power/
+    //                   savior tracking, buff windows, uses, DEVICE_USED
+    // The client's own tab is unaffected by either. EffectivenessEnabled()
+    // is public so upstream recorders (BuffWindowTracking's per-bullet
+    // scans) can skip their work entirely, not just discard results.
+    static void SetDeviceStatsEnabled(bool enabled);
+    static void SetEffectivenessEnabled(bool enabled);
+    static bool EffectivenessEnabled();
+
     // JOIN site (NotifyControlMessage, after GPawnSessions is populated).
     // Emits JOIN (+CLASS_CHANGE on character switch), restores banked
     // score sums into the fresh PRI on rejoin.

--- a/src/GameServer/Stats/MatchStats.hpp
+++ b/src/GameServer/Stats/MatchStats.hpp
@@ -95,6 +95,27 @@ public:
     static void OnSaviorTrigger(ATgPawn* CreditPawn, ATgPawn* TargetPawn,
                                 int device_id);
 
+    // A tracked boost effect group landed on a pawn (called from
+    // CheckEffectBuffModifier for every effect of every application AND
+    // every HoT tick — dedupe happens inside). Maintains the per-target
+    // boost registry that drives three counters on the caster's device row:
+    //   boost_targets    — distinct applications (reach; ticks and the
+    //                      group's 2nd/3rd effects fold into their record)
+    //   boost_overwrites — times THIS device's live boost was replaced by a
+    //                      different caster before expiry (newest-wins)
+    //   boost_wasted_secs— lifetime remaining at those overwrites, summed
+    // Every fresh application emits a BOOST_APPLY event, and each overwrite
+    // additionally a BOOST_OVERWRITE event (actor = the overwriter, owner =
+    // the medic whose ticks were lost, target = the pawn, device_id = the
+    // wasted device, detail = seconds remaining). A cast's APPLY rows minus
+    // its OVERWRITE rows = targets that had nothing running, so "was the
+    // second medic's cast justified" is per-incident data, not a judgment
+    // baked into a counter.
+    // Registry is (target pawnId, effect group) keyed with copied caster
+    // identity — no pawn pointers survive in it — and entries clear on the
+    // target's death so a post-respawn boost can't read as an overwrite.
+    static void OnBoostApply(UTgEffectGroup* g);
+
     // Damage that happened inside a tracked buff window (BuffWindowTracking):
     // offensive → buffed_damage_dealt on the buff device's row, defensive →
     // protected_damage_taken. Credit is the buff's caster, not the shooter.

--- a/src/GameServer/Stats/MatchStats.hpp
+++ b/src/GameServer/Stats/MatchStats.hpp
@@ -45,6 +45,62 @@ public:
                                       ATgDeployable* Deployable,
                                       bool is_beacon);
 
+    // Server-side mirror of every DeviceStats::Credit. `field` is the
+    // FDeviceStatInfo::Stats index the PRI row is about to take (kDamage /
+    // kHealing / kPlayerKills / kBotKills); the derived DPM/HPM slots are
+    // display-only and ignored here.
+    //
+    // Accumulates per (character, task force, device) for the whole match and
+    // upserts to ga_match_device_stats at leave + FlushAll. Deliberately NOT
+    // read back out of r_DeviceStats: that array is per-connection (wiped on
+    // reconnect) and caps at 9 rows, neither of which is acceptable for a
+    // persisted record. Credits arrive as increments, so summing them needs
+    // none of the r_Scores baseline/stint machinery.
+    static void OnDeviceCredit(ATgPawn* CreditPawn, int device_id,
+                               int field, int amount);
+
+    // Effectiveness pass. Both land on the same per-device row as
+    // OnDeviceCredit; cleanses additionally emit a CLEANSE event (actor =
+    // cleanser, target = cleansed pawn, device_id, detail = category code
+    // purged, flags = strip count) because "which category came off whom" is
+    // context a bare counter cannot hold.
+    //
+    // OnDeviceCleanse ← CleanseTracking::OnRemoved, removed > 0 only.
+    // OnDeviceOverheal ← TrackStats heal path: the magnitude the
+    // missing-health clamp threw away (heal cast on a topped-up target).
+    static void OnDeviceCleanse(ATgPawn* CreditPawn, ATgPawn* TargetPawn,
+                                int device_id, int category, int removed);
+    static void OnDeviceOverheal(ATgPawn* CreditPawn, int device_id,
+                                 int amount);
+
+    // One DeviceFiring activation (ProcessEvent DeviceFiringBeginState) —
+    // the "used" denominator. Per hold for continuous fire.
+    static void OnDeviceUsed(ATgPawn* UserPawn, int device_id);
+
+    // Property-243 Power Pool restore, split at apply time like the heal
+    // clamp: restored = what fit in the target's pool, wasted = the rest.
+    // Triage Wave (5808) is exempt from the power columns: its +250 rider
+    // always overflows the 160-max pool and is a designed rescue mechanic,
+    // not wasteful play. Its conditional firing logs on `devusage` only.
+    static void OnDevicePowerRestore(ATgPawn* CreditPawn, int device_id,
+                                     int restored, int wasted);
+
+    // Group Heal Savior (skill 852, eg 16587) fired: a group heal landed on
+    // a teammate under 25% with the skill slotted. Emits a SAVIOR event
+    // (actor = medic, target = rescued pawn, device_id = the delivering
+    // group heal, detail = 852). The source-device field on skill instances
+    // was verified reliable by single-cast tests (instances 207/208).
+    // Triage Wave never procs this skill — its rescues are visible via its
+    // own conditional group instead.
+    static void OnSaviorTrigger(ATgPawn* CreditPawn, ATgPawn* TargetPawn,
+                                int device_id);
+
+    // Damage that happened inside a tracked buff window (BuffWindowTracking):
+    // offensive → buffed_damage_dealt on the buff device's row, defensive →
+    // protected_damage_taken. Credit is the buff's caster, not the shooter.
+    static void OnBuffWindowDamage(ATgPawn* CreditPawn, int device_id,
+                                   bool offensive, int amount);
+
     // ProcessEvent intercept on TgPawn.TriggerBeaconEntrance.
     static void OnBeaconSpawnUsed(ATgPawn* User, ATgPawn* Deployer);
 

--- a/src/GameServer/TgGame/TgEffect/CheckEffectBuffModifier/TgEffect__CheckEffectBuffModifier.cpp
+++ b/src/GameServer/TgGame/TgEffect/CheckEffectBuffModifier/TgEffect__CheckEffectBuffModifier.cpp
@@ -110,6 +110,9 @@ void __fastcall TgEffect__CheckEffectBuffModifier::Call(UTgEffect* effect, void*
 		HitSituationalMitigation::BeginImpactMitigation(effect);
 	} else {
 		HitSituationalMitigation::NoteDebuffApplied(effect);
+		// Tracked-boost registry (reach + overwrite waste). Gated inside on
+		// the group id; HoT ticks and multi-effect groups dedupe there too.
+		MatchStats::OnBoostApply(g);
 		// Property-140 "Remove Effect": capture cleanse provenance before
 		// ApplyEffect routes to RemoveEffectGroupsByCategory (which never
 		// sees the instigator). No-op for every other property.

--- a/src/GameServer/TgGame/TgEffect/CheckEffectBuffModifier/TgEffect__CheckEffectBuffModifier.cpp
+++ b/src/GameServer/TgGame/TgEffect/CheckEffectBuffModifier/TgEffect__CheckEffectBuffModifier.cpp
@@ -2,6 +2,9 @@
 #include "src/GameServer/TgGame/_effect_core/OriginResolver.hpp"
 #include "src/GameServer/TgGame/_effect_core/DeviceLookup.hpp"
 #include "src/GameServer/TgGame/_effect_core/HitSituationalMitigation.hpp"
+#include "src/GameServer/TgGame/_effect_core/CleanseTracking.hpp"
+#include "src/GameServer/TgGame/_effect_core/EffectCredit.hpp"
+#include "src/GameServer/Stats/MatchStats.hpp"
 #include "src/GameServer/Utils/ObjectClassCache/ObjectClassCache.hpp"
 #include "src/Utils/Logger/Logger.hpp"
 
@@ -62,6 +65,39 @@ void __fastcall TgEffect__CheckEffectBuffModifier::Call(UTgEffect* effect, void*
 	UTgEffectGroup* g = effect->m_EffectGroup;
 	if (!g) return;
 
+	// Type-505 application capture (devusage) — settles what a skill-sourced
+	// situational instance actually carries at apply time. The KI/Eagle-Eye
+	// finding (theorycraft-console: killer-instinct-diag.md §3) shows skill
+	// groups resolve origin differently from device groups (KI's potency
+	// query "finds nothing"), so Group Heal Savior (eg 16587) attribution —
+	// which delivering wave, if any — must be read from a live capture, not
+	// assumed. Rare events (situational skill triggers only); one line each.
+	if (g->m_nType == 505 && Logger::IsChannelEnabled("devusage")) {
+		Logger::Log("devusage",
+			"[505-APPLY] egId=%d sit=%d prop=%d val=%.1f inst=%p srcInstId=%d srcSkillId=%d target=%p\n",
+			g->m_nEffectGroupId, g->m_nSituationalType, effect->m_nPropertyId,
+			*NewValue, (void*)g->m_Instigator, g->m_nSourceDeviceInstId,
+			g->m_nSourceDeviceSkillId, (void*)g->m_Target);
+	}
+
+	// Group Heal Savior (eg 16587) trigger → SAVIOR match event, with the
+	// delivering device. Single-cast tests (instances 207/208, 2026-08-04)
+	// settled the instance's m_nSourceDeviceInstId: it IS the delivering
+	// group-heal's inventory id, reliably — the earlier "wrong device"
+	// reading came from mis-grouping a multi-cast log. Those same tests
+	// showed Triage Wave does NOT proc this skill (its own 505 fires
+	// instead), so Triage rescues are covered by eg 22375, not here.
+	// Keyed on the prop-155 effect so the group's second effect
+	// (GroundSpeed) doesn't double-fire the event.
+	if (g->m_nEffectGroupId == 16587 && effect->m_nPropertyId == 155) {
+		ATgPawn* saveTarget =
+			(g->m_Target && ObjectClassCache::ClassNameContains(g->m_Target, "TgPawn"))
+				? static_cast<ATgPawn*>(g->m_Target) : nullptr;
+		ATgPawn* saveCredit = EffectCredit::ResolveCreditPawn(g->m_Instigator);
+		MatchStats::OnSaviorTrigger(saveCredit, saveTarget,
+			EffectCredit::ResolveDeviceId(g, saveCredit));
+	}
+
 	// Self-shot mitigation bracket. This native is the last thing that runs on
 	// an effect before its value reaches the target, which makes it the one
 	// place that sees both halves of the type-505 ordering defect at the right
@@ -74,6 +110,28 @@ void __fastcall TgEffect__CheckEffectBuffModifier::Call(UTgEffect* effect, void*
 		HitSituationalMitigation::BeginImpactMitigation(effect);
 	} else {
 		HitSituationalMitigation::NoteDebuffApplied(effect);
+		// Property-140 "Remove Effect": capture cleanse provenance before
+		// ApplyEffect routes to RemoveEffectGroupsByCategory (which never
+		// sees the instigator). No-op for every other property.
+		CleanseTracking::NotePendingCleanse(effect);
+
+		// Property-243 Power Pool restore (Power Wave 26097/16921, Triage
+		// Wave's conditional half 22375, …). Runs before ApplyToProperty, so
+		// the target's pool is still pre-restore — split the pre-buff-scale
+		// value into restored vs. wasted the same way the heal clamp does.
+		// Triage Wave carries power ONLY in its HP-gated group, so a nonzero
+		// power_restored on it doubles as "the conditional half fired".
+		if (effect->m_nPropertyId == 243 && *NewValue > 0.0f &&
+		    g->m_Target && ObjectClassCache::ClassNameContains(g->m_Target, "TgPawn")) {
+			ATgPawn* tp = static_cast<ATgPawn*>(g->m_Target);
+			float missing = tp->r_fMaxPowerPool - tp->r_fCurrentPowerPool;
+			if (missing < 0.0f) missing = 0.0f;
+			const float restored = *NewValue < missing ? *NewValue : missing;
+			ATgPawn* credit = EffectCredit::ResolveCreditPawn(g->m_Instigator);
+			MatchStats::OnDevicePowerRestore(credit,
+				EffectCredit::ResolveDeviceId(g, credit),
+				(int)restored, (int)(*NewValue - restored));
+		}
 	}
 
 	const float origValue = *NewValue;

--- a/src/GameServer/TgGame/TgEffect/TrackStats/TgEffect__TrackStats.cpp
+++ b/src/GameServer/TgGame/TgEffect/TrackStats/TgEffect__TrackStats.cpp
@@ -17,6 +17,7 @@
 #include "src/GameServer/TgGame/Morale/MoraleCredit.hpp"
 #include "src/GameServer/Stats/MatchStats.hpp"
 #include "src/GameServer/Stats/DeviceStats.hpp"
+#include "src/GameServer/TgGame/_effect_core/BuffWindowTracking.hpp"
 #include "src/Utils/Logger/Logger.hpp"
 #include <string>
 
@@ -711,6 +712,16 @@ void __fastcall TgEffect__TrackStats::Call(UTgEffect* /*Effect*/, void* /*edx*/,
 				if (effectiveHeal > missing) effectiveHeal = missing;
 				DeviceStats::Credit(damageCreditPawn, creditDeviceId,
 				                    DeviceStats::kHealing, (int)effectiveHeal);
+
+				// The clamped-away remainder is the wasted-heal metric:
+				// healing thrown at a target that had no room for it. Same
+				// gating as the credit above (self-heal and own-gear repair
+				// already filtered), so healing + overheal = total output.
+				const int overheal = (int)(magnitude - effectiveHeal);
+				if (overheal > 0) {
+					MatchStats::OnDeviceOverheal(damageCreditPawn,
+					                             creditDeviceId, overheal);
+				}
 			}
 		}
 	}
@@ -745,6 +756,12 @@ void __fastcall TgEffect__TrackStats::Call(UTgEffect* /*Effect*/, void* /*edx*/,
 			}
 			DeviceStats::Credit(damageCreditPawn, creditDeviceId,
 			                    DeviceStats::kDamage, (int)magnitude);
+			// Buff-window benefit: same magnitude, credited to whoever's
+			// Frenzy is on the shooter / Protection is on the victim.
+			// Separate columns on the buff device's row — no collision with
+			// the weapon credit above.
+			BuffWindowTracking::OnEnemyPawnDamage(Instigator, targetPawn,
+			                                      (int)magnitude);
 		} else if (targetIsDeployable) {
 			TgPawn__TrackDamagedBot::Call(damageCreditPawn, nullptr,
 				nullptr, 0, (int)magnitude);

--- a/src/GameServer/TgGame/TgEffectManager/RemoveEffectGroupsByCategory/TgEffectManager__RemoveEffectGroupsByCategory.cpp
+++ b/src/GameServer/TgGame/TgEffectManager/RemoveEffectGroupsByCategory/TgEffectManager__RemoveEffectGroupsByCategory.cpp
@@ -1,6 +1,7 @@
 #include "src/GameServer/TgGame/TgEffectManager/RemoveEffectGroupsByCategory/TgEffectManager__RemoveEffectGroupsByCategory.hpp"
 #include "src/GameServer/TgGame/TgEffectGroup/RemoveEffects/TgEffectGroup__RemoveEffects.hpp"
 #include "src/GameServer/TgGame/_effect_core/HitSituationalMitigation.hpp"
+#include "src/GameServer/TgGame/_effect_core/CleanseTracking.hpp"
 #include "src/Utils/Logger/Logger.hpp"
 
 // TgEffectManager::RemoveEffectGroupsByCategory — reimplements the stripped stub
@@ -79,5 +80,11 @@ bool __fastcall TgEffectManager__RemoveEffectGroupsByCategory::Call(ATgEffectMan
 	}
 
 	if (removed > 0) Manager->bNetDirty = 1;
+
+	// Cleanse stats: attribute the strip count to the player + device whose
+	// property-140 effect triggered this call. Internal callers (the 431/99
+	// mitigation bracket, invuln refcounting) are filtered inside.
+	CleanseTracking::OnRemoved(Manager, nCategoryCode, nQuantity, removed);
+
 	return removed > 0;
 }

--- a/src/GameServer/TgGame/_effect_core/BuffWindowTracking.cpp
+++ b/src/GameServer/TgGame/_effect_core/BuffWindowTracking.cpp
@@ -1,0 +1,65 @@
+#include "src/GameServer/TgGame/_effect_core/BuffWindowTracking.hpp"
+#include "src/GameServer/TgGame/_effect_core/EffectCredit.hpp"
+#include "src/GameServer/Stats/MatchStats.hpp"
+#include "src/Utils/Logger/Logger.hpp"
+
+namespace {
+
+// The tuning table. offensive=true → credit damage the buffed pawn DEALS;
+// false → credit damage the buffed pawn TAKES. See header for the rules.
+struct TrackedBuff {
+	int  effectGroupId;
+	bool offensive;
+};
+constexpr TrackedBuff kTracked[] = {
+	{ 10746, true  },   // Frenzy Wave      (+25 dmg/attack type, 10s)
+	{ 10740, false },   // Protection Wave  (+10 Physical protection, 7s)
+	{  8964, false },   // Protection Boost (+25 protection/attack type, 10s)
+	// Group Heal Savior (+10 Phys +10% speed, 5s) — skill-sourced, but its
+	// instance's source-device id resolves to the DELIVERING group heal
+	// (verified instances 207/208), so damage-taken-under-savior lands on
+	// the wave/grenade that applied it. Refresh rule (836): a second medic
+	// re-triggering extends the FIRST medic's instance, so extension-window
+	// damage credits the original caster — known, accepted bias.
+	{ 16587, false },
+};
+
+// Scan `pawn`'s applied groups for tracked entries of the wanted polarity and
+// credit `amount` to each match's caster + device.
+void ScanAndCredit(ATgPawn* pawn, bool offensive, int amount) {
+	if (!pawn || !pawn->r_EffectManager) return;
+	ATgEffectManager* mgr = pawn->r_EffectManager;
+
+	for (int i = 0; i < mgr->s_AppliedEffectGroups.Count; i++) {
+		UTgEffectGroup* g = mgr->s_AppliedEffectGroups.Data[i];
+		// Null / small-int corruption guard, same as RemoveEffectGroupsByCategory.
+		if (!g || reinterpret_cast<uintptr_t>(g) < 0x10000u) continue;
+
+		for (const TrackedBuff& t : kTracked) {
+			if (t.offensive != offensive) continue;
+			if (g->m_nEffectGroupId != t.effectGroupId) continue;
+
+			ATgPawn* credit = EffectCredit::ResolveCreditPawn(g->m_Instigator);
+			const int deviceId = EffectCredit::ResolveDeviceId(g, credit);
+			if (Logger::IsChannelEnabled("devusage")) {
+				Logger::Log("devusage",
+					"[BUFF-WINDOW] egId=%d %s pawn=%p amount=%d credit=%p deviceId=%d\n",
+					t.effectGroupId, offensive ? "dealt" : "taken",
+					(void*)pawn, amount, (void*)credit, deviceId);
+			}
+			MatchStats::OnBuffWindowDamage(credit, deviceId, offensive, amount);
+		}
+	}
+}
+
+}  // namespace
+
+namespace BuffWindowTracking {
+
+void OnEnemyPawnDamage(ATgPawn* shooter, ATgPawn* victim, int amount) {
+	if (amount <= 0) return;
+	ScanAndCredit(shooter, /*offensive=*/true,  amount);
+	ScanAndCredit(victim,  /*offensive=*/false, amount);
+}
+
+}  // namespace BuffWindowTracking

--- a/src/GameServer/TgGame/_effect_core/BuffWindowTracking.cpp
+++ b/src/GameServer/TgGame/_effect_core/BuffWindowTracking.cpp
@@ -57,6 +57,10 @@ void ScanAndCredit(ATgPawn* pawn, bool offensive, int amount) {
 namespace BuffWindowTracking {
 
 void OnEnemyPawnDamage(ATgPawn* shooter, ATgPawn* victim, int amount) {
+	// Effectiveness toggle checked HERE, not just inside MatchStats — with
+	// recording off the applied-group scans shouldn't run at all, this
+	// being the only per-bullet cost the effectiveness pass added.
+	if (!MatchStats::EffectivenessEnabled()) return;
 	if (amount <= 0) return;
 	ScanAndCredit(shooter, /*offensive=*/true,  amount);
 	ScanAndCredit(victim,  /*offensive=*/false, amount);

--- a/src/GameServer/TgGame/_effect_core/BuffWindowTracking.hpp
+++ b/src/GameServer/TgGame/_effect_core/BuffWindowTracking.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "src/pch.hpp"
+
+// BuffWindowTracking — attributes combat that happens WHILE a tracked buff is
+// active to the player + device that applied the buff. This is the "benefit"
+// metric for pure-buff devices, which otherwise measure as nothing (no heal,
+// no cleanse, no damage of their own).
+//
+//   offensive window: damage dealt BY a buffed pawn  → buffed_damage_dealt
+//   defensive window: damage taken BY a buffed pawn  → protected_damage_taken
+//
+// Called from TgEffect__TrackStats' enemy-damage branch, after the shooter's
+// own damage credit. The scan walks the pawn's s_AppliedEffectGroups for the
+// group ids in kTracked below; each applied instance carries its own
+// m_Instigator + source device, so attribution is per-instance:
+//
+//   * Caster overwrite ("B frenzies over A's frenzy") is self-resolving. All
+//     tracked groups have stack_count_max=0 with replace-on-reapply rules
+//     (157 Strongest-Wins measures as newest-wins in practice — 2026-08-03,
+//     doc §6 — and 156 IS newest-wins), so exactly one instance of a group
+//     can exist on a pawn, and it belongs to whoever cast last. Damage before
+//     the overwrite credited A, damage after credits B. No double counting.
+//   * The shooter's own damage row is untouched — these are separate columns
+//     on the BUFF device's row, so a Frenzy-buffed Raven SMG kill counts the
+//     damage on the SMG row (damage) and on Frenzy Wave's row
+//     (buffed_damage_dealt) without colliding.
+//
+// ============================ TUNING TABLE =================================
+// kTracked in the .cpp is the parameter surface: one line per effect group,
+// offensive or defensive. Group ids verified against gaa.db 2026-08-04.
+// Currently: Frenzy Wave 10746 (offensive, 10s) · Protection Wave 10740
+// (defensive, 7s) · Protection Boost 8964 (defensive, 10s) · Group Heal
+// Savior 16587 (defensive, 5s, attributed to the delivering group heal).
+// ===========================================================================
+namespace BuffWindowTracking {
+
+// Record one enemy damage event on a pawn victim. `shooter` is the actual
+// firing pawn (NOT pet-resolved — the buff sits on the pet/pawn that fired),
+// `victim` the pawn hit, `amount` the post-mitigation magnitude.
+void OnEnemyPawnDamage(ATgPawn* shooter, ATgPawn* victim, int amount);
+
+}  // namespace BuffWindowTracking

--- a/src/GameServer/TgGame/_effect_core/CleanseTracking.cpp
+++ b/src/GameServer/TgGame/_effect_core/CleanseTracking.cpp
@@ -1,0 +1,109 @@
+#include "src/GameServer/TgGame/_effect_core/CleanseTracking.hpp"
+#include "src/GameServer/TgGame/_effect_core/EffectCredit.hpp"
+#include "src/GameServer/Stats/MatchStats.hpp"
+#include "src/GameServer/Utils/ObjectClassCache/ObjectClassCache.hpp"
+#include "src/Utils/Logger/Logger.hpp"
+
+namespace {
+
+// The one in-flight cleanse. Valid between NotePendingCleanse and the
+// RemoveEffectGroupsByCategory call the same ApplyEffect issues next.
+struct PendingCleanse {
+	AActor*  target       = nullptr;  // g->m_Target — the pawn being cleansed
+	ATgPawn* creditPawn   = nullptr;  // instigator, pet/deployable → owner
+	int      deviceId     = 0;        // asm device id, 0 if unresolved
+	int      effectGroupId = 0;       // diagnostics only
+	bool     armed        = false;
+};
+PendingCleanse g_pending;
+
+}  // namespace
+
+namespace CleanseTracking {
+
+void NotePendingCleanse(UTgEffect* effect) {
+	if (!effect || effect->m_nPropertyId != 140) return;
+	UTgEffectGroup* g = effect->m_EffectGroup;
+	if (!g || !g->m_Target) return;
+
+	ATgPawn* creditPawn = EffectCredit::ResolveCreditPawn(g->m_Instigator);
+
+	g_pending.target        = g->m_Target;
+	g_pending.creditPawn    = creditPawn;
+	g_pending.deviceId      = EffectCredit::ResolveDeviceId(g, creditPawn);
+	g_pending.effectGroupId = g->m_nEffectGroupId;
+	g_pending.armed         = true;
+
+	if (Logger::IsChannelEnabled("devusage")) {
+		Logger::Log("devusage",
+			"[CLEANSE-NOTE] egId=%d target=%p credit=%p deviceId=%d\n",
+			g->m_nEffectGroupId, (void*)g->m_Target, (void*)creditPawn,
+			g_pending.deviceId);
+	}
+}
+
+void OnRemoved(ATgEffectManager* Manager, int nCategoryCode, int nQuantity,
+               int removed) {
+	// Mitigation bracket — every damaging impact enters the function with
+	// exactly these args (TgEffectDamage.uc:206). Never a cleanse, and it
+	// must not consume a pending record either.
+	if (nCategoryCode == 431 && nQuantity == 99) return;
+	if (!Manager) return;
+
+	if (!g_pending.armed) {
+		// Unarmed callers, catalogued from the instance-199 full-logging
+		// capture: UC housekeeping polls (Rest 1095 and Team Stealth Buff
+		// 1036, every pawn, continuously) — never player cleanses. The same
+		// capture settled the miss question: a cleanse's non-matching
+		// categories produce NO purge call at all (no unarmed burst around a
+		// real NOTE→consume pair), so the game pre-filters remove-effect
+		// groups upstream — "cast but nothing to strip" is invisible here by
+		// design of the UC, not a gap in this hook. Only removed>0 is worth
+		// a line: an unarmed call that actually stripped something would be
+		// a provenance miss and must stay visible.
+		if (removed > 0 && Logger::IsChannelEnabled("devusage")) {
+			Logger::Log("devusage",
+				"[CLEANSE-UNATTRIBUTED] mgr=%p owner=%p cat=%d qty=%d removed=%d\n",
+				(void*)Manager, (void*)Manager->r_Owner, nCategoryCode,
+				nQuantity, removed);
+		}
+		return;
+	}
+
+	// A note is only valid for the immediately-following purge. Wrong pawn →
+	// drop it (logged); letting it linger could mis-attribute an unrelated
+	// purge on the noted pawn much later.
+	if ((AActor*)Manager->r_Owner != g_pending.target) {
+		if (Logger::IsChannelEnabled("devusage")) {
+			Logger::Log("devusage",
+				"[CLEANSE-MISMATCH] egId=%d noted target=%p, purge on owner=%p cat=%d removed=%d — note dropped\n",
+				g_pending.effectGroupId, (void*)g_pending.target,
+				(void*)Manager->r_Owner, nCategoryCode, removed);
+		}
+		g_pending = PendingCleanse{};
+		return;
+	}
+
+	const PendingCleanse rec = g_pending;
+	g_pending = PendingCleanse{};
+
+	if (Logger::IsChannelEnabled("devusage")) {
+		Logger::Log("devusage",
+			"[CLEANSE] egId=%d cat=%d removed=%d credit=%p deviceId=%d target=%p\n",
+			rec.effectGroupId, nCategoryCode, removed, (void*)rec.creditPawn,
+			rec.deviceId, (void*)rec.target);
+	}
+
+	// "Used, ineffective, 0 removed" stays out of the stats — only actual
+	// strips count. removed==0 still consumed the record above so the next
+	// category's call starts clean.
+	if (removed <= 0 || !rec.creditPawn) return;
+
+	ATgPawn* targetPawn =
+		ObjectClassCache::ClassNameContains(rec.target, "TgPawn")
+			? static_cast<ATgPawn*>(rec.target) : nullptr;
+	MatchStats::OnDeviceCleanse(rec.creditPawn, targetPawn, rec.deviceId,
+	                            nCategoryCode, removed);
+}
+
+}  // namespace CleanseTracking

--- a/src/GameServer/TgGame/_effect_core/CleanseTracking.hpp
+++ b/src/GameServer/TgGame/_effect_core/CleanseTracking.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "src/pch.hpp"
+
+// CleanseTracking — attributes RemoveEffectGroupsByCategory purges to the
+// player + device that cast the cleanse, so the count the reimplementation
+// already computes (and discarded until now) reaches match stats.
+//
+// A cleanse is a property-140 ("Remove Effect") effect: TgEffect.ApplyEffect
+// sees m_nPropertyId == 140 and calls RemoveEffectGroupsByCategory on the
+// TARGET's manager. The manager call carries no instigator, so provenance is
+// captured one step earlier: CheckEffectBuffModifier runs on every effect
+// before its value is consumed (TgEffect.uc:115 — the same ordering the
+// HitSituationalMitigation brackets rely on), and there the effect still
+// knows its group → instigator, target, and source device.
+//
+//   NotePendingCleanse()  ← TgEffect::CheckEffectBuffModifier, m_nPropertyId 140
+//   OnRemoved()           ← TgEffectManager::RemoveEffectGroupsByCategory,
+//                           after the purge loop, with the `removed` count
+//
+// The pending record is single-slot: within one ApplyEffect the note is
+// immediately followed by that effect's own Remove call, nothing interleaves
+// (ApplyEffects applies effects one at a time, fully synchronously). OnRemoved
+// consumes only when the manager's owner matches the noted target; the
+// (431, 99) mitigation bracket — which enters the same function on every
+// damaging impact — is skipped before the consume check, so it can neither
+// count as a cleanse nor eat a pending record.
+//
+// If the note never fires for a real cleanse (ApplyEffect branching to the
+// purge before CheckEffectBuffModifier would contradict the KI ordering, but
+// TgEffect.uc:115's surroundings are unverified for the 140 branch — doc
+// §8.3), removals show up as "unattributed" on the `devusage` channel instead
+// of being miscounted. Self-cleanse counts: Sealed Systems and Purity are
+// self-target devices, so stripping your own debuffs IS effective use.
+namespace CleanseTracking {
+
+// Record the pending cleanse context off a property-140 effect. No-op for
+// any other property id.
+void NotePendingCleanse(UTgEffect* effect);
+
+// Consume the pending record and credit `removed` stripped groups to the
+// noted player + device. Call after the purge loop with the loop's count;
+// safe to call for every invocation (internal callers are filtered here).
+void OnRemoved(ATgEffectManager* Manager, int nCategoryCode, int nQuantity,
+               int removed);
+
+}  // namespace CleanseTracking

--- a/src/GameServer/TgGame/_effect_core/EffectCredit.hpp
+++ b/src/GameServer/TgGame/_effect_core/EffectCredit.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "src/pch.hpp"
+#include "src/GameServer/TgGame/_effect_core/OriginResolver.hpp"
+#include "src/GameServer/TgGame/_effect_core/DeviceLookup.hpp"
+#include "src/GameServer/Stats/DeviceStats.hpp"
+#include "src/GameServer/Utils/ObjectClassCache/ObjectClassCache.hpp"
+
+// EffectCredit — shared resolution of "who gets scoreboard credit for this
+// effect group, and which player-equipped device produced it". Factored out
+// of CleanseTracking when power-restore and buff-window recording needed the
+// identical logic. Mirrors TrackStats conventions: pawn directly (pet →
+// r_Owner), deployable → its deploying pawn / spawning device.
+namespace EffectCredit {
+
+inline ATgPawn* ResolveCreditPawn(AActor* inst) {
+	if (!inst) return nullptr;
+	if (ObjectClassCache::ClassNameContains(inst, "TgPawn")) {
+		ATgPawn* p = static_cast<ATgPawn*>(inst);
+		return p->r_Owner ? p->r_Owner : p;
+	}
+	if (ObjectClassCache::ClassNameContains(inst, "TgDeploy")) {
+		APawn* deployer = inst->Instigator;
+		if (deployer && ObjectClassCache::ClassNameContains(deployer, "TgPawn")) {
+			return static_cast<ATgPawn*>(deployer);
+		}
+	}
+	return nullptr;
+}
+
+// Effect group → asm device id. Canonical instance-id path first
+// (OriginResolver + the pawn's equipped-device scan), then the deployable
+// r_Owner fallback TrackStats uses when the fire mode is deployable-owned.
+// Returns 0 when unresolvable.
+inline int ResolveDeviceId(UTgEffectGroup* g, ATgPawn* creditPawn) {
+	if (!g) return 0;
+	OriginResolver::DeviceOrigin origin = OriginResolver::Resolve(g);
+	if (origin.instId != 0 && creditPawn) {
+		ATgDevice* d = DeviceLookup::DeviceByInstanceId(creditPawn, origin.instId);
+		if (d && d->r_nDeviceId > 0) return d->r_nDeviceId;
+	}
+	AActor* inst = g->m_Instigator;
+	if (inst && ObjectClassCache::ClassNameContains(inst, "TgDeploy")) {
+		ATgDeployable* dep = static_cast<ATgDeployable*>(inst);
+		if (dep->r_Owner && dep->r_Owner->r_nDeviceId > 0) {
+			return dep->r_Owner->r_nDeviceId;
+		}
+		return DeviceStats::DeviceIdFromDeployableId(dep->r_nDeployableId);
+	}
+	return 0;
+}
+
+}  // namespace EffectCredit

--- a/src/IpcClient/IpcClient.cpp
+++ b/src/IpcClient/IpcClient.cpp
@@ -460,9 +460,16 @@ void IpcClient::DrainInbound() {
         } else if (type == IpcProtocol::MSG_INSTANCE_HELLO_ACK) {
             bool accepted = j.value("accepted", false);
             bool stats_enabled = j.value("stats_enabled", false);
+            // Recording toggles default TRUE when absent, so an older
+            // control server without the fields keeps today's behaviour.
+            bool device_stats  = j.value("device_stats_enabled", true);
+            bool effectiveness = j.value("effectiveness_enabled", true);
             MatchStats::SetEnabled(stats_enabled);
-            Logger::Log("ipc", "[IPC] INSTANCE_HELLO_ACK: accepted=%d stats=%d\n",
-                (int)accepted, (int)stats_enabled);
+            MatchStats::SetDeviceStatsEnabled(device_stats);
+            MatchStats::SetEffectivenessEnabled(effectiveness);
+            Logger::Log("ipc",
+                "[IPC] INSTANCE_HELLO_ACK: accepted=%d stats=%d device_stats=%d effectiveness=%d\n",
+                (int)accepted, (int)stats_enabled, (int)device_stats, (int)effectiveness);
         } else if (type == IpcProtocol::MSG_PLAYER_REGISTER) {
             std::string guid        = j.value("session_guid", "");
             std::string pname       = j.value("player_name", "");

--- a/src/Shared/IpcProtocol.hpp
+++ b/src/Shared/IpcProtocol.hpp
@@ -86,6 +86,27 @@ constexpr const char* MSG_MATCH_EVENT = "MATCH_EVENT";
 //     "time_played_seconds": <float> }
 constexpr const char* MSG_MATCH_STATS = "MATCH_STATS";
 
+// Absolute per-device totals for ga_match_device_stats — the server-side
+// record of the same counters DeviceStats replicates to the end-of-mission
+// Device Stats tab. One message per (character, task force, device) at leave
+// and at FlushAll. Upsert keyed (instance_id, character_id, task_force,
+// device_id) — idempotent, resend-safe. No DPM/HPM: those are rates derived
+// from ga_match_player_stats.time_played_seconds, not stored.
+//   { "type": "MATCH_DEVICE_STATS", "instance_id": <int64>,
+//     "user_id": <int64>, "character_id": <int64>, "task_force": <int>,
+//     "device_id": <int>, "damage": <int>, "healing": <int>,
+//     "player_kills": <int>, "bot_kills": <int>,
+//     "debuffs_removed": <int>, "overheal": <int>, "uses": <int>,
+//     "power_restored": <int>, "power_wasted": <int>,
+//     "buffed_damage_dealt": <int>, "protected_damage_taken": <int> }
+// debuffs_removed = effect groups stripped by this device's property-140
+// cleanses; overheal = heal magnitude clamped away on full-health targets;
+// uses = DeviceFiring activations; power_restored/power_wasted = prop-243
+// Power Pool split at the pool cap; buffed_damage_dealt / protected_damage_
+// taken = damage dealt/taken by pawns inside this device's tracked buff
+// window (BuffWindowTracking's table).
+constexpr const char* MSG_MATCH_DEVICE_STATS = "MATCH_DEVICE_STATS";
+
 // Sent by a mission instance at the game-mode-specific pre-warm trigger
 // (e.g. when one team passes the 50% threshold, or a 60s-remaining alert
 // fires — exact trigger TBD per game mode). Asks the control server to

--- a/src/Shared/IpcProtocol.hpp
+++ b/src/Shared/IpcProtocol.hpp
@@ -107,8 +107,14 @@ constexpr const char* MSG_MATCH_STATS = "MATCH_STATS";
 // taken = damage dealt/taken by pawns inside this device's tracked buff
 // window (BuffWindowTracking's table); rescues = under-25% conditional
 // deliveries (Triage's own group, or a Savior trigger this device carried).
-// Allowlisted activatables (group heals + boosts) additionally emit
-// timestamped DEVICE_USED MATCH_EVENT rows for per-cast joins.
+// boost_targets / boost_overwrites / boost_wasted_secs = tracked-boost
+// reach and newest-wins overwrite waste. Every fresh boost application
+// emits a BOOST_APPLY MATCH_EVENT and each overwrite a BOOST_OVERWRITE
+// (actor = the overwriter, owner = the medic whose ticks were lost,
+// detail = seconds remaining) — a cast's APPLY minus OVERWRITE rows =
+// its fresh coverage. Allowlisted activatables (group heals + boosts)
+// additionally emit timestamped DEVICE_USED MATCH_EVENT rows for
+// per-cast joins.
 constexpr const char* MSG_MATCH_DEVICE_STATS = "MATCH_DEVICE_STATS";
 
 // Sent by a mission instance at the game-mode-specific pre-warm trigger

--- a/src/Shared/IpcProtocol.hpp
+++ b/src/Shared/IpcProtocol.hpp
@@ -98,13 +98,17 @@ constexpr const char* MSG_MATCH_STATS = "MATCH_STATS";
 //     "player_kills": <int>, "bot_kills": <int>,
 //     "debuffs_removed": <int>, "overheal": <int>, "uses": <int>,
 //     "power_restored": <int>, "power_wasted": <int>,
-//     "buffed_damage_dealt": <int>, "protected_damage_taken": <int> }
+//     "buffed_damage_dealt": <int>, "protected_damage_taken": <int>,
+//     "rescues": <int> }
 // debuffs_removed = effect groups stripped by this device's property-140
 // cleanses; overheal = heal magnitude clamped away on full-health targets;
 // uses = DeviceFiring activations; power_restored/power_wasted = prop-243
 // Power Pool split at the pool cap; buffed_damage_dealt / protected_damage_
 // taken = damage dealt/taken by pawns inside this device's tracked buff
-// window (BuffWindowTracking's table).
+// window (BuffWindowTracking's table); rescues = under-25% conditional
+// deliveries (Triage's own group, or a Savior trigger this device carried).
+// Allowlisted activatables (group heals + boosts) additionally emit
+// timestamped DEVICE_USED MATCH_EVENT rows for per-cast joins.
 constexpr const char* MSG_MATCH_DEVICE_STATS = "MATCH_DEVICE_STATS";
 
 // Sent by a mission instance at the game-mode-specific pre-warm trigger

--- a/src/Shared/IpcProtocol.hpp
+++ b/src/Shared/IpcProtocol.hpp
@@ -38,6 +38,10 @@ constexpr const char* MSG_PLAYER_LEAVE = "PLAYER_LEAVE";
 constexpr const char* MSG_PLAYER_CLOSE = "PLAYER_CLOSE";
 
 constexpr const char* MSG_INSTANCE_HELLO     = "INSTANCE_HELLO";
+// ACK fields: accepted, stats_enabled (master — false on home maps), plus
+// the recording toggles device_stats_enabled / effectiveness_enabled
+// (control-server.json, both default true; the DLL also defaults absent
+// fields to true so an older control server keeps full recording).
 constexpr const char* MSG_INSTANCE_HELLO_ACK = "INSTANCE_HELLO_ACK";
 constexpr const char* MSG_INSTANCE_READY     = "INSTANCE_READY";
 


### PR DESCRIPTION
## What this is

The end-of-mission Device Stats tab numbers existed only in the PRI — per-connection,
9-row-capped, gone when the match ends. This PR records them server-side and layers
effectiveness metrics on top, so a medic's *quality* of play (rescues, cleanses,
wasted healing, buff timing) is observable in data rather than inferred from raw
heal totals. Recording is strictly observational: no gameplay behavior changes.

## Recording

**`ga_match_device_stats`** — one row per (instance, character, task force, device),
upserted over the existing IPC path (60s safety flush + leave + mission end;
idempotent, survives reconnects, uncapped):

- baseline: `uses`, `damage`, `healing`, `player_kills`, `bot_kills`
- effectiveness: `debuffs_removed`, `overheal`, `power_restored/wasted`,
  `rescues` (under-25% conditional deliveries; self-rescues excluded),
  `buffed_damage_dealt` (Frenzy windows), `protected_damage_taken`
  (Protection/Savior windows), `boost_targets/overwrites/wasted_secs`
  (Healing Boost reach + newest-wins overwrite waste)

**`ga_match_events`** — new timestamped types: `CLEANSE` (which category came off
whom), `SAVIOR` (medic → rescued teammate, delivering device), `DEVICE_USED`
(allowlisted activatables only — group heals + boosts, so weapons never flood the
table), `BOOST_APPLY` / `BOOST_OVERWRITE` (per-cast fresh-vs-stomped coverage,
with the overwritten medic's remaining seconds).

Counters stay neutral (an overwrite is a fact on the victim's row, not blame);
the judgment data lives in the event stream.

## Toggles — defaults matter here

Recording resolves per instance at IPC HELLO as **global AND per-queue**:

- `control-server.json`: `device_stats_enabled` / `effectiveness_enabled`
  (default **true**; absent fields default true on both sides, so mixed
  versions keep today's behavior)
- `ga_queues.record_device_stats` / `record_effectiveness`: default **0**,
  seeded **1 for `merc` and `1v1` only**, exactly once — recording follows
  competitive queues by construction, so PvE farming can't reach MMR-facing
  data. `queue_id=0` (ad-hoc instances) falls back to the globals; home maps
  stay fully off via the existing master flag.

With effectiveness off, the per-bullet buff-window scans don't run at all
(checked upstream, not just discarded).

## Attribution and correctness

Pet → owner and deployable → deploying device credit follow TrackStats
conventions. Cleanse counting is provenance-gated at the effect that triggered
the purge, so the per-impact mitigation bracket (431/99), Rest/stealth
housekeeping polls, and invuln refcounting can never count as cleanses.
Excluded devices (all jetpacks by slot, Bionics/Regeneration/Power Stim +
tiers) record nothing.

(`docs/claude/effective-device-use.md`): **Triage Wave never procs Group Heal
Savior** (its own conditional covers those rescues), skill-sourced instances
carry the delivering device's inventory id reliably, and **Combat Off-Hand
Utility is live, not an authoring leftover** (it buffs the *target* of Area
Poisons — intent unknown, behavior confirmed).

## Performance considerations

Sized against a 20-player lobby; every addition rides paths that already do
far heavier work (TrackStats kill attribution, the mitigation brackets).

- **Hot paths are integer early-outs.** The per-effect chokepoint
  (`CheckEffectBuffModifier`) gained 3–4 integer compares, all early-exit;
  per-credit recording is one set lookup + one `std::map` op over ≤ ~160
  rows. No allocations, no `GetFullName`, no `GObjObjects` iteration —
  class checks go through the existing caches.
- **The one state-scaling cost** is the buff-window scan: two walks of the
  shooter's/victim's applied-effect lists (typically 5–20 entries × 4
  tracked ids) per enemy damage event on a pawn. With
  `effectiveness_enabled` off it doesn't run at all — the toggle is checked
  before the scan, not after.
- **The one bursty cost** is the 60s safety flush: ~1 IPC message per
  active device row (≈160 at 20 players × 8 devices) in a single tick,
  once a minute. If it ever registers, staggering it across ticks is a
  contained change.
- **Event volume is capped by design**: `DEVICE_USED` is allowlisted
  (group heals + boosts — weapons never emit), boost events are
  morale-priced and rare, and `CLEANSE` only emits on actual strips. The
  expected addition is low-thousands of rows per match worst case, well
  inside SQLite-WAL insert rates on the control server.
- **Constant background calls are filtered cheaply**: the Rest/stealth
  housekeeping polls that enter `RemoveEffectGroupsByCategory` on every
  pawn continuously exit the cleanse tracker in two compares.
- **Nothing accumulates across matches** — registries are bounded by
  players × tracked groups and die with the per-match instance process.
- Measurable in the field via the existing `dbperf` channel
  (statements/sec on the control server) if a before/after comparison is
  ever wanted.

## Compatibility

- Schema self-migrates (`CREATE IF NOT EXISTS` + tolerated `ALTER`s) on
  control-server start; no manual migration
- No client changes; the client Device Stats tab is unaffected by all toggles
- Hot-path additions are integer early-outs; the one bursty addition (60s
  flush) is ~1 IPC message per active device row per minute
- `docs/claude/device-stats-mmr-handoff.md` documents the column semantics,
  traps, and the intended consumption by the MMR perf-engine work

