### PR TITLE
Switch default active MMR engine from W/L to performance (hybrid)

### DIFF
--- a/src/ControlServer/Database/Database.cpp
+++ b/src/ControlServer/Database/Database.cpp
@@ -1885,12 +1885,47 @@ void Database::Init() {
 		"CREATE TABLE IF NOT EXISTS cs_settings ("
 		"  key TEXT PRIMARY KEY, value TEXT);"
 		"INSERT OR IGNORE INTO cs_settings (key, value)"
-		"  VALUES ('active_mmr_engine', 'wl');";
+		"  VALUES ('active_mmr_engine', 'perf');";
 	result = sqlite3_exec(db, kMmrSchema, nullptr, nullptr, &err);
 	if (result != SQLITE_OK) {
 		Logger::Log("db", "Failed to ensure MMR schema: %s\n", err);
 		sqlite3_free(err);
 		err = nullptr;
+	}
+
+	// One-time switch of the live matchmaking engine from pure W/L to the
+	// performance-adjusted (hybrid) engine. Analysis on 195 decisive rated
+	// PvP matches showed perf MMR at 59% pick-favorite accuracy vs 50.8% for
+	// W/L, with a monotonic band curve. Marker-guarded so operator overrides
+	// via set-mmr-engine after this runs are respected.
+	{
+		bool mmr_engine_switched = false;
+		sqlite3_stmt* mstmt = nullptr;
+		if (sqlite3_prepare_v2(db,
+				"SELECT 1 FROM cs_migration_markers "
+				"WHERE name='active_mmr_engine_perf_default_2026_08_08'",
+				-1, &mstmt, nullptr) == SQLITE_OK && mstmt) {
+			mmr_engine_switched = (sqlite3_step(mstmt) == SQLITE_ROW);
+		}
+		if (mstmt) sqlite3_finalize(mstmt);
+
+		if (!mmr_engine_switched) {
+			static const char* kMmrEngineSwitch[] = {
+				"UPDATE cs_settings SET value = 'perf' "
+				"WHERE key = 'active_mmr_engine' AND value = 'wl';",
+				"INSERT OR IGNORE INTO cs_migration_markers (name) "
+				"VALUES ('active_mmr_engine_perf_default_2026_08_08');",
+			};
+			for (const char* sql : kMmrEngineSwitch) {
+				if (sqlite3_exec(db, sql, nullptr, nullptr, &err) != SQLITE_OK) {
+					Logger::Log("db", "[Database] MMR engine switch step failed: %s\n",
+						err ? err : "?");
+					if (err) { sqlite3_free(err); err = nullptr; }
+				}
+			}
+			Logger::Log("db",
+				"[Database] Switched active_mmr_engine default from wl to perf\n");
+		}
 	}
 
 	// Floor-only version write. The game-server DLL bumps `version_info.version`

--- a/src/ControlServer/MmrService/MmrService.cpp
+++ b/src/ControlServer/MmrService/MmrService.cpp
@@ -572,8 +572,8 @@ std::string MmrService::Reseed() {
 
 std::string MmrService::GetActiveEngine() {
     sqlite3* db = Database::GetConnection();
-    if (!db) return "wl";
-    std::string engine = "wl";
+    if (!db) return "perf";
+    std::string engine = "perf";
     sqlite3_stmt* stmt = nullptr;
     if (sqlite3_prepare_v2(db,
             "SELECT value FROM cs_settings WHERE key = 'active_mmr_engine'",

--- a/src/ControlServer/MmrService/MmrService.hpp
+++ b/src/ControlServer/MmrService/MmrService.hpp
@@ -7,7 +7,7 @@
 //   wl   — pure win/loss Elo              -> ga_wl_mmr_history/_processed
 //   perf — performance-adjusted Elo       -> ga_mmr_history/_processed
 // cs_settings.active_mmr_engine ('wl'|'perf') selects which one downstream
-// consumers (matchmaking, stats site) use.
+// consumers (matchmaking, stats site) use. Default: perf (hybrid engine).
 class MmrService {
 public:
     // Fold every concluded, unprocessed PvP match into both engines, in


### PR DESCRIPTION
## Summary

- Switch `cs_settings.active_mmr_engine` default from `wl` to `perf` so matchmaking, team balance, and stats use the hybrid performance-adjusted rating (`ga_mmr_history`) instead of pure W/L Elo (`ga_wl_mmr_history`).
- Both engines continue to be computed on every rated match; this only changes which rating is live.
- Add a one-time, marker-guarded migration to move existing deployments off `wl` -> `perf` on first boot after deploy.

## Motivation

Offline evaluation on 195 decisive rated PvP matches (pre-match `mmr_before`, no leakage):

| Engine | Pick-favorite accuracy | Band curve |
|--------|------------------------|------------|
| **Perf (hybrid)** | **59.0%** | Monotonic (50% -> 61% -> 64% -> 79% across MMR bands) |
| W/L | 50.8% | Flat/noisy (~coin flip overall) |

Perf MMR is materially more predictive of match outcomes and better suited for team assignment and matchmaking.

## Out of scope

This does **not** change in-match autobalance logic (still class-surplus only; `ComputeFullReassignDelta` remains unwired). A follow-up could wire MMR-aware rebalance when class counts are even.

## Test plan

- [ ] Fresh DB: `active_mmr_engine` initializes to `perf`
- [ ] Existing DB with `wl`: migration runs once, value becomes `perf`, marker inserted
- [ ] After migration: `set-mmr-engine wl` still overrides and persists
- [ ] Matchmaking / `BalanceByMmr` reads from `ga_mmr_history` (verify via logs or a test match)
- [ ] `MmrService::FoldUnprocessed()` still writes both `ga_mmr_history` and `ga_wl_mmr_history`
