### PR TITLE
Performance-based per-class MMR engine (not enabled)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -647,6 +647,7 @@ CS_CPP_SOURCES= \
 	$(CS_SRC_DIR)/QuestStore/QuestStore.cpp \
 	$(CS_SRC_DIR)/TeamService/TeamService.cpp \
 	$(CS_SRC_DIR)/MmrService/MmrService.cpp \
+	$(CS_SRC_DIR)/MmrService/ClassProfiles.cpp \
 	$(CS_SRC_DIR)/MatchmakingService/MmrSwap.cpp \
 	$(CS_SRC_DIR)/MatchmakingService/MatchmakingService.cpp \
     $(CS_SRC_DIR)/MatchmakingService/TicketInfoEncoder.cpp \

--- a/docs/claude/device-stats-perf-engine-plan.md
+++ b/docs/claude/device-stats-perf-engine-plan.md
@@ -1,0 +1,552 @@
+# Device stats → perf engine: integration plan
+
+Response to `device-stats-mmr-handoff.md` (on `device-usage-metrics`). What the
+new signals change for the rating engine in `src/ControlServer/MmrService/`,
+what has to be built before they can be consumed, and what cannot be decided
+until data exists.
+
+**Status: plan only.** Recording is pre-golive, so there are no rows to fit
+against. Nothing here is tuned; the weights are placeholders with a stated
+procedure for setting them.
+
+The archetype definitions in §4 are now specified rather than open — they came
+from the game side, not from the data, and the device ids were resolved against
+the canonical inventory. §7 records what that settled and what it did not.
+
+---
+
+## 1. Why this matters more than it looks
+
+The engine's standing limitation, stated on the player-facing page and in the
+review doc, is that it measures what is in `ga_match_player_stats` and nothing
+else. Two experienced medics — amna (81 games) and Callizle (78) — sit mid- and
+low-table with the same profile: **good at surviving, average at every measured
+output**. Players who know them say they are better than that. The honest
+conclusion was that whatever they do well is not healing volume, assists, buffs
+or objective score, because all four are measured and they are average on them.
+
+The device signals are the first data that could settle it. `rescues`,
+effective-heal ratio and `debuffs_removed` are precisely the "clutch and
+discipline" axes that raw healing cannot see.
+
+There is a second reason, from the closed-pool analysis (`tools/mmr/closed_pool.py`):
+thirty regulars account for 92% of appearances and any two are teammates 47% of
+the time, so **only ~45% of the variance in win rates is skill**. Win/loss
+cannot carry a rating here. Per-player device measurements do not dilute across
+teammates the way a match result does, which makes them structurally more
+valuable in this population than they would be on a larger server.
+
+---
+
+## 2. What has to change in the engine first
+
+The current pipeline makes four assumptions the device data breaks, and needs a
+fifth thing it does not have at all (2e). These are prerequisites, not
+refinements.
+
+### 2a. Stats come from more than one table
+
+`ClassProfiles::StatColumn` returns a `ga_match_player_stats` column or `nullptr`
+for derived, and `BuildParticipants` builds one `SELECT` from it. Device signals
+need a second source with its own aggregation and a `LEFT JOIN` on
+`(instance_id, character_id)`.
+
+```
+enum class Source { PlayerStats, DeviceStats, Derived };
+```
+
+### 2b. Not everything is a per-minute rate
+
+Every stat is currently divided by minutes played. That is right for volumes and
+wrong for ratios — effective-heal ratio, boost reach (`boost_targets / uses`)
+and boost freshness are already normalized, and dividing them by time makes them
+meaningless.
+
+```
+enum class Scaling { PerMinute, Ratio };
+```
+
+### 2c. Missing is not zero — and this one will bite silently
+
+Matches before recording started have no device rows. If those are folded in as
+zeros, the class baselines are dragged down and **every player who was active
+before golive looks catastrophically bad at rescues and cleanses**, while
+post-golive players look inflated against a corrupted mean. The engine would
+produce a confident, wrong answer.
+
+`Participant` needs per-stat availability, and both scoring *and*
+`AccumulateBaseline` must skip unavailable stats. The structures already support
+this — `ZScore` returns false on insufficient baseline, and `ArchSignal` tracks
+per-stat counts — so it is an extension rather than a rewrite.
+
+The handoff says this explicitly ("absent rows = missing, not zero, when
+normalizing"). It is the single easiest thing here to get wrong, because
+nothing about the output will look broken.
+
+### 2d. Devices need a family map — and it already exists, elsewhere
+
+The effective-heal ratio must be restricted to heal-class devices, because
+`overheal` includes on-hit rider heals — the handoff records a poison dagger
+carrying ~14k overheal. Without the filter, a Death-Medic reads as the most
+wasteful healer on the server.
+
+Tiering is not a problem: **every device in play is max tier**, and the canonical
+device list is one level-50 character's inventory (`ga_players_inventory`, user
+2381 in the tooling). No tier collapsing is needed.
+
+The taxonomy is not in the ASM tables in usable form — `item_subtype_value_id`
+is 0 for every device checked, and `skill_id` does not partition by role (Frenzy
+Wave and Protection Wave are both `skill = 1`). But it **does** already exist, on
+`theorycraft-console`: `tools/device-console/gen_ix.py` emits `devmeta.json`,
+carrying per device its `name`, `cls` (owning class), `heals`, `dmg`, `aoe`,
+`pet` and `atk` flags — the console reports 115 usable devices, of which 19 are
+healers and 15 are deployables/pets.
+
+**Do not re-derive it.** I tried, filtering devices whose effect groups touch the
+heal props `{330, 210, 51, 211}` — the same set the console uses for its `H`
+chip letter — and got **73 "healers" including iMINIGUN, Tremor Launcher and
+three grenades** against the true 19. Heal props appear in effect groups that
+are not the device's own healing, and the console only reaches the right answer
+after resolving fire modes, sign and context. A naive filter here would put the
+rider-heal caveat back in through the front door, which is the exact failure it
+was meant to prevent.
+
+**Dependency, and it needs an owner.** `devmeta.json` is a generated artifact: it
+is not committed, and `gen_ix.py` currently writes it to a hard-coded scratchpad
+path from a previous session that no longer exists. Before the rating engine can
+consume the taxonomy, one of:
+
+- `gen_ix.py` emits a committed `device_taxonomy.json` at a stable repo path, or
+- the classification lands in a small DB table the engine can join, or
+- the flags move into `MatchStats.cpp` alongside the existing allowlist and
+  exclusion list, so recording and rating share one definition.
+
+The third is tidiest — `MatchStats.cpp` already carries a Group-Heals allowlist
+and a device exclusion list, so a device taxonomy has a natural home there and
+two copies cannot drift apart. **Decided: `MatchStats.cpp`.**
+
+### 2e. Archetypes are decided by devices, not by outcomes
+
+This is the largest change in the document and it was not in the earlier draft.
+
+`ClassProfiles::Rule` compares *outcomes*: mean z of one stat group minus mean z
+of another, above a threshold. Every archetype definition supplied for Recon,
+Robotics and Medic (§4) is instead a statement about **which devices the player
+used**. Those are different questions, and the device form is better for two
+reasons:
+
+- **It is an observation, not an inference.** A tank is currently identified
+  partly by taking damage, which is also part of what a tank is *scored* on. The
+  discriminant and the score share an input, so a player having a bad game can
+  be moved onto a different archetype by the same numbers that judge them.
+  Device usage breaks that loop: what you brought and fired is independent of
+  how well it went.
+- **It separates classes the current stats cannot.** A sword Recon and a sniper
+  Recon produce `kills` and `damage_dealt` and nothing else the engine can see.
+  Their device usage is not remotely similar.
+
+So `Rule` needs a second form alongside the existing comparison:
+
+```
+struct DeviceRule {
+    std::string      profile;
+    std::vector<int> devices;    // item_ids
+    Metric           metric;     // Uses | Damage | Kills
+    double           min_share;  // of the player's total on this class
+};
+```
+
+**Share of usage, never equipped loadout.** Stated twice and unprompted in the
+spec: *"they would be using it in the match — that's important, because some
+builds will just have it there and never use it."* There is no equipped-loadout
+signal to be tempted by anyway; `ga_match_device_stats` records use, which is
+the right thing.
+
+Two consequences worth stating now:
+
+- **Assignment stays per player, not per match**, for the reason already in the
+  header comment — scoring someone on whichever profile flattered a given game
+  inflates the whole population. Device shares accumulate across matches exactly
+  as the z-means do today.
+- **Devices are shared across archetypes and that is fine.** Stealth appears in
+  three of the four Recon archetypes; it is a *corroborator*, not a
+  discriminant. The discriminating device sets below are disjoint by
+  construction — the offhands.
+
+---
+
+## 3. Signals, and how each is normalized
+
+Volumes go per-minute like the existing stats. Ratios do not. Two are
+deliberately excluded.
+
+| Signal | Source | Scaling | Notes |
+|---|---|---|---|
+| `heal_eff` | `SUM(healing) / SUM(healing + overheal)`, heal-family devices only | Ratio | discipline vs wave-spam |
+| `rescues` | `SUM(rescues)` | PerMinute | already self-excluded; already unifies Triage + Savior |
+| `cleanses` | `SUM(debuffs_removed)` | PerMinute | self-cleanse counts by design |
+| `dmg_enabled` | `SUM(buffed_damage_dealt)` | PerMinute | Frenzy — offensive buffing |
+| `dmg_absorbed` | `SUM(protected_damage_taken)` | PerMinute | Protection/Savior — defensive buffing |
+| `boost_reach` | `SUM(boost_targets) / SUM(uses)`, boost devices only | Ratio | placement |
+| `boost_fresh` | `(BOOST_APPLY − BOOST_OVERWRITE) / BOOST_APPLY` from events | Ratio | was the cast justified |
+| ~~`boost_overwrites`~~ | — | — | **excluded.** Being stomped is the other medic's timing. Not a covariate either — with 30 regulars it would proxy for "plays alongside the other main medic" |
+| ~~SAVIOR events~~ | — | — | **excluded.** `rescues` already includes them; counting both double-counts |
+
+### Normalization beyond per-minute
+
+The handoff's caveat 2 — waves never affect their caster, so heal output depends
+on having teammates nearby — is the same problem `rel_deaths` already solves for
+deaths: measure against the team's situation, not in isolation.
+
+Two candidates worth testing when data exists:
+
+- **`rescue_share` = `rescues / (rescues + team_deaths)`** — the share of
+  near-deaths converted into saves. This is the one I would expect to carry the
+  most signal, because it is inherently normalized against how much trouble the
+  team was in.
+- **`heal_share` = `healing / team_damage_taken`** — already tested against the
+  *old* data, where it was the single most reliable per-player measurement found
+  (0.96) but nearly uncorrelated with winning (+0.049). Reliable-but-not-
+  predictive is exactly the profile of a signal that measures effort rather than
+  impact. Worth re-testing with the overheal split available, since the old
+  version could not distinguish real healing from waste.
+
+---
+
+## 4. Archetype granularity, per class
+
+Device stats are **not** here to invent archetypes. For Medic they identify the
+existing three properly; for Recon and Robotics they make visible a split that
+already exists in how the class is played and that the current stats cannot see
+at all. An earlier draft proposed five or six medic archetypes; that was wrong
+and is dropped.
+
+```
+class      today   proposed   why
+Assault      2         2      roamer/tank already work; no change
+Medic        3         3      same three, decided by devices not by z-scores
+Recon        1         4      sniper / bomber / mines / melee
+Robotics     1         2      drone / turret-station   ("two for now")
+```
+
+Device ids below are from the canonical level-50 inventory (`ga_players_inventory`,
+user 2381) and are the discriminating sets — the ones a rule would key on.
+
+### Recon — the class the current stats cannot see at all
+
+The clearest win outside Medic. The engine currently sees `kills`,
+`damage_dealt` and `bot_kills` for all four of these and cannot tell them apart,
+so every Recon is scored against one profile that fits three of them badly.
+
+```
+sniper   ranged      2110 Ballista · 3249 Scorpia
+         specialty   5807 Targeting System
+         > discriminant: SHARE OF DAMAGE from Ballista/Scorpia.
+         > the specialty corroborates; the ranged weapon decides.
+
+bomber   offhand     2219 EMP Bomb · 4708 Venom Bomb · 3056 Fire Bomb
+                     4716 Graviton Bomb  (rare)
+         specialty   2209 Sprint Stealth · 3023 Spring Stealth
+         > discriminant: SHARE OF USES from the bomb set. "throwing bombs
+         > the whole match."
+
+mines    offhand     2897 Sticky Poison Mine · 2225 Standard Mine
+         specialty   stealth, as above
+         > discriminant: SHARE OF USES from the mine set.
+         > bomber and mines differ ONLY in the offhand — stealth is common
+         > to both and carries no information for this split.
+
+melee    melee       3970 Ghost Sword · 5799 Dual Daggers
+         offhand     2953 Melee Stim          <-- the telltale
+         specialty   stealth, as above
+         > discriminant: SHARE OF DAMAGE from the melee slot, corroborated
+         > by Melee Stim USES. Stim uses is the stated giveaway: "they would
+         > have the melee stim equipped, and they would be USING it."
+```
+
+Two notes. *"Jewel daggers"* has no exact match in the item table; **Dual
+Daggers (5799)** is the only dagger device and is assumed to be it — worth a
+one-line confirmation, since Assassin Blade (6895) also exists and is not
+mentioned. And Sprint Stealth (2209) and Spring Stealth (3023) are distinct
+devices, each with I/II/III variants; both count as stealth.
+
+Damage-share is the right metric for sniper and melee (a sniper's whole output
+comes through the rifle), use-share for bomber and mines (mines can sit unused
+and a bomb's damage varies with how many it catches).
+
+### Robotics — a clean two-way split on the offhands
+
+Currently one profile for the whole class. *"There is a very clear divide there
+between the two in terms of the offhands they take."* Three-way (drone / turret
+/ station) was considered and rejected: turrets and stations are carried by the
+same players in the same builds.
+
+```
+drone         offhand     2107 Grizzly Drone · 2279 Hornet Drone
+                          4782 Harrier Drone · 2675 Eye Drone ("iDrone")
+                          4698 Lockdown Drone · 2051 Force Wall (sometimes)
+              specialty   5811 Force Target
+              > Force Target is a strong corroborator, not incidental: it
+              > directs the drones onto a target, so it only makes sense in
+              > this build.
+
+turret/       offhand     2300 Personal Turret · 3755 Auto Cannon
+station                   5792 Flame Turret · 2095 Rocket Turret
+                          2066 Medical Station · 4076 Power Station
+                          2326 Sensor
+              specialty   2918 Focused Repair Arm
+              > Focused Repair Arm is the corroborator — you bring it to keep
+              > emplacements alive.
+```
+
+Discriminant: share of offhand uses. The two sets are disjoint, so this is close
+to a straight majority vote. Force Wall (2051) is the one ambiguous device —
+listed under drones but plausible in either; leave it out of the discriminating
+set and let the drones decide.
+
+### Medic — same three, decided by offhands rather than by `buff_value`
+
+Full-heal, buff and poison stay. What changes is what decides them.
+
+The specialty slot splits two ways but **does not separate the archetypes**:
+
+```
+nanite family   2061 Nanite Restoration System · 5064 Nanite Enhancement System
+                6898 Adrenaline Gun            — heal-over-time, applied to others
+beam family     2906 BioFeedback Beam · 3946 Boost Beam · 6004 Multi-Boost Beam
+                                               — focused heal on a single target
+```
+
+That is a real distinction in *how* someone heals, and worth recording, but the
+explicit instruction is that **the offhands tell the tale**:
+
+```
+clutch / lifesaver   5808 Triage Wave · 2376 Healing Wave · 2531 Healing Grenade
+                     (+ perhaps one buff: Protection, Frenzy or Power Wave)
+
+buff                 3639 Protection Wave · 4682 Power Wave · 3645 Frenzy Wave
+                     nanite gun + nanite specialty, then buffs
+                     "focused on giving buffs to the team"
+
+poison               2379 Poison Aura · 2168 Poison Grenade · 4690 PowerVirus
+                     Grenade · ranged 2991 Agonizer / 4676 Pain Gun
+                     melee 3967 Poison Injector
+```
+
+The distinction is the *balance* of the wave offhands, not their presence — both
+archetypes carry some of each. A clutch medic runs mostly heal waves with maybe
+one buff; a buff medic runs mostly buffs with maybe a heal wave. So the rule is
+a share comparison between the two sets, not a floor on either.
+
+This replaces the current buff discriminant, which is a floor on `buff_value`
+plus a healing floor — a blunt aggregate that says someone buffed a lot without
+saying what they buffed or whether it landed. Alongside it,
+`buffed_damage_dealt` and `protected_damage_taken` measure whether the buff did
+any work.
+
+**Full-heal / clutch medic** is where the amna / Callizle question lives. What
+those players are believed to be good at is **wave discipline** — Triage on
+low-health teammates, cleanses, Group Heal Savior procs, and *not* spamming
+waves for volume. None of it is visible in raw `healing`, which is exactly why
+they read as average.
+
+| what it captures | signal |
+|---|---|
+| landing waves on people who needed them | `rescues` (self-excluded, already unifies Triage + Savior) |
+| not spamming for volume | `heal_eff` = `healing / (healing + overheal)`, heal-family devices only |
+| counterplay awareness | `debuffs_removed` |
+| placement rather than luck | `boost_reach` = `boost_targets / uses` |
+
+If this is right, amna and Callizle should score well on `rescues` and
+`heal_eff` while remaining average on raw healing. That is a **falsifiable
+prediction**, and the first thing to check when data exists — see §7.
+
+**Poison medic — flagged for correction, by the person it favours.** The
+archetype is unchanged, but its *valuation* is now a known open problem, raised
+unprompted:
+
+> "I am not better than a lot of the medics I was above, because my damage
+> output as a medic is valued higher than their heals — which is arguable."
+
+That is a self-report against interest and it matches a structural weakness
+already visible in the data. Medic kills and damage are **zero-inflated** — most
+medics record almost none — so their standard deviation is small and any medic
+who deals damage lands several z above the mean, while a healer's `healing` z is
+bounded by a population where everyone heals. The poison profile scores kills at
+0.8 and damage at 0.8, directly on the two most inflated stats in the class.
+Lowering the 0.45 premium treats the symptom; the cause is that a z-score
+computed over a zero-inflated distribution is not comparable to one computed
+over a well-spread distribution. Candidate fixes, in order of preference:
+
+1. score poison medics' damage stats against the **poison sub-population**, once
+   device usage identifies who they are — which is exactly what §2e provides;
+2. use a rank or percentile transform instead of a z for zero-inflated stats;
+3. failing both, reduce the premium — but that is a fudge and should be labelled
+   as one.
+
+The intent stated is to bake poison into the device tracker so their efficiency
+is measured rather than assumed. Option 1 depends on that.
+
+### Assault — unchanged
+
+Roamer is a set piece and tank is already identified; the existing stats handle
+both. Device usage could separate further styles, but nothing needs deciding
+now.
+
+### Deliberately deferred
+
+Scoring a player against the *class average for the specific devices they use*
+is a further step and may not prove useful. Not planned; revisit only if the
+family-level split works first.
+
+## 5. Weights — what I will not guess
+
+Every weight in `ClassProfiles.cpp` today came from a test in `tools/mmr/`, and
+several improvements that looked obvious in isolation turned out to be noise or
+artefacts — learned per-stat weights performed *worse* out of sample, and a rule
+built on a 66%-vs-49% win-rate split turned out to be two under-rated players
+rather than a real pairing effect.
+
+Setting device weights before there is data would repeat exactly that mistake.
+The procedure instead:
+
+1. **Wait for one full Sunday of recorded matches**, then check coverage — how
+   many rated participants have device rows, and how many devices per player.
+2. **Reliability first, not prediction.** Split-half each new signal per player
+   the way `closed_pool.py` does. Anything below ~0.7 is not measuring a stable
+   property of the player and should not be weighted regardless of how good the
+   story is. Existing benchmarks: win/loss 0.64, performance index 0.90.
+3. **Then out-of-sample prediction**, via the harness in `tools/mmr/reseed.py`,
+   one signal at a time. Add a weight only if it improves prediction *and* is
+   reliable.
+4. **Re-check the archetype labels are stable.** With §2e this now means the
+   device-share thresholds, not just the stat weights: does a player keep the
+   same label between Sundays? Device shares should be far more stable than
+   outcome-based rules, which is much of the argument for them — so if they are
+   *not*, that is a finding and the threshold is wrong.
+5. **Sanity-check the new splits against known players before trusting them.**
+   Recon and Robotics go from one profile to four and two; the split is only
+   worth having if the labels match what people actually play. This is cheap to
+   check and catches a wrong device set immediately.
+6. **Expect most candidates to fail.** Seven signals are listed; if two survive
+   this procedure that is a good outcome.
+
+Starting placeholders, to be overwritten by step 3 and not before: inside the
+full-heal profile, `rescues` around the weight `healing` currently carries (1.0)
+with `healing` itself reduced to compensate, `heal_eff` and `debuffs_removed`
+around 0.4; inside the buff profile, `buffed_damage_dealt` and
+`protected_damage_taken` around 0.8 replacing most of `buff_value`'s current
+0.8. These are shaped to be plausible, not correct.
+
+---
+
+## 6. Interaction with the rest of the engine
+
+- **The premium mechanism is unchanged; the premium values are not.** A premium
+  (`poison` 0.45, `tank` 1.10) stays a judgement about how valuable a role is,
+  which no amount of device data settles. But four Recon archetypes and two
+  Robotics archetypes need six premiums that do not exist yet, and `poison` 0.45
+  is now explicitly disputed (§4). Both are decisions, not fits — see §7 item 4.
+- **`perf_scale` may need re-fitting.** It sets how many rating points one unit
+  of performance is worth at rest. Adding signals changes the spread of the
+  performance index, so the resting spread moves with it.
+- **`min_baseline_games` (20) applies per stat.** New signals will be
+  unscoreable for the first ~20 recorded matches per class and simply drop out,
+  which is the correct behaviour and needs no special handling.
+- **The reference implementation must be updated in lockstep.**
+  `tools/mmr/reseed.py` is the acceptance test for the compiled engine; if it
+  does not learn the device signals at the same time, the test silently stops
+  testing anything.
+
+---
+
+## 7. Decisions taken, and what is still open
+
+Six of the eight items in the previous draft are now answered. What follows
+records the answers so they are not re-litigated, and states plainly what is
+left.
+
+### Settled
+
+**1. Recon archetypes — four.** Sniper, bomber, mines, melee, with device sets
+in §4. Keyed on **used** devices, not equipped loadout.
+
+**2. Robotics archetypes — two.** Drone and turret/station. *"We'll go with two
+for now."* Turrets and stations do not separate; the same players carry both.
+
+**3. Medic buff/clutch discriminant — the offhands.** Buff = protection / power /
+frenzy waves over a nanite base; clutch = triage / heal wave / heal grenade with
+at most one buff. The `buff_value` floor is replaced.
+
+**5. Taxonomy home — `MatchStats.cpp`.** Recommendation accepted; it already
+carries the Group-Heals allowlist and the exclusion list, so recording and
+rating share one definition and cannot drift. Still needs doing, but no longer
+needs deciding.
+
+**6. Assault beyond roamer and tank.** Deferred by agreement. Nothing to do.
+
+**7. Wave discipline.** `heal_eff` plus `rescues` accepted as *"sharp enough for
+now"*, with a specific refinement recorded below.
+
+### Still open — decisions
+
+**4. Premiums for the new archetypes.** Six values that do not exist: sniper,
+bomber, mines, melee, drone, turret/station. The existing premiums are
+judgements about how valuable a role is, not fitted numbers — poison sits at
+0.45 because poison medics win fewer games, tank at 1.10 because holding the
+point wins them. The same call is needed here: is a melee Recon doing its job
+well worth as much to a team as a sniper doing its job well? The data cannot
+answer this and should not be asked to. **The safe default is 1.00 for all
+six** — it asserts nothing — and to revisit once each archetype has enough
+games to compare win rates, which will take considerably longer than the signal
+work.
+
+**Poison medic valuation.** Raised in §4 and repeated here because it is the one
+outstanding item that affects a *live* number rather than a future one. Whether
+this is fixed structurally (sub-population baselines, rank transform) or by
+lowering the premium is open, but the structural fix depends on device data
+identifying poison medics, so nothing changes before golive.
+
+### Still open — needs building, not deciding
+
+**Buff-outcome attribution.** The gap identified in the wave-discipline
+discussion, and it is a real one:
+
+> "If a frenzy is used to try and save someone on low health but that person
+> does no damage, it'll look negatively against the player."
+
+`buffed_damage_dealt` and `protected_damage_taken` credit the *caster* with what
+the *target* subsequently did. That is the right instinct — it is what makes
+them better than raw `buff_value` — but it means a correct cast on a teammate
+who then does nothing scores as a wasted one, and a player who buffs the best
+teammate on the server scores well regardless of timing. Frenzy is the worst
+case: its whole value is conditional on the target then fighting.
+
+Two mitigations, neither free:
+
+- **Judge the cast, not the outcome** — was the target in a state where the buff
+  was the right call (low health for protection, in combat for frenzy)? This
+  needs state at cast time, which is a recording change, not a rating change.
+- **Normalize by the target's own baseline** — credit `buffed_damage_dealt`
+  against what that teammate normally does per minute, so buffing a passive
+  player is not punished and buffing a strong one is not automatically rewarded.
+  This is computable from existing data with no recording change, and is the
+  cheaper of the two to try first.
+
+Flagged as owned by the game side to specify, per *"that's one for me to take
+away."* Noted here so the weakness is on the record before any weight is fitted
+to those two signals.
+
+**Timing.** When recording goes live, and roughly when a full Sunday of rows
+will exist. Affects scheduling only.
+
+### The first thing to check once data exists
+
+**Do amna and Callizle score well on `rescues` and `heal_eff` while remaining
+average on raw `healing`?**
+
+That is the whole hypothesis in one test. If yes, the model was under-selling
+them, the fix is real, and the same treatment should be extended. If they are
+average there too, then either the discipline theory is wrong or it is still not
+being measured — and the honest response is to say so rather than keep adding
+signals until the answer comes out right.

--- a/src/ControlServer/Database/Database.cpp
+++ b/src/ControlServer/Database/Database.cpp
@@ -1893,6 +1893,60 @@ void Database::Init() {
 		err = nullptr;
 	}
 
+	// Perf-engine rebuild. The old ga_mmr_history recorded only before/after,
+	// so a rating movement could not be explained without re-running the fold.
+	// The new shape stores every term of the update — perf index, expected,
+	// actual, the archetype the player was scored as, and how much of the match
+	// they played — so any rating is auditable from the row alone.
+	// Destructive by design: the engine's constants changed, which invalidates
+	// the old sequential chain. Watermarks are cleared with it so the next
+	// FoldUnprocessed() replays every match from scratch. The wl engine's
+	// tables are deliberately untouched — it stays as a working fallback
+	// behind cs_settings.active_mmr_engine.
+	bool perf_rebuilt = false;
+	{
+		sqlite3_stmt* mstmt = nullptr;
+		if (sqlite3_prepare_v2(db,
+				"SELECT 1 FROM cs_migration_markers WHERE name='perf_mmr_rebuild_2026_08_03'",
+				-1, &mstmt, nullptr) == SQLITE_OK && mstmt) {
+			perf_rebuilt = (sqlite3_step(mstmt) == SQLITE_ROW);
+		}
+		if (mstmt) sqlite3_finalize(mstmt);
+	}
+	if (!perf_rebuilt) {
+		static const char* kPerfRebuild =
+			"DROP TABLE IF EXISTS ga_mmr_history;"
+			"CREATE TABLE ga_mmr_history ("
+			"  user_id     INTEGER NOT NULL,"
+			"  class_name  TEXT    NOT NULL,"
+			"  archetype   TEXT    NOT NULL DEFAULT '',"
+			"  instance_id INTEGER NOT NULL,"
+			"  played_at   INTEGER NOT NULL,"
+			"  minutes     REAL    NOT NULL DEFAULT 0,"   // time on this class
+			"  match_share REAL    NOT NULL DEFAULT 0,"   // minutes / match length
+			"  perf        REAL    NOT NULL DEFAULT 0,"   // performance index
+			"  expected    REAL    NOT NULL DEFAULT 0,"   // pre-match win expectation
+			"  actual      REAL    NOT NULL DEFAULT 0,"   // 1 win / 0.5 draw / 0 loss
+			"  mmr_before  REAL    NOT NULL,"
+			"  mmr_after   REAL    NOT NULL,"
+			"  games_after INTEGER NOT NULL,"
+			"  PRIMARY KEY (user_id, class_name, instance_id));"
+			// Reverse lookup: every rating change produced by one match.
+			"CREATE INDEX IF NOT EXISTS idx_mmr_history_instance"
+			"  ON ga_mmr_history(instance_id);"
+			"DELETE FROM ga_mmr_processed;"
+			"INSERT OR IGNORE INTO cs_migration_markers (name)"
+			"  VALUES ('perf_mmr_rebuild_2026_08_03');";
+		if (sqlite3_exec(db, kPerfRebuild, nullptr, nullptr, &err) != SQLITE_OK) {
+			Logger::Log("db", "[Database] perf MMR rebuild failed: %s\n", err ? err : "?");
+			if (err) { sqlite3_free(err); err = nullptr; }
+		} else {
+			Logger::Log("db",
+				"[Database] Rebuilt ga_mmr_history for the perf engine; "
+				"watermarks cleared, next fold replays every match\n");
+		}
+	}
+
 	// Floor-only version write. The game-server DLL bumps `version_info.version`
 	// past 19 (currently to 24) — an unconditional UPDATE here would silently
 	// downgrade the counter, causing the DLL's `version < 21` block to re-fire

--- a/src/ControlServer/MmrService/ClassProfiles.cpp
+++ b/src/ControlServer/MmrService/ClassProfiles.cpp
@@ -66,9 +66,8 @@ void InstallDefaults() {
         c.profiles.push_back(MakeProfile("tank", 1.10, {
             {kDamageTaken, 1.0}, {kObjPoints, 1.0}, {kDefense, 0.7},
             {kDamageDealt, 0.4}, {kKills, 0.3}, {kDeaths, -0.2}}));
-        c.discriminant.pos = {kDamageTaken, kObjPoints, kDefense};
-        c.discriminant.neg = {kKills, kDamageDealt};
-        c.discriminant.threshold = 0.0;
+        c.rules.push_back({"tank", {kDamageTaken, kObjPoints, kDefense},
+                           {kKills, kDamageDealt}, 0.0, {}});
         g_classes.push_back(std::move(c));
     }
     {
@@ -96,11 +95,23 @@ void InstallDefaults() {
             {kKills, 0.8}, {kDamageDealt, 0.8}, {kAssists, 0.5},
             {kHealing, 0.4}, {kBuffValue, 0.2}, {kObjPoints, 0.2},
             {kDeaths, -0.3}}));
-        // A poison medic is identified by dealing damage INSTEAD of healing,
-        // never by scoring badly as a healer.
-        c.discriminant.pos = {kKills, kDamageDealt};
-        c.discriminant.neg = {kHealing};
-        c.discriminant.threshold = 0.5;
+        // Buff medics heal heavily AND buff heavily -- not a trade of one for
+        // the other. Scored like a healer with the buff weight doubled, at the
+        // same premium, because the operator rates them alongside healers
+        // rather than above or below them.
+        c.profiles.push_back(MakeProfile("buff", 1.00, {
+            {kHealing, 1.0}, {kBuffValue, 0.8}, {kAssists, 0.6},
+            {kObjPoints, 0.2}, {kDeaths, -0.2}, {kDamageTaken, -0.4},
+            {kRelDeaths, -0.3}}));
+        // Order matters: poison first, because a damage medic should never be
+        // caught by the buff floors.
+        // A poison medic deals damage INSTEAD of healing -- never merely scores
+        // badly as a healer.
+        c.rules.push_back({"poison", {kKills, kDamageDealt}, {kHealing}, 0.5, {}});
+        // Both floors, not an average: averaging lets a very high healer with
+        // ordinary buffs (Deadly, buff z +0.09) qualify on healing alone.
+        c.rules.push_back({"buff", {}, {}, -1e9,
+                           {{kHealing, 0.35}, {kBuffValue, 0.30}}});
         g_classes.push_back(std::move(c));
     }
     {   // Robotics heal too, but cannot reach medic volume -- per-class
@@ -142,6 +153,8 @@ void ApplyOverrides(const nlohmann::json& mmr) {
             if (t.contains(k) && t[k].is_number_integer()) dst = t[k].get<int>();
         };
         num("beta",                g_tunables.beta);
+        num("perf_scale",          g_tunables.perf_scale);
+        num("elo_divisor",         g_tunables.elo_divisor);
         num("k_base",              g_tunables.k_base);
         num("k_provisional",       g_tunables.k_provisional);
         num("elo_per_player_gap",  g_tunables.elo_per_player_gap);
@@ -185,14 +198,33 @@ void ApplyOverrides(const nlohmann::json& mmr) {
                 }
             }
         }
-        if (jc.contains("discriminant") && jc["discriminant"].is_object()) {
-            const auto& jd = jc["discriminant"];
-            if (jd.contains("pos") && jd["pos"].is_array())
-                ReadStatList(jd["pos"], cls.discriminant.pos);
-            if (jd.contains("neg") && jd["neg"].is_array())
-                ReadStatList(jd["neg"], cls.discriminant.neg);
-            if (jd.contains("threshold") && jd["threshold"].is_number())
-                cls.discriminant.threshold = jd["threshold"].get<double>();
+        if (jc.contains("rules") && jc["rules"].is_array()) {
+            std::vector<Rule> parsed;
+            for (const auto& jr : jc["rules"]) {
+                if (!jr.is_object() || !jr.contains("profile")) continue;
+                Rule r;
+                r.profile = jr["profile"].get<std::string>();
+                if (!cls.ByName(r.profile)) {
+                    Logger::Log("mmr", "[ClassProfiles] %s: rule names unknown "
+                                "profile '%s' -- ignored
+",
+                                cls.name.c_str(), r.profile.c_str());
+                    continue;
+                }
+                if (jr.contains("pos") && jr["pos"].is_array()) ReadStatList(jr["pos"], r.pos);
+                if (jr.contains("neg") && jr["neg"].is_array()) ReadStatList(jr["neg"], r.neg);
+                if (jr.contains("threshold") && jr["threshold"].is_number())
+                    r.threshold = jr["threshold"].get<double>();
+                if (jr.contains("require") && jr["require"].is_object()) {
+                    for (auto it = jr["require"].begin(); it != jr["require"].end(); ++it) {
+                        const int st = StatByName(it.key());
+                        if (st < 0 || !it.value().is_number()) continue;
+                        r.require.push_back({st, it.value().get<double>()});
+                    }
+                }
+                parsed.push_back(std::move(r));
+            }
+            if (!parsed.empty()) cls.rules = std::move(parsed);
         }
     }
 }

--- a/src/ControlServer/MmrService/ClassProfiles.cpp
+++ b/src/ControlServer/MmrService/ClassProfiles.cpp
@@ -1,0 +1,286 @@
+#include "src/ControlServer/MmrService/ClassProfiles.hpp"
+
+#include "src/ControlServer/Logger.hpp"
+#include "lib/nlohmann/json.hpp"
+
+#include <fstream>
+#include <initializer_list>
+#include <mutex>
+#include <utility>
+
+namespace ClassProfiles {
+
+namespace {
+
+struct StatMeta {
+    const char* name;
+    const char* column;   // nullptr = derived
+};
+
+// Order must match the Stat enum.
+const StatMeta kStats[kStatCount] = {
+    {"kills",         "kills"},
+    {"assists",       "assists"},
+    {"deaths",        "deaths"},
+    {"damage_dealt",  "damage_dealt"},
+    {"damage_taken",  "damage_taken"},
+    {"healing",       "healing"},
+    {"defense",       "defense"},
+    {"buff_value",    "buff_value"},
+    {"obj_points",    "obj_points"},
+    {"bot_kills",     "bot_kills"},
+    {"rel_deaths",    nullptr},
+};
+
+std::mutex             g_mutex;
+std::vector<ClassDef>  g_classes;
+Tunables               g_tunables;
+bool                   g_initialised = false;
+
+Profile MakeProfile(const char* name, double premium,
+                    std::initializer_list<std::pair<int, double>> weights) {
+    Profile p;
+    p.name = name;
+    p.premium = premium;
+    for (const auto& w : weights) p.weight[w.first] = w.second;
+    return p;
+}
+
+// Tuned against 159 Sunday matches on 2026-08-03. Every number here is a
+// judgement backed by either the operator's description of strong play or an
+// out-of-sample prediction test; none of them are derived constants.
+void InstallDefaults() {
+    g_classes.clear();
+    g_tunables = Tunables{};
+
+    {   // Roamers trade kills and damage; tanks hold the point and soak. Both
+        // are viable, so a player is scored on whichever they actually play.
+        // The tank premium is the operator's call -- prediction was flat across
+        // 0.80..1.35, so the data neither supports nor refutes it.
+        ClassDef c;
+        c.name = "Assault";
+        c.profile_id = 680;
+        c.profiles.push_back(MakeProfile("roamer", 1.00, {
+            {kDamageDealt, 1.0}, {kKills, 1.0}, {kObjPoints, 0.4},
+            {kAssists, 0.3}, {kDeaths, -0.4}}));
+        c.profiles.push_back(MakeProfile("tank", 1.10, {
+            {kDamageTaken, 1.0}, {kObjPoints, 1.0}, {kDefense, 0.7},
+            {kDamageDealt, 0.4}, {kKills, 0.3}, {kDeaths, -0.2}}));
+        c.discriminant.pos = {kDamageTaken, kObjPoints, kDefense};
+        c.discriminant.neg = {kKills, kDamageDealt};
+        c.discriminant.threshold = 0.0;
+        g_classes.push_back(std::move(c));
+    }
+    {
+        ClassDef c;
+        c.name = "Recon";
+        c.profile_id = 681;
+        c.profiles.push_back(MakeProfile("recon", 1.00, {
+            {kKills, 1.0}, {kDamageDealt, 0.9}, {kObjPoints, 0.4},
+            {kAssists, 0.3}, {kDeaths, -0.4}}));
+        g_classes.push_back(std::move(c));
+    }
+    {   // Healing volume leads, but damage taken and dying more than your own
+        // team both count against -- they separate medics who hold position
+        // from ones who get caught out. Poison medics deal damage instead of
+        // healing; they are real and useful, but win fewer games than healers,
+        // hence the premium well below 1.0.
+        ClassDef c;
+        c.name = "Medic";
+        c.profile_id = 567;
+        c.profiles.push_back(MakeProfile("healer", 1.00, {
+            {kHealing, 1.0}, {kAssists, 0.8}, {kBuffValue, 0.4},
+            {kObjPoints, 0.2}, {kDeaths, -0.2}, {kDamageTaken, -0.4},
+            {kRelDeaths, -0.3}}));
+        c.profiles.push_back(MakeProfile("poison", 0.45, {
+            {kKills, 0.8}, {kDamageDealt, 0.8}, {kAssists, 0.5},
+            {kHealing, 0.4}, {kBuffValue, 0.2}, {kObjPoints, 0.2},
+            {kDeaths, -0.3}}));
+        // A poison medic is identified by dealing damage INSTEAD of healing,
+        // never by scoring badly as a healer.
+        c.discriminant.pos = {kKills, kDamageDealt};
+        c.discriminant.neg = {kHealing};
+        c.discriminant.threshold = 0.5;
+        g_classes.push_back(std::move(c));
+    }
+    {   // Robotics heal too, but cannot reach medic volume -- per-class
+        // z-scoring handles that automatically.
+        ClassDef c;
+        c.name = "Robotic";
+        c.profile_id = 679;
+        c.profiles.push_back(MakeProfile("robo", 1.00, {
+            {kDamageDealt, 0.8}, {kDefense, 0.8}, {kKills, 0.7},
+            {kObjPoints, 0.4}, {kHealing, 0.4}, {kAssists, 0.3},
+            {kDeaths, -0.3}}));
+        g_classes.push_back(std::move(c));
+    }
+    g_initialised = true;
+}
+
+void ReadStatList(const nlohmann::json& arr, std::vector<int>& out) {
+    std::vector<int> parsed;
+    for (const auto& e : arr) {
+        if (!e.is_string()) continue;
+        const int s = StatByName(e.get<std::string>());
+        if (s < 0) {
+            Logger::Log("mmr", "[ClassProfiles] unknown stat '%s' ignored\n",
+                        e.get<std::string>().c_str());
+            continue;
+        }
+        parsed.push_back(s);
+    }
+    if (!parsed.empty()) out = std::move(parsed);
+}
+
+void ApplyOverrides(const nlohmann::json& mmr) {
+    if (mmr.contains("tunables") && mmr["tunables"].is_object()) {
+        const auto& t = mmr["tunables"];
+        auto num = [&](const char* k, auto& dst) {
+            if (t.contains(k) && t[k].is_number()) dst = t[k].get<double>();
+        };
+        auto integer = [&](const char* k, int& dst) {
+            if (t.contains(k) && t[k].is_number_integer()) dst = t[k].get<int>();
+        };
+        num("beta",                g_tunables.beta);
+        num("k_base",              g_tunables.k_base);
+        num("k_provisional",       g_tunables.k_provisional);
+        num("elo_per_player_gap",  g_tunables.elo_per_player_gap);
+        num("gap_cap",             g_tunables.gap_cap);
+        num("seed_weight",         g_tunables.seed_weight);
+        num("default_mmr",         g_tunables.default_mmr);
+        num("min_match_share",     g_tunables.min_match_share);
+        num("z_clamp",             g_tunables.z_clamp);
+        integer("provisional_games",  g_tunables.provisional_games);
+        integer("min_seconds",        g_tunables.min_seconds);
+        integer("min_rated_players",  g_tunables.min_rated_players);
+        integer("min_baseline_games", g_tunables.min_baseline_games);
+    }
+
+    if (!mmr.contains("classes") || !mmr["classes"].is_object()) return;
+    for (auto& cls : g_classes) {
+        if (!mmr["classes"].contains(cls.name)) continue;
+        const auto& jc = mmr["classes"][cls.name];
+        if (!jc.is_object()) continue;
+
+        if (jc.contains("profiles") && jc["profiles"].is_object()) {
+            for (auto& prof : cls.profiles) {
+                if (!jc["profiles"].contains(prof.name)) continue;
+                const auto& jp = jc["profiles"][prof.name];
+                if (!jp.is_object()) continue;
+                if (jp.contains("premium") && jp["premium"].is_number())
+                    prof.premium = jp["premium"].get<double>();
+                if (jp.contains("weights") && jp["weights"].is_object()) {
+                    // Named weights only -- an absent stat keeps its default
+                    // rather than being zeroed, so a partial edit is safe.
+                    for (auto it = jp["weights"].begin(); it != jp["weights"].end(); ++it) {
+                        const int s = StatByName(it.key());
+                        if (s < 0) {
+                            Logger::Log("mmr",
+                                "[ClassProfiles] %s/%s: unknown stat '%s' ignored\n",
+                                cls.name.c_str(), prof.name.c_str(), it.key().c_str());
+                            continue;
+                        }
+                        if (it.value().is_number()) prof.weight[s] = it.value().get<double>();
+                    }
+                }
+            }
+        }
+        if (jc.contains("discriminant") && jc["discriminant"].is_object()) {
+            const auto& jd = jc["discriminant"];
+            if (jd.contains("pos") && jd["pos"].is_array())
+                ReadStatList(jd["pos"], cls.discriminant.pos);
+            if (jd.contains("neg") && jd["neg"].is_array())
+                ReadStatList(jd["neg"], cls.discriminant.neg);
+            if (jd.contains("threshold") && jd["threshold"].is_number())
+                cls.discriminant.threshold = jd["threshold"].get<double>();
+        }
+    }
+}
+
+}  // namespace
+
+const char* StatColumn(int stat) {
+    if (stat < 0 || stat >= kStatCount) return nullptr;
+    return kStats[stat].column;
+}
+
+const char* StatName(int stat) {
+    if (stat < 0 || stat >= kStatCount) return "?";
+    return kStats[stat].name;
+}
+
+int StatByName(const std::string& name) {
+    for (int i = 0; i < kStatCount; ++i) {
+        if (name == kStats[i].name) return i;
+    }
+    return -1;
+}
+
+void Load(const std::string& config_path) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    InstallDefaults();
+
+    std::ifstream in(config_path);
+    if (!in) {
+        Logger::Log("mmr",
+            "[ClassProfiles] no config at %s -- using tuned defaults\n",
+            config_path.c_str());
+        return;
+    }
+    nlohmann::json j;
+    try {
+        in >> j;
+    } catch (const std::exception& e) {
+        // Keep the defaults rather than failing to start. A typo in the config
+        // should cost the operator their overrides, not the engine.
+        Logger::Log("mmr",
+            "[ClassProfiles] %s is not valid JSON (%s) -- using tuned defaults\n",
+            config_path.c_str(), e.what());
+        return;
+    }
+    if (!j.contains("mmr") || !j["mmr"].is_object()) {
+        Logger::Log("mmr", "[ClassProfiles] no \"mmr\" section -- using tuned defaults\n");
+        return;
+    }
+    try {
+        ApplyOverrides(j["mmr"]);
+    } catch (const std::exception& e) {
+        Logger::Log("mmr",
+            "[ClassProfiles] failed to apply \"mmr\" overrides (%s) -- "
+            "some defaults may have been replaced\n", e.what());
+        return;
+    }
+    Logger::Log("mmr",
+        "[ClassProfiles] loaded: beta=%.2f gap=%.0f seed=%.2f "
+        "min=%ds/%.0f%% of match\n",
+        g_tunables.beta, g_tunables.elo_per_player_gap, g_tunables.seed_weight,
+        g_tunables.min_seconds, g_tunables.min_match_share * 100.0);
+    for (const auto& c : g_classes) {
+        for (const auto& p : c.profiles) {
+            Logger::Log("mmr", "[ClassProfiles]   %s/%s premium=%.2f\n",
+                        c.name.c_str(), p.name.c_str(), p.premium);
+        }
+    }
+}
+
+const std::vector<ClassDef>& Classes() {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    if (!g_initialised) InstallDefaults();
+    return g_classes;
+}
+
+const ClassDef* ByProfileId(uint32_t profile_id) {
+    const auto& classes = Classes();
+    for (const auto& c : classes) {
+        if (c.profile_id == profile_id) return &c;
+    }
+    return nullptr;
+}
+
+const Tunables& Get() {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    if (!g_initialised) InstallDefaults();
+    return g_tunables;
+}
+
+}  // namespace ClassProfiles

--- a/src/ControlServer/MmrService/ClassProfiles.hpp
+++ b/src/ControlServer/MmrService/ClassProfiles.hpp
@@ -53,31 +53,67 @@ struct Profile {
     double      weight[kStatCount] = {};  // 0 = stat unused by this profile
 };
 
-// Picks which profile a player is scored against. Compares the mean z of the
-// `pos` stats against the mean z of the `neg` stats, accumulated over that
-// player's history on the class; above `threshold` selects profiles[1],
-// otherwise profiles[0].
+// Picks which profile a player is scored against, from their accumulated
+// per-stat z-scores on that class.
+//
+// A rule fires when BOTH hold:
+//   - mean z of `pos` minus mean z of `neg` exceeds `threshold`
+//     (either list may be empty; an empty side contributes 0, which is the
+//      class average, so `pos` alone means "well above average at these")
+//   - every (stat, min_z) in `require` is met
+//
+// Rules are tried in order and the first to fire wins; no match leaves the
+// player on profiles[0]. Two conditions are needed because the archetypes are
+// not all separable the same way: "poison" is a medic who deals damage INSTEAD
+// of healing (a comparison), while "buff" is one who heals a lot AND buffs a
+// lot (two floors) -- expressing the latter as a comparison would catch medics
+// who simply buff more than they heal, which is a different player.
 //
 // Assignment is per PLAYER, not per match. Scoring someone on whichever
 // profile happened to flatter them in a given game inflates the whole
-// population, and it also mislabels players -- a medic with weak survivability
-// would get pushed onto "poison" despite dealing no damage.
-struct Discriminant {
+// population, and it mislabels people -- a medic with weak survivability would
+// get pushed onto "poison" despite dealing no damage.
+struct Rule {
+    std::string      profile;                        // profile name it selects
     std::vector<int> pos;
     std::vector<int> neg;
     double           threshold = 0.0;
-    bool active() const { return !pos.empty() && !neg.empty(); }
+    std::vector<std::pair<int, double>> require;     // stat -> minimum z
 };
 
 struct ClassDef {
     std::string          name;            // "Assault"
     uint32_t             profile_id = 0;  // engine PROFILE_* id
     std::vector<Profile> profiles;        // [0] is the default
-    Discriminant         discriminant;
+    std::vector<Rule>    rules;           // tried in order
+    const Profile* ByName(const std::string& n) const {
+        for (const auto& p : profiles) if (p.name == n) return &p;
+        return nullptr;
+    }
 };
 
 struct Tunables {
     double beta               = 1.0;      // weight on the performance term
+    // Rating points one unit of performance is worth at rest. A player is
+    // scored on (perf - perf_expected_for_their_rating), where the expectation
+    // is (rating - default) / perf_scale -- so you only gain by beating your
+    // own rating, not by being good in absolute terms.
+    //
+    // Without this the performance term is a constant upward push with nothing
+    // pulling back: the win/loss half can only ever pull as hard as
+    // (win_rate - 1), so any player with beta*perf above that climbs forever.
+    // At beta 1.0 that meant everyone winning more than ~44% drifted without
+    // limit -- a +0.56 perf player passed 5000 by their thousandth game.
+    //
+    // This term is also the ONLY per-player feedback in the update: the
+    // win/loss half is scored team against team and shared by everyone on a
+    // side, because who won is a team fact. Convergence rests entirely here.
+    double perf_scale         = 600.0;
+    // Rating difference that corresponds to a given win probability. 400 is the
+    // chess convention and is far too flat for this game: teams it called 62%
+    // favourites won 86% of the time. Calibrated against 128 out-of-sample
+    // matches. Re-fit this when the population or the balancer changes.
+    double elo_divisor        = 120.0;
     double k_base             = 24.0;
     double k_provisional      = 48.0;
     int    provisional_games  = 5;

--- a/src/ControlServer/MmrService/ClassProfiles.hpp
+++ b/src/ControlServer/MmrService/ClassProfiles.hpp
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// ClassProfiles.hpp -- per-class performance indices for the perf MMR engine.
+//
+// A player's per-match performance is a weighted average of z-scores taken
+// against the population of the class they played, so a medic is measured
+// against medics and never against assaults.
+//
+// Two classes have more than one way to play them well -- Assault (roamer vs
+// point-holding tank) and Medic (healer vs poison) -- so each class carries one
+// or more Profiles plus a Discriminant that decides which one a given player is
+// scored against.
+//
+// Every weight here is a tuned value, not a derived constant. They are
+// overridable from control-server.json so they can be adjusted between play
+// sessions without a rebuild -- see Load().
+namespace ClassProfiles {
+
+// Stat slots. The first ten map 1:1 onto ga_match_player_stats columns; they
+// are summed per (match, player, class) and converted to per-minute rates
+// before scoring. kRelDeaths is derived: the player's death rate divided by
+// their TEAMMATES' death rate, so someone who dies a lot on a team that dies a
+// lot is not punished for it.
+enum Stat {
+    kKills = 0,
+    kAssists,
+    kDeaths,
+    kDamageDealt,
+    kDamageTaken,
+    kHealing,
+    kDefense,
+    kBuffValue,
+    kObjPoints,
+    kBotKills,
+    kRelDeaths,
+    kStatCount
+};
+
+// ga_match_player_stats column, or nullptr when the stat is derived.
+const char* StatColumn(int stat);
+// Name used in config and logs; covers derived stats too.
+const char* StatName(int stat);
+// -1 when the name is not recognised.
+int StatByName(const std::string& name);
+
+struct Profile {
+    std::string name;                     // "roamer", "tank", "healer", "poison"
+    double      premium = 1.0;            // scales the finished score
+    double      weight[kStatCount] = {};  // 0 = stat unused by this profile
+};
+
+// Picks which profile a player is scored against. Compares the mean z of the
+// `pos` stats against the mean z of the `neg` stats, accumulated over that
+// player's history on the class; above `threshold` selects profiles[1],
+// otherwise profiles[0].
+//
+// Assignment is per PLAYER, not per match. Scoring someone on whichever
+// profile happened to flatter them in a given game inflates the whole
+// population, and it also mislabels players -- a medic with weak survivability
+// would get pushed onto "poison" despite dealing no damage.
+struct Discriminant {
+    std::vector<int> pos;
+    std::vector<int> neg;
+    double           threshold = 0.0;
+    bool active() const { return !pos.empty() && !neg.empty(); }
+};
+
+struct ClassDef {
+    std::string          name;            // "Assault"
+    uint32_t             profile_id = 0;  // engine PROFILE_* id
+    std::vector<Profile> profiles;        // [0] is the default
+    Discriminant         discriminant;
+};
+
+struct Tunables {
+    double beta               = 1.0;      // weight on the performance term
+    double k_base             = 24.0;
+    double k_provisional      = 48.0;
+    int    provisional_games  = 5;
+    double elo_per_player_gap = 110.0;    // headcount advantage, per player
+    double gap_cap            = 3.0;      // ... capped at this many players
+    double seed_weight        = 0.6;      // new class rating from other classes
+    double default_mmr        = 1000.0;
+    int    min_seconds        = 180;      // minimum time played on the class
+    double min_match_share    = 0.50;     // ... and minimum share of the match
+    // Matches with fewer rated players than this are ignored entirely: they
+    // neither move ratings nor feed the class baselines. Near-empty lobbies
+    // are not representative of how a class plays, and on this server they are
+    // almost all midweek — every match with 14+ rated players was a Sunday.
+    int    min_rated_players  = 10;
+    double z_clamp            = 3.0;
+    int    min_baseline_games = 20;       // before a stat's z-score is trusted
+};
+
+// Applies the "mmr" object from `config_path` on top of the compiled defaults;
+// absent keys keep their default. Safe to call more than once. A malformed
+// file is logged and leaves the defaults untouched, so a bad edit degrades to
+// the tuned values rather than taking the engine down.
+void Load(const std::string& config_path);
+
+const std::vector<ClassDef>& Classes();
+const ClassDef*              ByProfileId(uint32_t profile_id);
+const Tunables&              Get();
+
+}  // namespace ClassProfiles

--- a/src/ControlServer/MmrService/MmrService.cpp
+++ b/src/ControlServer/MmrService/MmrService.cpp
@@ -69,14 +69,21 @@ struct Accum {
 };
 using ClassBaseline = std::array<Accum, kNumStats>;
 
-// Running archetype signal for one (player, class).
+// A player's running per-stat z-scores on one class. Archetype rules are
+// evaluated against these means rather than a single match, so one unusual
+// game cannot relabel someone.
 struct ArchSignal {
-    double  sum = 0.0;
-    int64_t n = 0;
+    double  zsum[kNumStats] = {};
+    int64_t zn[kNumStats] = {};
 };
 
-double ExpectedScore(double rating, double opp_avg) {
-    return 1.0 / (1.0 + std::pow(10.0, (opp_avg - rating) / 400.0));
+// Divisor is a claim about how decisive a rating gap is in THIS game, not a
+// universal constant — see Tunables::elo_divisor. The wl engine keeps chess's
+// 400 so its (retired) history stays on its original scale.
+constexpr double kWlDivisor = 400.0;
+
+double ExpectedScore(double rating, double opp_avg, double divisor) {
+    return 1.0 / (1.0 + std::pow(10.0, (opp_avg - rating) / divisor));
 }
 
 // z of `value` against the class population, or false when the stat has too
@@ -99,54 +106,66 @@ bool ZScore(const ClassBaseline& base, int stat, double value,
     return true;
 }
 
-// Mean z across a list of stats; false when none of them are scorable yet.
-bool MeanZ(const ClassBaseline& base, const std::vector<int>& stats,
-           const double* rate, const CP::Tunables& tun, double* out) {
-    double total = 0.0;
-    int count = 0;
-    for (int s : stats) {
-        double z = 0.0;
-        if (ZScore(base, s, rate[s], tun.z_clamp, tun.min_baseline_games, &z)) {
-            total += z;
-            count++;
-        }
-    }
-    if (count == 0) return false;
-    *out = total / count;
-    return true;
-}
-
 // Score one participant against the class population as it stood BEFORE this
 // match, and label them with the archetype they play.
 void ScoreParticipant(Participant& p, const ClassBaseline& base,
                       const CP::ClassDef& def, ArchSignal& signal,
                       const CP::Tunables& tun) {
-    // Which profile is this player? Compare what the discriminant says they do
-    // a lot of against what they do little of, averaged over their whole
-    // history on the class — not just this match. Scoring someone on whichever
-    // profile flattered them in a given game inflates the population.
+    double z[kNumStats] = {};
+    bool   have[kNumStats] = {};
+    for (int s = 0; s < kNumStats; ++s) {
+        have[s] = ZScore(base, s, p.rate[s], tun.z_clamp, tun.min_baseline_games, &z[s]);
+        if (have[s]) {
+            signal.zsum[s] += z[s];
+            signal.zn[s]++;
+        }
+    }
+
+    // Rule conditions read the player's whole history on the class, this match
+    // included — a healer having one aggressive game stays a healer.
+    auto mean_of = [&signal](int s, double* out) -> bool {
+        if (signal.zn[s] == 0) return false;
+        *out = signal.zsum[s] / static_cast<double>(signal.zn[s]);
+        return true;
+    };
+    auto group_of = [&mean_of](const std::vector<int>& stats, double* out) -> bool {
+        double total = 0.0;
+        int count = 0;
+        for (int s : stats) {
+            double m = 0.0;
+            if (mean_of(s, &m)) { total += m; count++; }
+        }
+        if (count == 0) return false;
+        *out = total / count;
+        return true;
+    };
+
     const CP::Profile* profile = &def.profiles.front();
-    if (def.profiles.size() > 1 && def.discriminant.active()) {
+    for (const auto& rule : def.rules) {
+        const CP::Profile* cand = def.ByName(rule.profile);
+        if (!cand) continue;
+        // An empty side contributes 0 — the class average — so a rule may use
+        // either comparison, floors, or both.
         double pos = 0.0, neg = 0.0;
-        if (MeanZ(base, def.discriminant.pos, p.rate, tun, &pos) &&
-            MeanZ(base, def.discriminant.neg, p.rate, tun, &neg)) {
-            signal.sum += pos - neg;
-            signal.n++;
+        if (!rule.pos.empty() && !group_of(rule.pos, &pos)) continue;
+        if (!rule.neg.empty() && !group_of(rule.neg, &neg)) continue;
+        if (pos - neg <= rule.threshold) continue;
+        bool floors_met = true;
+        for (const auto& req : rule.require) {
+            double m = 0.0;
+            if (!mean_of(req.first, &m) || m < req.second) { floors_met = false; break; }
         }
-        if (signal.n > 0) {
-            const double mean = signal.sum / static_cast<double>(signal.n);
-            if (mean > def.discriminant.threshold) profile = &def.profiles[1];
-        }
+        if (!floors_met) continue;
+        profile = cand;
+        break;
     }
     p.archetype = profile->name;
 
     double num = 0.0, den = 0.0;
     for (int s = 0; s < kNumStats; ++s) {
         const double w = profile->weight[s];
-        if (w == 0.0) continue;
-        double z = 0.0;
-        if (!ZScore(base, s, p.rate[s], tun.z_clamp, tun.min_baseline_games, &z)) continue;
-        num += w * z;
+        if (w == 0.0 || !have[s]) continue;
+        num += w * z[s];
         den += std::fabs(w);
     }
     p.perf = (den > 0.0) ? profile->premium * (num / den) : 0.0;
@@ -643,7 +662,7 @@ std::string FoldLocked() {
                 const RatingKey key{p.user_id, p.cls};
                 auto it = wl_rating.find(key);
                 const double before = (it != wl_rating.end()) ? it->second : tun.default_mmr;
-                const double expected = ExpectedScore(before, adj.at(opp));
+                const double expected = ExpectedScore(before, adj.at(opp), kWlDivisor);
                 // winning_tf 0 = stalemate (NULL winner) -> both sides draw.
                 const double actual = (m.winning_tf == 0) ? 0.5
                     : (p.task_force == m.winning_tf) ? 1.0 : 0.0;
@@ -672,18 +691,32 @@ std::string FoldLocked() {
                 const double before = (it != perf_rating.end())
                     ? it->second
                     : SeedRating(perf_rating, perf_games, p.user_id, tun);
-                // Individual expected, not the team average: a rating only
-                // converges if its own level feeds back into what is expected
-                // of it. With the team average there, a strong player is never
-                // pulled back and the rating drifts instead of settling.
-                const double expected = ExpectedScore(before, adj.at(opp));
+                // Whether the match was won is a TEAM fact, so it is scored
+                // team against team and every player shares the result. Scoring
+                // an individual's rating against the opposing team instead
+                // treats one player as if they decided a 9-a-side match: at
+                // this divisor it expected the top Assault to win 98% of his
+                // games, then punished him for winning 60%.
+                //
+                // What stops the rating drifting is not this term but the
+                // anchored performance term below, which is per-player.
+                const double expected =
+                    ExpectedScore(adj.at(p.task_force), adj.at(opp), tun.elo_divisor);
                 const double actual = (m.winning_tf == 0) ? 0.5
                     : (p.task_force == m.winning_tf) ? 1.0 : 0.0;
                 const int64_t games = perf_games[key];
                 const double k = (games < tun.provisional_games)
                     ? tun.k_provisional : tun.k_base;
-                const double after =
-                    before + k * ((actual - expected) + tun.beta * p.perf);
+                // Both halves of the update are now self-correcting. The
+                // win/loss half asks "did you do better than your rating
+                // predicted?"; the performance half asks the same question of
+                // your stats. Scoring raw perf instead would be a constant
+                // push with nothing pulling back, and the rating would climb
+                // for as long as you kept playing.
+                const double expected_perf =
+                    (before - tun.default_mmr) / tun.perf_scale;
+                const double after = before + k * ((actual - expected)
+                    + tun.beta * (p.perf - expected_perf));
                 perf_rating[key] = after;
                 perf_games[key] = games + 1;
                 p.expected = expected;

--- a/src/ControlServer/MmrService/MmrService.cpp
+++ b/src/ControlServer/MmrService/MmrService.cpp
@@ -1,9 +1,11 @@
 #include "src/ControlServer/MmrService/MmrService.hpp"
+#include "src/ControlServer/MmrService/ClassProfiles.hpp"
 #include "src/ControlServer/Database/Database.hpp"
 #include "src/ControlServer/Logger.hpp"
 #include "sqlite3.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstdio>
 #include <iterator>
@@ -17,66 +19,141 @@ std::mutex MmrService::mutex_;
 
 namespace {
 
-// Constants mirror the analyst's compute_mmr.py / mmr_tracker.py. Changing
-// any of them invalidates the sequential rating chain — change + reseed
-// together (both engines).
-constexpr double kDefaultMmr       = 1000.0;
-constexpr int    kMinPlaySeconds   = 180;
-// W/L engine
-constexpr double kWlK              = 32.0;
-// Perf engine
-constexpr double kPerfKBase        = 24.0;
-constexpr double kPerfKProvisional = 48.0;
-constexpr int    kPerfMinGames     = 5;
-constexpr double kPerfBeta         = 0.35;
-constexpr double kPerfZClamp       = 3.0;
-// Team-size imbalance correction, calibrated on this server's data
-// (>=1.0 avg player gap -> larger side wins ~79%).
-constexpr double kEloPerPlayerGap  = 220.0;
-constexpr double kGapDeadzone      = 0.25;
-constexpr double kMaxGapCap        = 3.0;
+namespace CP = ClassProfiles;
+constexpr int kNumStats = CP::kStatCount;
 
-constexpr int kNumStats = 7;
-// stat order: kills, assists, deaths, damage_dealt, healing, obj_points, bot_kills
-constexpr double kStatSign[kNumStats] = {1, 1, -1, 1, 1, 1, 1};
+// W/L engine. Left on its original constants and kept working as a fallback
+// behind cs_settings.active_mmr_engine — it is not the engine we want, but it
+// is a known quantity to fall back to if the perf engine misbehaves live.
+constexpr double kWlK = 32.0;
 
 using RatingKey = std::pair<int64_t, std::string>;  // (user_id, class_name)
 
-const char* ClassNameForProfile(int profile_id) {
-    switch (profile_id) {
-        case 680: return "Assault";
-        case 567: return "Medic";
-        case 681: return "Recon";
-        case 679: return "Robotic";
-        default:  return nullptr;
-    }
-}
-
 struct Stint {
     std::string cls;
+    uint32_t    profile_id = 0;
     int         task_force = 0;
-    double      time = 0.0;
-    double      stats[kNumStats] = {};
+    double      time = 0.0;              // seconds
+    double      raw[kNumStats] = {};     // DB-backed slots only
 };
 
 struct Participant {
     int64_t     user_id = 0;
     int         task_force = 0;
     std::string cls;
-    double      class_time = 0.0;
-    double      stats[kNumStats] = {};
-    double      perf = 0.0;  // z-score performance index, filled after baselines
+    uint32_t    profile_id = 0;
+    double      class_time = 0.0;        // seconds on the finishing class
+    double      match_share = 1.0;       // class_time / match length
+    double      rate[kNumStats] = {};    // per-minute, incl. derived rel_deaths
+    double      perf = 0.0;              // filled during the chronological walk
+    double      expected = 0.0;
+    double      actual = 0.0;
+    std::string archetype;
 };
 
 struct Match {
     int64_t id = 0;
     int64_t started_at = 0;
     int     winning_tf = 0;
+    double  length = 0.0;                // seconds, MAX(game_time)
     std::vector<Participant> players;
+};
+
+// Running mean/variance for one stat within one class.
+struct Accum {
+    double  sum = 0.0;
+    double  sumsq = 0.0;
+    int64_t n = 0;
+
+    void Add(double v) { sum += v; sumsq += v * v; n++; }
+};
+using ClassBaseline = std::array<Accum, kNumStats>;
+
+// Running archetype signal for one (player, class).
+struct ArchSignal {
+    double  sum = 0.0;
+    int64_t n = 0;
 };
 
 double ExpectedScore(double rating, double opp_avg) {
     return 1.0 / (1.0 + std::pow(10.0, (opp_avg - rating) / 400.0));
+}
+
+// z of `value` against the class population, or false when the stat has too
+// little history or no spread to say anything. A stat that does not vary
+// within a class (healing for Assault) drops out rather than contributing a
+// meaningless zero.
+bool ZScore(const ClassBaseline& base, int stat, double value,
+            double clamp, int64_t min_games, double* out) {
+    const Accum& a = base[stat];
+    if (a.n < min_games) return false;
+    const double mean = a.sum / static_cast<double>(a.n);
+    double var = a.sumsq / static_cast<double>(a.n) - mean * mean;
+    if (var < 0.0) var = 0.0;
+    const double sd = std::sqrt(var);
+    if (sd == 0.0) return false;
+    double z = (value - mean) / sd;
+    if (z >  clamp) z =  clamp;
+    if (z < -clamp) z = -clamp;
+    *out = z;
+    return true;
+}
+
+// Mean z across a list of stats; false when none of them are scorable yet.
+bool MeanZ(const ClassBaseline& base, const std::vector<int>& stats,
+           const double* rate, const CP::Tunables& tun, double* out) {
+    double total = 0.0;
+    int count = 0;
+    for (int s : stats) {
+        double z = 0.0;
+        if (ZScore(base, s, rate[s], tun.z_clamp, tun.min_baseline_games, &z)) {
+            total += z;
+            count++;
+        }
+    }
+    if (count == 0) return false;
+    *out = total / count;
+    return true;
+}
+
+// Score one participant against the class population as it stood BEFORE this
+// match, and label them with the archetype they play.
+void ScoreParticipant(Participant& p, const ClassBaseline& base,
+                      const CP::ClassDef& def, ArchSignal& signal,
+                      const CP::Tunables& tun) {
+    // Which profile is this player? Compare what the discriminant says they do
+    // a lot of against what they do little of, averaged over their whole
+    // history on the class — not just this match. Scoring someone on whichever
+    // profile flattered them in a given game inflates the population.
+    const CP::Profile* profile = &def.profiles.front();
+    if (def.profiles.size() > 1 && def.discriminant.active()) {
+        double pos = 0.0, neg = 0.0;
+        if (MeanZ(base, def.discriminant.pos, p.rate, tun, &pos) &&
+            MeanZ(base, def.discriminant.neg, p.rate, tun, &neg)) {
+            signal.sum += pos - neg;
+            signal.n++;
+        }
+        if (signal.n > 0) {
+            const double mean = signal.sum / static_cast<double>(signal.n);
+            if (mean > def.discriminant.threshold) profile = &def.profiles[1];
+        }
+    }
+    p.archetype = profile->name;
+
+    double num = 0.0, den = 0.0;
+    for (int s = 0; s < kNumStats; ++s) {
+        const double w = profile->weight[s];
+        if (w == 0.0) continue;
+        double z = 0.0;
+        if (!ZScore(base, s, p.rate[s], tun.z_clamp, tun.min_baseline_games, &z)) continue;
+        num += w * z;
+        den += std::fabs(w);
+    }
+    p.perf = (den > 0.0) ? profile->premium * (num / den) : 0.0;
+}
+
+void AccumulateBaseline(ClassBaseline& base, const Participant& p) {
+    for (int s = 0; s < kNumStats; ++s) base[s].Add(p.rate[s]);
 }
 
 struct GapEvent {
@@ -93,9 +170,14 @@ struct GapEvent {
 std::pair<int, double> GetTeamSizeGap(sqlite3* db, int64_t instance_id) {
     std::vector<GapEvent> evs;
     sqlite3_stmt* stmt = nullptr;
+    // TEAM_CHANGE carries its destination team in `detail`, not in
+    // target_task_force (that column is NULL on every row). Reading the wrong
+    // one coalesced to 0, dropping the mover from BOTH headcounts for the rest
+    // of the match.
     if (sqlite3_prepare_v2(db,
             "SELECT event_type, game_time, COALESCE(actor_user_id, 0), "
-            "       COALESCE(actor_task_force, 0), COALESCE(target_task_force, 0) "
+            "       COALESCE(actor_task_force, 0), "
+            "       COALESCE(target_task_force, detail, 0) "
             "FROM ga_match_events "
             "WHERE instance_id = ? AND event_type IN ('JOIN', 'LEAVE', 'TEAM_CHANGE') "
             "  AND game_time IS NOT NULL "
@@ -170,7 +252,9 @@ std::vector<Match> LoadMatches(sqlite3* db) {
     if (sqlite3_prepare_v2(db,
             "SELECT i.id, i.started_at, COALESCE(i.winning_task_force, 0), "
             "       COALESCE(NULLIF(i.end_mission_at, 0), NULLIF(i.sealed_at, 0), "
-            "                i.started_at) AS concluded_at "
+            "                i.started_at) AS concluded_at, "
+            "       COALESCE((SELECT MAX(e.game_time) FROM ga_match_events e "
+            "                 WHERE e.instance_id = i.id), 0.0) AS match_len "
             "FROM ga_instances i "
             "WHERE i.outcome IN ('ATTACKERS_WIN', 'DEFENDERS_WIN', 'STALEMATE') "
             "  AND EXISTS (SELECT 1 FROM map_game_info m "
@@ -186,39 +270,81 @@ std::vector<Match> LoadMatches(sqlite3* db) {
         m.id         = sqlite3_column_int64(stmt, 0);
         m.started_at = sqlite3_column_int64(stmt, 1);
         m.winning_tf = sqlite3_column_int(stmt, 2);
+        m.length     = sqlite3_column_double(stmt, 4);
         matches.push_back(std::move(m));
     }
     sqlite3_finalize(stmt);
     return matches;
 }
 
-// Shared participation rule (identical to both scripts): roster de-duped to
-// one class per character, non-zero activity, finishing-class credit (longest
-// stint), >= kMinPlaySeconds summed in that class.
+// Per-(instance, task force) totals, used to derive rel_deaths: a player's
+// death rate measured against their TEAMMATES' death rate, so someone who dies
+// often on a team that dies often is not punished for the team's problem.
+struct TeamTotals {
+    double deaths = 0.0;
+    double time = 0.0;
+};
+
+std::map<std::pair<int64_t, int>, TeamTotals> LoadTeamTotals(sqlite3* db) {
+    std::map<std::pair<int64_t, int>, TeamTotals> out;
+    sqlite3_stmt* stmt = nullptr;
+    if (sqlite3_prepare_v2(db,
+            "SELECT instance_id, task_force, SUM(deaths), SUM(time_played_seconds) "
+            "FROM ga_match_player_stats GROUP BY instance_id, task_force",
+            -1, &stmt, nullptr) == SQLITE_OK && stmt) {
+        while (sqlite3_step(stmt) == SQLITE_ROW) {
+            TeamTotals t;
+            t.deaths = sqlite3_column_double(stmt, 2);
+            t.time   = sqlite3_column_double(stmt, 3);
+            out[{sqlite3_column_int64(stmt, 0), sqlite3_column_int(stmt, 1)}] = t;
+        }
+    }
+    sqlite3_finalize(stmt);
+    return out;
+}
+
+// Participation rule: roster de-duped to one class per character, non-zero
+// activity, finishing-class credit (longest stint), then BOTH a minimum time
+// on that class AND a minimum share of the match. The share test is what keeps
+// a 3-minute cameo in a 25-minute match from moving anybody's rating — such a
+// stint says almost nothing about who was going to win.
 void BuildParticipants(sqlite3* db, std::vector<Match>& matches) {
     std::map<int64_t, Match*> by_id;
     for (auto& m : matches) by_id[m.id] = &m;
 
+    const CP::Tunables& tun = CP::Get();
+    const auto team_totals = LoadTeamTotals(db);
+
+    // Column list is driven by the profile stat table so adding a stat means
+    // touching ClassProfiles only.
+    std::string cols;
+    std::vector<int> col_slot;
+    for (int s = 0; s < kNumStats; ++s) {
+        const char* c = CP::StatColumn(s);
+        if (!c) continue;                       // derived, not selected
+        cols += ", s.";
+        cols += c;
+        col_slot.push_back(s);
+    }
+    const std::string sql =
+        "SELECT s.instance_id, s.user_id, s.task_force, r.profile_id, "
+        "       s.time_played_seconds" + cols + " "
+        "FROM ga_match_player_stats s "
+        "JOIN ga_instances i ON i.id = s.instance_id "
+        "JOIN (SELECT instance_id, character_id, MIN(profile_id) AS profile_id "
+        "      FROM ga_instance_players "
+        "      WHERE profile_id IN (680, 567, 681, 679) "
+        "      GROUP BY instance_id, character_id) r "
+        "  ON r.instance_id = s.instance_id AND r.character_id = s.character_id "
+        "WHERE i.outcome IN ('ATTACKERS_WIN', 'DEFENDERS_WIN', 'STALEMATE') "
+        "  AND (s.kills + s.assists + s.deaths + s.damage_dealt "
+        "       + s.healing + s.obj_points + s.bot_kills) > 0 "
+        "  AND EXISTS (SELECT 1 FROM map_game_info m "
+        "              WHERE m.map_name = i.map_name AND m.is_pvp = 1)";
+
     std::map<std::pair<int64_t, int64_t>, std::vector<Stint>> stints;
     sqlite3_stmt* stmt = nullptr;
-    if (sqlite3_prepare_v2(db,
-            "SELECT s.instance_id, s.user_id, s.task_force, r.profile_id, "
-            "       s.time_played_seconds, "
-            "       s.kills, s.assists, s.deaths, s.damage_dealt, s.healing, "
-            "       s.obj_points, s.bot_kills "
-            "FROM ga_match_player_stats s "
-            "JOIN ga_instances i ON i.id = s.instance_id "
-            "JOIN (SELECT instance_id, character_id, MIN(profile_id) AS profile_id "
-            "      FROM ga_instance_players "
-            "      WHERE profile_id IN (680, 567, 681, 679) "
-            "      GROUP BY instance_id, character_id) r "
-            "  ON r.instance_id = s.instance_id AND r.character_id = s.character_id "
-            "WHERE i.outcome IN ('ATTACKERS_WIN', 'DEFENDERS_WIN', 'STALEMATE') "
-            "  AND (s.kills + s.assists + s.deaths + s.damage_dealt "
-            "       + s.healing + s.obj_points + s.bot_kills) > 0 "
-            "  AND EXISTS (SELECT 1 FROM map_game_info m "
-            "              WHERE m.map_name = i.map_name AND m.is_pvp = 1)",
-            -1, &stmt, nullptr) != SQLITE_OK || !stmt) {
+    if (sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr) != SQLITE_OK || !stmt) {
         Logger::Log("mmr", "[MmrService] participant query prepare failed: %s\n",
             sqlite3_errmsg(db));
         return;
@@ -226,14 +352,17 @@ void BuildParticipants(sqlite3* db, std::vector<Match>& matches) {
     while (sqlite3_step(stmt) == SQLITE_ROW) {
         const int64_t inst = sqlite3_column_int64(stmt, 0);
         if (!by_id.count(inst)) continue;
-        const char* cls = ClassNameForProfile(sqlite3_column_int(stmt, 3));
-        if (!cls) continue;
+        const uint32_t pid = static_cast<uint32_t>(sqlite3_column_int(stmt, 3));
+        const CP::ClassDef* def = CP::ByProfileId(pid);
+        if (!def) continue;
         Stint st;
-        st.cls        = cls;
+        st.cls        = def->name;
+        st.profile_id = pid;
         st.task_force = sqlite3_column_int(stmt, 2);
         st.time       = sqlite3_column_double(stmt, 4);
-        for (int k = 0; k < kNumStats; k++)
-            st.stats[k] = sqlite3_column_double(stmt, 5 + k);
+        for (size_t k = 0; k < col_slot.size(); ++k) {
+            st.raw[col_slot[k]] = sqlite3_column_double(stmt, 5 + static_cast<int>(k));
+        }
         stints[{inst, sqlite3_column_int64(stmt, 1)}].push_back(std::move(st));
     }
     sqlite3_finalize(stmt);
@@ -243,60 +372,43 @@ void BuildParticipants(sqlite3* db, std::vector<Match>& matches) {
         std::stable_sort(grp.begin(), grp.end(),
             [](const Stint& a, const Stint& b) { return a.time > b.time; });
         const Stint& fin = grp.front();
+
         Participant p;
         p.user_id    = entry.first.second;
         p.cls        = fin.cls;
+        p.profile_id = fin.profile_id;
         p.task_force = fin.task_force;
+        double summed[kNumStats] = {};
         for (const auto& s : grp) {
             if (s.cls != p.cls) continue;
             p.class_time += s.time;
-            for (int k = 0; k < kNumStats; k++) p.stats[k] += s.stats[k];
+            for (int k = 0; k < kNumStats; ++k) summed[k] += s.raw[k];
         }
-        if (p.class_time < kMinPlaySeconds) continue;
-        by_id[entry.first.first]->players.push_back(std::move(p));
+        if (p.class_time < tun.min_seconds) continue;
+
+        Match* m = by_id[entry.first.first];
+        p.match_share = (m->length > 0.0)
+            ? std::min(1.0, p.class_time / m->length) : 1.0;
+        if (p.match_share < tun.min_match_share) continue;
+
+        const double minutes = p.class_time / 60.0;
+        for (int k = 0; k < kNumStats; ++k) p.rate[k] = summed[k] / minutes;
+
+        // rel_deaths: own death rate over the rest of the team's death rate.
+        // 1.0 when the team's rate is unknown — neutral, neither credit nor
+        // penalty.
+        p.rate[CP::kRelDeaths] = 1.0;
+        auto tt = team_totals.find({m->id, p.task_force});
+        if (tt != team_totals.end()) {
+            const double others_min = (tt->second.time - p.class_time) / 60.0;
+            const double others_deaths = tt->second.deaths - summed[CP::kDeaths];
+            if (others_min > 1.0 && others_deaths > 0.0) {
+                const double others_rate = others_deaths / others_min;
+                p.rate[CP::kRelDeaths] = p.rate[CP::kDeaths] / others_rate;
+            }
+        }
+        m->players.push_back(std::move(p));
     }
-}
-
-// Perf engine: class-population baselines of per-minute stat rates over ALL
-// qualifying records (recomputed each fold, same as mmr_tracker.py — baselines
-// drift as data accumulates; only the wl engine is exactly replayable).
-void ComputePerfIndices(std::vector<Match>& matches) {
-    struct Acc { double sum = 0.0, sumsq = 0.0; int64_t n = 0; };
-    std::map<std::string, Acc> acc[kNumStats];
-
-    auto rate = [](const Participant& p, int k) {
-        return p.stats[k] / (p.class_time / 60.0);
-    };
-
-    for (const auto& m : matches)
-        for (const auto& p : m.players)
-            for (int k = 0; k < kNumStats; k++) {
-                Acc& a = acc[k][p.cls];
-                const double r = rate(p, k);
-                a.sum += r;
-                a.sumsq += r * r;
-                a.n++;
-            }
-
-    for (auto& m : matches)
-        for (auto& p : m.players) {
-            double zsum = 0.0;
-            int zn = 0;
-            for (int k = 0; k < kNumStats; k++) {
-                const Acc& a = acc[k][p.cls];
-                if (a.n < 2) continue;
-                const double mean = a.sum / a.n;
-                double var = a.sumsq / a.n - mean * mean;
-                if (var < 0) var = 0;
-                const double sd = std::sqrt(var);
-                if (sd == 0) continue;
-                double z = (rate(p, k) - mean) / sd;
-                z = std::max(-kPerfZClamp, std::min(kPerfZClamp, z));
-                zsum += kStatSign[k] * z;
-                zn++;
-            }
-            p.perf = zn ? zsum / zn : 0.0;
-        }
 }
 
 std::set<int64_t> LoadProcessed(sqlite3* db, const char* table) {
@@ -332,7 +444,7 @@ void LoadPerfState(sqlite3* db, std::map<RatingKey, double>& rating,
     sqlite3_stmt* stmt = nullptr;
     if (sqlite3_prepare_v2(db,
             "SELECT user_id, class_name, mmr_after, games_after FROM ga_mmr_history "
-            "ORDER BY rowid", -1, &stmt, nullptr) == SQLITE_OK && stmt) {
+            "ORDER BY instance_id", -1, &stmt, nullptr) == SQLITE_OK && stmt) {
         while (sqlite3_step(stmt) == SQLITE_ROW) {
             const char* cls = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
             const RatingKey key{sqlite3_column_int64(stmt, 0), cls ? cls : ""};
@@ -341,6 +453,27 @@ void LoadPerfState(sqlite3* db, std::map<RatingKey, double>& rating,
         }
     }
     sqlite3_finalize(stmt);
+}
+
+// A rating for a class the player has not played before. Starting everyone at
+// the default throws away what we already know: general skill carries across
+// classes more than it doesn't, so a strong Assault is a better-than-average
+// bet on Medic. seed_weight controls how much of that carries — below 1.0 so
+// there is still room to be genuinely bad at a class.
+double SeedRating(const std::map<RatingKey, double>& rating,
+                  const std::map<RatingKey, int64_t>& games,
+                  int64_t user_id, const CP::Tunables& tun) {
+    double sum = 0.0;
+    int n = 0;
+    for (const auto& e : rating) {
+        if (e.first.first != user_id) continue;
+        auto g = games.find(e.first);
+        if (g == games.end() || g->second < tun.provisional_games) continue;
+        sum += e.second;
+        n++;
+    }
+    if (n == 0) return tun.default_mmr;
+    return tun.default_mmr + tun.seed_weight * (sum / n - tun.default_mmr);
 }
 
 std::string FoldLocked() {
@@ -366,9 +499,10 @@ std::string FoldLocked() {
         if (pending == 0) return "up to date";
     }
 
+    const CP::Tunables& tun = CP::Get();
+
     std::vector<Match> matches = LoadMatches(db);
     BuildParticipants(db, matches);
-    ComputePerfIndices(matches);
 
     std::map<RatingKey, double> wl_rating, perf_rating;
     std::map<RatingKey, int64_t> perf_games;
@@ -388,7 +522,10 @@ std::string FoldLocked() {
         "INSERT OR IGNORE INTO ga_wl_mmr_processed VALUES (?, ?)",
         -1, &ins_wl_proc, nullptr);
     sqlite3_prepare_v2(db,
-        "INSERT OR IGNORE INTO ga_mmr_history VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "INSERT OR IGNORE INTO ga_mmr_history "
+        "(user_id, class_name, archetype, instance_id, played_at, minutes, "
+        " match_share, perf, expected, actual, mmr_before, mmr_after, games_after) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         -1, &ins_pf_hist, nullptr);
     sqlite3_prepare_v2(db,
         "INSERT OR IGNORE INTO ga_mmr_processed VALUES (?, ?)",
@@ -411,43 +548,75 @@ std::string FoldLocked() {
 
     sqlite3_exec(db, "BEGIN IMMEDIATE", nullptr, nullptr, nullptr);
 
-    int rated = 0, skipped_one_sided = 0, gap_adjusted = 0;
+    // Class populations and per-player archetype signals are rebuilt from the
+    // whole match history on every fold, always in conclusion order. They are
+    // never read ahead of the match being scored, so a match scored live and
+    // the same match scored during a full replay get identical numbers — that
+    // is what makes a reseed reproduce the live chain.
+    std::map<std::string, ClassBaseline> baselines;
+    std::map<RatingKey, ArchSignal> arch;
+
+    int rated = 0, skipped_one_sided = 0, skipped_small = 0, gap_adjusted = 0;
     int64_t wl_rows = 0, pf_rows = 0;
 
     for (auto& m : matches) {
         const bool wl_new = !wl_done.count(m.id);
         const bool pf_new = !perf_done.count(m.id);
-        if (!wl_new && !pf_new) continue;
+
+        // Near-empty lobbies are watermarked so they are never revisited, but
+        // otherwise ignored completely — they neither move ratings nor feed
+        // the class baselines, because a 4-player match says nothing about how
+        // a class is normally played.
+        if (static_cast<int>(m.players.size()) < tun.min_rated_players) {
+            if (wl_new) insert_proc(ins_wl_proc, m.id, m.started_at);
+            if (pf_new) insert_proc(ins_pf_proc, m.id, m.started_at);
+            if (wl_new || pf_new) skipped_small++;
+            continue;
+        }
+
+        // Score against the population as it stood before this match, whether
+        // or not we are writing it — the baselines have to advance in lockstep
+        // with the walk even across already-folded matches.
+        for (auto& p : m.players) {
+            const CP::ClassDef* def = CP::ByProfileId(p.profile_id);
+            if (!def) continue;
+            ScoreParticipant(p, baselines[p.cls], *def, arch[{p.user_id, p.cls}], tun);
+        }
+
+        auto advance_baselines = [&]() {
+            for (const auto& p : m.players) AccumulateBaseline(baselines[p.cls], p);
+        };
+
+        if (!wl_new && !pf_new) { advance_baselines(); continue; }
 
         // Watermark first, even when skipped below (mirrors the scripts).
         if (wl_new) insert_proc(ins_wl_proc, m.id, m.started_at);
         if (pf_new) insert_proc(ins_pf_proc, m.id, m.started_at);
 
-        if (m.players.empty()) continue;
+        if (m.players.empty()) { advance_baselines(); continue; }
 
         std::set<int> tfs;
         for (const auto& p : m.players) tfs.insert(p.task_force);
         if (tfs.size() != 2) {
             skipped_one_sided++;
+            advance_baselines();
             continue;
         }
         const int tf_a = *tfs.begin();
         const int tf_b = *std::next(tfs.begin());
 
-        // Plain locals (not structured bindings): the lambdas below capture
-        // them, which C++17 forbids for structured bindings.
         const std::pair<int, double> gap_res = GetTeamSizeGap(db, m.id);
         const int bigger_tf = gap_res.first;
-        const double gap = std::min(gap_res.second, kMaxGapCap);
+        const double gap = std::min(gap_res.second, tun.gap_cap);
         const bool adjust = bigger_tf != 0
             && (bigger_tf == tf_a || bigger_tf == tf_b)
-            && gap > kGapDeadzone;
+            && gap > 0.0;
         if (adjust) gap_adjusted++;
 
         auto team_avg = [&](const std::map<RatingKey, double>& ratings) {
             std::map<int, std::pair<double, int>> agg;
             for (const auto& p : m.players) {
-                double r = kDefaultMmr;
+                double r = tun.default_mmr;
                 auto it = ratings.find({p.user_id, p.cls});
                 if (it != ratings.end()) r = it->second;
                 agg[p.task_force].first += r;
@@ -460,7 +629,7 @@ std::string FoldLocked() {
         auto adjusted = [&](std::map<int, double> avg) {
             if (adjust) {
                 const int smaller = (bigger_tf == tf_a) ? tf_b : tf_a;
-                const double half = gap * kEloPerPlayerGap / 2.0;
+                const double half = gap * tun.elo_per_player_gap / 2.0;
                 avg[bigger_tf] += half;
                 avg[smaller]  -= half;
             }
@@ -473,7 +642,7 @@ std::string FoldLocked() {
                 const int opp = (p.task_force == tf_a) ? tf_b : tf_a;
                 const RatingKey key{p.user_id, p.cls};
                 auto it = wl_rating.find(key);
-                const double before = (it != wl_rating.end()) ? it->second : kDefaultMmr;
+                const double before = (it != wl_rating.end()) ? it->second : tun.default_mmr;
                 const double expected = ExpectedScore(before, adj.at(opp));
                 // winning_tf 0 = stalemate (NULL winner) -> both sides draw.
                 const double actual = (m.winning_tf == 0) ? 0.5
@@ -495,39 +664,53 @@ std::string FoldLocked() {
         }
 
         if (pf_new) {
-            const auto avg = team_avg(perf_rating);
-            const auto adj = adjusted(avg);
-            for (const auto& p : m.players) {
+            const auto adj = adjusted(team_avg(perf_rating));
+            for (auto& p : m.players) {
                 const int opp = (p.task_force == tf_a) ? tf_b : tf_a;
                 const RatingKey key{p.user_id, p.cls};
                 auto it = perf_rating.find(key);
-                const double before = (it != perf_rating.end()) ? it->second : kDefaultMmr;
-                // Team-average expected score (mmr_tracker.py semantics).
-                const double expected = ExpectedScore(avg.at(p.task_force), adj.at(opp));
-                // winning_tf 0 = stalemate (NULL winner) -> both sides draw.
+                const double before = (it != perf_rating.end())
+                    ? it->second
+                    : SeedRating(perf_rating, perf_games, p.user_id, tun);
+                // Individual expected, not the team average: a rating only
+                // converges if its own level feeds back into what is expected
+                // of it. With the team average there, a strong player is never
+                // pulled back and the rating drifts instead of settling.
+                const double expected = ExpectedScore(before, adj.at(opp));
                 const double actual = (m.winning_tf == 0) ? 0.5
                     : (p.task_force == m.winning_tf) ? 1.0 : 0.0;
                 const int64_t games = perf_games[key];
-                const double k = (games < kPerfMinGames) ? kPerfKProvisional : kPerfKBase;
-                const double after = before + k * ((actual - expected) + kPerfBeta * p.perf);
+                const double k = (games < tun.provisional_games)
+                    ? tun.k_provisional : tun.k_base;
+                const double after =
+                    before + k * ((actual - expected) + tun.beta * p.perf);
                 perf_rating[key] = after;
                 perf_games[key] = games + 1;
+                p.expected = expected;
+                p.actual = actual;
 
                 sqlite3_reset(ins_pf_hist);
                 sqlite3_clear_bindings(ins_pf_hist);
-                sqlite3_bind_int64(ins_pf_hist, 1, p.user_id);
-                sqlite3_bind_text(ins_pf_hist, 2, p.cls.c_str(), -1, SQLITE_TRANSIENT);
-                sqlite3_bind_int64(ins_pf_hist, 3, m.id);
-                sqlite3_bind_int64(ins_pf_hist, 4, m.started_at);
-                sqlite3_bind_double(ins_pf_hist, 5, before);
-                sqlite3_bind_double(ins_pf_hist, 6, after);
-                sqlite3_bind_int64(ins_pf_hist, 7, games + 1);
+                sqlite3_bind_int64 (ins_pf_hist, 1,  p.user_id);
+                sqlite3_bind_text  (ins_pf_hist, 2,  p.cls.c_str(), -1, SQLITE_TRANSIENT);
+                sqlite3_bind_text  (ins_pf_hist, 3,  p.archetype.c_str(), -1, SQLITE_TRANSIENT);
+                sqlite3_bind_int64 (ins_pf_hist, 4,  m.id);
+                sqlite3_bind_int64 (ins_pf_hist, 5,  m.started_at);
+                sqlite3_bind_double(ins_pf_hist, 6,  p.class_time / 60.0);
+                sqlite3_bind_double(ins_pf_hist, 7,  p.match_share);
+                sqlite3_bind_double(ins_pf_hist, 8,  p.perf);
+                sqlite3_bind_double(ins_pf_hist, 9,  expected);
+                sqlite3_bind_double(ins_pf_hist, 10, actual);
+                sqlite3_bind_double(ins_pf_hist, 11, before);
+                sqlite3_bind_double(ins_pf_hist, 12, after);
+                sqlite3_bind_int64 (ins_pf_hist, 13, games + 1);
                 sqlite3_step(ins_pf_hist);
                 pf_rows++;
             }
         }
 
         rated++;
+        advance_baselines();
     }
 
     sqlite3_exec(db, "COMMIT", nullptr, nullptr, nullptr);
@@ -538,9 +721,9 @@ std::string FoldLocked() {
 
     char buf[256];
     snprintf(buf, sizeof(buf),
-        "folded %d match(es) (%d one-sided skipped, %d gap-adjusted); "
+        "folded %d match(es) (%d too small, %d one-sided, %d gap-adjusted); "
         "rows appended wl=%lld perf=%lld",
-        rated, skipped_one_sided, gap_adjusted,
+        rated, skipped_small, skipped_one_sided, gap_adjusted,
         (long long)wl_rows, (long long)pf_rows);
     Logger::Log("mmr", "[MmrService] %s\n", buf);
     return buf;
@@ -588,21 +771,24 @@ std::string MmrService::GetActiveEngine() {
 }
 
 double MmrService::GetCurrentRating(int64_t user_id, uint32_t profile_id) {
-    const char* cls = ClassNameForProfile(static_cast<int>(profile_id));
-    if (!cls) return kDefaultMmr;
+    const ClassProfiles::ClassDef* def = ClassProfiles::ByProfileId(profile_id);
+    const double default_mmr = ClassProfiles::Get().default_mmr;
+    if (!def) return default_mmr;
     sqlite3* db = Database::GetConnection();
-    if (!db) return kDefaultMmr;
-    const std::string table =
-        (GetActiveEngine() == "perf") ? "ga_mmr_history" : "ga_wl_mmr_history";
-    // rowid order == fold order; the last row per (user, class) is current.
-    const std::string sql =
-        "SELECT mmr_after FROM " + table +
-        " WHERE user_id = ? AND class_name = ? ORDER BY rowid DESC LIMIT 1";
+    if (!db) return default_mmr;
+    const bool perf = (GetActiveEngine() == "perf");
+    // Both histories are keyed (user_id, class_name, instance_id), so ordering
+    // by instance_id walks the primary key backwards instead of scanning.
+    const std::string sql = perf
+        ? "SELECT mmr_after FROM ga_mmr_history "
+          "WHERE user_id = ? AND class_name = ? ORDER BY instance_id DESC LIMIT 1"
+        : "SELECT mmr_after FROM ga_wl_mmr_history "
+          "WHERE user_id = ? AND class_name = ? ORDER BY rowid DESC LIMIT 1";
     sqlite3_stmt* stmt = nullptr;
-    double rating = kDefaultMmr;
+    double rating = default_mmr;
     if (sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr) == SQLITE_OK && stmt) {
         sqlite3_bind_int64(stmt, 1, user_id);
-        sqlite3_bind_text(stmt, 2, cls, -1, SQLITE_STATIC);
+        sqlite3_bind_text(stmt, 2, def->name.c_str(), -1, SQLITE_STATIC);
         if (sqlite3_step(stmt) == SQLITE_ROW)
             rating = sqlite3_column_double(stmt, 0);
     }

--- a/src/ControlServer/main.cpp
+++ b/src/ControlServer/main.cpp
@@ -16,6 +16,7 @@
 #include "src/ControlServer/MatchmakingService/MatchmakingService.hpp"
 #include "src/ControlServer/MatchmakingService/SidePlacement.hpp"
 #include "src/ControlServer/MmrService/MmrService.hpp"
+#include "src/ControlServer/MmrService/ClassProfiles.hpp"
 #include <asio.hpp>
 #include <thread>
 #include <cstdlib>
@@ -428,6 +429,12 @@ int main(int argc, char* argv[]) {
     // (e.g. 3P_Beachhead2_P, 3P_Beachhead_P) belong in ga_map_pool_entries with
     // enabled=0 until the client downloads them.
     MatchmakingService::Init();
+
+    // Per-class scoring weights for the perf engine. Compiled defaults are the
+    // tuned values; control-server.json's "mmr" section overrides them, so the
+    // weights can be adjusted between play sessions without a rebuild. Must
+    // run before the first fold — the weights decide how every match scores.
+    ClassProfiles::Load(config_path);
 
     // Seed / catch up the MMR engines (design 2026-07-12). First boot on an
     // empty history replays the entire match backlog; later boots fold

--- a/tools/mmr/README.md
+++ b/tools/mmr/README.md
@@ -1,0 +1,53 @@
+# MMR analysis tools
+
+Offline scripts behind the performance-based rating engine in
+`src/ControlServer/MmrService/`. None of them touch the server; they read a DB
+snapshot and, in one case, write to it. Python 3, stdlib only.
+
+Point them at a snapshot with the match tables populated. `reseed.py` takes the
+path as an argument; the rest have it near the top of the file.
+
+## The one that matters
+
+**`reseed.py`** — a deliberate line-for-line port of `MmrService.cpp`, not a
+tidier rewrite. It is the **acceptance test for the build**: reseed with the
+compiled engine and with this, and the two should agree. If they don't, one of
+them has a bug and this tells you what the answer should have been.
+
+```
+python reseed.py path/to/snapshot.db            # dry run, prints the fold summary
+python reseed.py path/to/snapshot.db --apply    # rebuilds ga_mmr_history
+```
+
+Keep it in step with the C++. If you change a weight, a rule or a tunable in
+`ClassProfiles.cpp`, change it here too or the acceptance test is worthless.
+
+## Why the constants are what they are
+
+Every number in `ClassProfiles.hpp` came from one of these. Re-run the relevant
+script before changing one.
+
+| script | question it answers |
+|---|---|
+| `closed_pool.py` | Can win/loss carry a rating at this population size? Shuffles which players were on the winning side, keeping every real roster and result, to get the win-rate spread chance alone would produce. **Observed sd 8.7pp against 6.5pp from chance — only ~45% of the variance is skill.** This is why win/loss was abandoned rather than retuned. |
+| `wl_divisor.py` | Would retuning the old engine's Elo divisor fix it? Sweeps the divisor, and separately lets the update and the prediction use different values. Best single value is ~300 for a gain inside noise; the two uses pull in opposite directions because one compares an individual to a team and the other a team to a team. |
+| `converge.py` | Does the rating settle? Compares the drifting rule against the anchored one and sweeps `perf_scale`. A drifting +0.56-performance player passes 5,000 by their thousandth game; anchored, they settle around 1,230. |
+| `wl_project.py` | Forward-projects the old engine under both divisors, with resting points. |
+| `team_splits.py` | Time-weighted headcount balance per match. **47% of matches are even, 51% are exactly one player apart** — which is what the 110-Elo headcount correction exists for. |
+| `gen_data.py` | Builds the standings and per-player stat profiles used by the published pages. |
+| `recent_form.py` | Rebuilds ratings from a recent window only (last two Sundays), for a form table. |
+| `final_data.py` | Multi-class player profiles, plus past steamrolls with what the balancer would have done to them. |
+
+## Things worth knowing before trusting any of it
+
+- Everything rests on **158 rated matches**. The direction of each finding held
+  across every cut; the exact constants did not. Several improvements measured
+  are inside noise individually.
+- Two of the three most consequential bugs were found by reviewers asking plain
+  questions about a specific player, not by any test in here.
+- The rating measures what is in `ga_match_player_stats`. Shot-calling,
+  positioning, keeping the right player alive — none of it appears, and no
+  reweighting of the existing columns will find it.
+- `rep_points`, `objective_captures` and `beacon_spawns_provided` are populated
+  as zero on every row. `capture_seconds` and `contest_seconds` carry real data
+  but nothing reads them.

--- a/tools/mmr/closed_pool.py
+++ b/tools/mmr/closed_pool.py
@@ -1,0 +1,109 @@
+"""Does a small, closed playerbase limit what win/loss can tell us?
+
+Everyone plays with and against everyone else, repeatedly. Two consequences
+worth measuring:
+
+  1. Teams are drawn from the same pool, so your win rate is mostly decided by
+     the eight other people on your side, not by you.
+  2. Ratings are zero-sum inside the pool -- the average is pinned near the
+     default, so any spread one player gains, others must lose.
+
+The test: keep every real roster and every real result, but shuffle WHICH
+players were on the winning side. That produces the win-rate spread you would
+see from pure chance on this exact schedule. If the real spread is not much
+wider, win rate is not carrying the skill signal a wider divisor would amplify.
+"""
+import sqlite3, math, random, statistics as st
+from collections import defaultdict
+import wl_divisor as W
+
+random.seed(20260803)
+conn = sqlite3.connect(W.DB, uri=True)
+matches = [m for m in W.load(conn) if len(m["players"]) >= 10]
+col = next(x[1] for x in conn.execute("PRAGMA table_info(ga_users)")
+           if x[1] in ("username", "name", "display_name"))
+NM = {u: n for u, n in conn.execute(f"SELECT id,{col} FROM ga_users")}
+
+# ---- how closed is the pool? ----------------------------------------------
+appear = defaultdict(int)
+pair_same, pair_opp = defaultdict(int), defaultdict(int)
+for m in matches:
+    ps = m["players"]
+    for p in ps:
+        appear[p["uid"]] += 1
+    for i in range(len(ps)):
+        for j in range(i + 1, len(ps)):
+            a, b = sorted((ps[i]["uid"], ps[j]["uid"]))
+            if ps[i]["tf"] == ps[j]["tf"]:
+                pair_same[(a, b)] += 1
+            else:
+                pair_opp[(a, b)] += 1
+
+regulars = [u for u, n in appear.items() if n >= 20]
+print(f"{len(matches)} matches, {len(appear)} distinct players, "
+      f"{len(regulars)} with 20+ appearances")
+tot = sum(appear.values())
+top = sorted(appear.values(), reverse=True)
+print(f"the {len(regulars)} regulars account for "
+      f"{sum(n for n in appear.values() if n >= 20)/tot*100:.0f}% of all appearances")
+
+# for a regular, what share of matches is any other regular also in?
+co = []
+for a in regulars:
+    for b in regulars:
+        if a >= b:
+            continue
+        n = pair_same[(a, b)] + pair_opp[(a, b)]
+        if n:
+            co.append(n / min(appear[a], appear[b]))
+print(f"two regulars share a match {st.median(co)*100:.0f}% of the time (median pair)")
+same_share = [pair_same[k] / (pair_same[k] + pair_opp[k])
+              for k in set(pair_same) | set(pair_opp)
+              if pair_same[k] + pair_opp[k] >= 10]
+print(f"when two players are both in a match they are TEAMMATES "
+      f"{st.median(same_share)*100:.0f}% of the time (median pair)\n")
+
+# ---- observed vs chance win-rate spread ------------------------------------
+obs = defaultdict(lambda: [0, 0])
+for m in matches:
+    if m["wtf"] == 0:
+        continue
+    for p in m["players"]:
+        obs[p["uid"]][1] += 1
+        obs[p["uid"]][0] += 1 if p["tf"] == m["wtf"] else 0
+MING = 20
+real = {u: w / n for u, (w, n) in obs.items() if n >= MING}
+print(f"{len(real)} players with {MING}+ decided matches")
+print(f"OBSERVED win rate: {min(real.values())*100:.0f}%-{max(real.values())*100:.0f}%, "
+      f"sd {st.pstdev(list(real.values()))*100:.1f}pp")
+
+TRIALS = 400
+sds, spans = [], []
+for _ in range(TRIALS):
+    sim = defaultdict(lambda: [0, 0])
+    for m in matches:
+        if m["wtf"] == 0:
+            continue
+        ps = m["players"]
+        n_win = sum(1 for p in ps if p["tf"] == m["wtf"])
+        ids = [p["uid"] for p in ps]
+        random.shuffle(ids)
+        winners = set(ids[:n_win])
+        for u in ids:
+            sim[u][1] += 1
+            sim[u][0] += 1 if u in winners else 0
+    vals = [w / n for u, (w, n) in sim.items() if n >= MING]
+    sds.append(st.pstdev(vals))
+    spans.append(max(vals) - min(vals))
+print(f"CHANCE  win rate: sd {st.mean(sds)*100:.1f}pp "
+      f"(95% of trials {sorted(sds)[10]*100:.1f}-{sorted(sds)[-10]*100:.1f}pp)")
+real_sd = st.pstdev(list(real.values()))
+print(f"\nreal sd {real_sd*100:.1f}pp vs chance {st.mean(sds)*100:.1f}pp "
+      f"-> {real_sd/st.mean(sds):.2f}x")
+above = sum(1 for s in sds if s >= real_sd)
+print(f"{above}/{TRIALS} random shuffles produced a spread this wide or wider")
+
+# how much of the real spread is signal?
+signal_var = max(0.0, real_sd**2 - st.mean(sds)**2)
+print(f"variance attributable to skill: {signal_var/real_sd**2*100:.0f}% "
+      f"(=> genuine win-rate sd about {math.sqrt(signal_var)*100:.1f}pp)")

--- a/tools/mmr/converge.py
+++ b/tools/mmr/converge.py
@@ -1,0 +1,158 @@
+"""Test a convergent update rule against the current drifting one.
+
+Current:   delta = K * ( (actual - expected) + beta * perf )
+             -> the perf term is a constant push with nothing pulling back, so
+                any player whose beta*perf exceeds (1 - win_rate) rises forever.
+
+Proposed:  delta = K * ( (actual - expected) + beta * (perf - perf_expected) )
+           where perf_expected = (rating - default) / perf_scale
+
+             -> a player is only rewarded for OUTPERFORMING their own rating.
+                perf_scale is the one new parameter: how many rating points one
+                unit of perf is worth at rest. It gives the rating a genuine
+                equilibrium instead of a direction of travel.
+"""
+import sqlite3, math, statistics as st
+from collections import defaultdict
+import reseed
+from reseed import TUN, PROFILES, IX, STATS
+
+DB = "file:E:/ga.db?mode=ro"
+
+
+def fold(matches, conn, beta, perf_scale, divisor=400.0, warm=40):
+    """perf_scale None = the current drifting rule."""
+    baselines = defaultdict(lambda: [[0.0, 0.0, 0] for _ in range(len(STATS))])
+    arch = defaultdict(lambda: [0.0, 0])
+    rating, games = {}, defaultdict(int)
+    preds, ll, n, acc = [], 0.0, 0, 0
+
+    for i, m in enumerate(matches):
+        if len(m["players"]) < TUN["min_rated_players"]:
+            continue
+        for p in m["players"]:
+            d = PROFILES[p["cls"]]
+            base = baselines[p["cls"]]
+            prof = d["profiles"][0]
+            if len(d["profiles"]) > 1 and d["disc"]:
+                pos = reseed.mean_z(base, d["disc"]["pos"], p["rate"])
+                neg = reseed.mean_z(base, d["disc"]["neg"], p["rate"])
+                k = (p["uid"], p["cls"])
+                if pos is not None and neg is not None:
+                    arch[k][0] += pos - neg
+                    arch[k][1] += 1
+                if arch[k][1] and arch[k][0] / arch[k][1] > d["disc"]["threshold"]:
+                    prof = d["profiles"][1]
+            _nm, prem, w = prof
+            num = den = 0.0
+            for s, wt in w.items():
+                z = reseed.zscore(base[IX[s]], p["rate"][IX[s]],
+                                  TUN["z_clamp"], TUN["min_baseline_games"])
+                if z is None:
+                    continue
+                num += wt * z
+                den += abs(wt)
+            p["perf"] = prem * (num / den) if den else 0.0
+
+        tfs = sorted({p["tf"] for p in m["players"]})
+        if len(tfs) == 2:
+            ta, tb = tfs
+            agg = defaultdict(lambda: [0.0, 0])
+            for p in m["players"]:
+                k = (p["uid"], p["cls"])
+                if k not in rating:
+                    rating[k] = reseed.seed_rating(rating, games, p["uid"])
+                agg[p["tf"]][0] += rating[k]
+                agg[p["tf"]][1] += 1
+            avg = {t: s / c for t, (s, c) in agg.items()}
+            big, gap = reseed.team_size_gap(conn, m["id"])
+            gap = min(gap, TUN["gap_cap"])
+            adj = dict(avg)
+            if big in (ta, tb) and gap > 0:
+                sm = tb if big == ta else ta
+                half = gap * TUN["elo_per_player_gap"] / 2.0
+                adj[big] += half
+                adj[sm] -= half
+            if i >= warm and m["wtf"] != 0:
+                pr = 1.0 / (1.0 + 10.0 ** ((adj[tb] - adj[ta]) / divisor))
+                pr = min(max(pr, 1e-6), 1 - 1e-6)
+                y = 1.0 if m["wtf"] == ta else 0.0
+                ll += -(y * math.log(pr) + (1 - y) * math.log(1 - pr))
+                acc += (pr > .5) == (y == 1)
+                n += 1
+                preds.append((pr, y))
+
+            new = {}
+            for p in m["players"]:
+                k = (p["uid"], p["cls"])
+                opp = tb if p["tf"] == ta else ta
+                b = rating[k]
+                e = 1.0 / (1.0 + 10.0 ** ((adj[opp] - b) / divisor))
+                a = 0.5 if m["wtf"] == 0 else (1.0 if p["tf"] == m["wtf"] else 0.0)
+                g = games[k]
+                K = TUN["k_provisional"] if g < TUN["provisional_games"] else TUN["k_base"]
+                if perf_scale is None:
+                    term = beta * p["perf"]
+                else:
+                    expected_perf = (b - TUN["default_mmr"]) / perf_scale
+                    term = beta * (p["perf"] - expected_perf)
+                new[k] = b + K * ((a - e) + term)
+                games[k] = g + 1
+            rating.update(new)
+
+        for p in m["players"]:
+            bl = baselines[p["cls"]]
+            for k2 in range(len(STATS)):
+                bl[k2][0] += p["rate"][k2]
+                bl[k2][1] += p["rate"][k2] ** 2
+                bl[k2][2] += 1
+
+    return dict(rating=rating, games=games, ll=ll / n, acc=acc / n, n=n, preds=preds)
+
+
+def drift_test(res, conn, matches, beta, perf_scale, extra=400):
+    """Replay one player's own matches on repeat and see where they end up."""
+    hist = defaultdict(list)
+    for m in matches:
+        if len(m["players"]) < TUN["min_rated_players"]:
+            continue
+        for p in m["players"]:
+            hist[(p["uid"], p["cls"])].append(p["perf"])
+    out = {}
+    for key, perfs in hist.items():
+        if len(perfs) < 60:
+            continue
+        r, g = 1000.0, 0
+        track = {}
+        for i in range(extra):
+            pf = perfs[i % len(perfs)]
+            # neutral opponent, empirical win rate for this key
+            e = 1.0 / (1.0 + 10.0 ** ((1050.0 - r) / 400.0))
+            a = 0.60
+            K = TUN["k_provisional"] if g < TUN["provisional_games"] else TUN["k_base"]
+            term = beta * pf if perf_scale is None else \
+                beta * (pf - (r - 1000.0) / perf_scale)
+            r += K * ((a - e) + term)
+            g += 1
+            if g in (100, 200, 400):
+                track[g] = round(r)
+        out[key] = track
+    return out
+
+
+if __name__ == "__main__":
+    conn = sqlite3.connect(DB, uri=True)
+    matches = reseed.load(conn)
+    print("rule                                 logloss    acc   spread(>=20g)   drift 100->400")
+    for label, beta, scale in (("current (drifting)", 1.0, None),
+                               ("anchored, scale 400", 1.0, 400.0),
+                               ("anchored, scale 600", 1.0, 600.0),
+                               ("anchored, scale 800", 1.0, 800.0),
+                               ("anchored, scale 1200", 1.0, 1200.0)):
+        r = fold(matches, conn, beta, scale)
+        vals = sorted(v for k, v in r["rating"].items() if r["games"][k] >= 20)
+        d = drift_test(r, conn, matches, beta, scale)
+        sample = next(iter(d.values())) if d else {}
+        dr = f"{sample.get(100,'')}->{sample.get(400,'')}" if sample else "n/a"
+        print(f"{label:<34}{r['ll']:>9.4f}{r['acc']*100:>6.0f}%"
+              f"   {min(vals):.0f}-{max(vals):.0f} (sd {st.pstdev(vals):.0f})   {dr}")

--- a/tools/mmr/final_data.py
+++ b/tools/mmr/final_data.py
@@ -1,0 +1,197 @@
+"""Gather everything the final report needs: multi-class player profiles, and
+past steamrolls with what the balancer would have done to them."""
+import sqlite3, math, json, itertools, statistics as st
+from collections import defaultdict
+import reseed
+from reseed import TUN, STATS, IX
+
+DB = "file:E:/server-redacted.db?mode=ro"
+conn = sqlite3.connect(DB, uri=True)
+col = next(x[1] for x in conn.execute("PRAGMA table_info(ga_users)")
+           if x[1] in ("username", "name", "display_name"))
+NM = {u: n for u, n in conn.execute(f"SELECT id,{col} FROM ga_users")}
+rev = defaultdict(list)
+for u, n in NM.items():
+    if n:
+        rev[n.lower()].append(u)
+
+matches = reseed.load(conn)
+rated = [m for m in matches if len(m["players"]) >= TUN["min_rated_players"]]
+
+# class populations for z-scores
+pop, per = defaultdict(list), defaultdict(list)
+for m in rated:
+    for p in m["players"]:
+        pop[p["cls"]].append(p["rate"])
+        per[(p["uid"], p["cls"])].append(p["rate"])
+base = {}
+for cls, rows in pop.items():
+    b = []
+    for k in range(len(STATS)):
+        v = [r[k] for r in rows]
+        mu = sum(v) / len(v)
+        b.append((mu, math.sqrt(max(0.0, sum(x * x for x in v) / len(v) - mu * mu))))
+    base[cls] = b
+
+# current ratings from the reseeded history
+cur, gm, arch_last, pf, wl_, ex_ = {}, defaultdict(int), {}, \
+    defaultdict(list), defaultdict(list), defaultdict(list)
+for u, cl, a, p, e, act, after, g in conn.execute(
+        """SELECT user_id,class_name,archetype,perf,expected,actual,mmr_after,games_after
+           FROM ga_mmr_history ORDER BY instance_id"""):
+    k = (u, cl)
+    cur[k] = after; gm[k] = g; arch_last[k] = a
+    pf[k].append(p); wl_[k].append(act); ex_[k].append(e)
+
+oldwl = {}
+for u, cl, v in conn.execute(
+        "SELECT user_id,class_name,mmr_after FROM ga_wl_mmr_history_oldengine ORDER BY rowid"):
+    oldwl[(u, cl)] = v
+
+
+def settle(r0, perf, surprise):
+    r, n = r0, 0
+    while n < 5000:
+        d = TUN["k_base"] * (surprise + TUN["beta"] *
+                             (perf - (r - TUN["default_mmr"]) / TUN["perf_scale"]))
+        r += d; n += 1
+        if abs(d) < 0.25:
+            break
+    return round(r)
+
+
+SHOW = ["kills", "assists", "deaths", "damage_dealt", "damage_taken",
+        "healing", "defense", "buff_value", "obj_points", "rel_deaths"]
+NAMES = ["Jeronix", "Zipe", "Kelrior", "Peltz", "Zaxik", "amna", "Callizle"]
+players = {}
+for nm in NAMES:
+    entries = []
+    for cls in ("Assault", "Recon", "Medic", "Robotic"):
+        u = next((x for x in rev[nm.lower()] if (x, cls) in cur), None)
+        if u is None or gm[(u, cls)] < 5:
+            continue
+        k = (u, cls)
+        rows = per[k]
+        z = {}
+        for i, s in enumerate(STATS):
+            if s not in SHOW:
+                continue
+            mu, sd = base[cls][i]
+            m = sum(r[i] for r in rows) / len(rows)
+            z[s] = round((m - mu) / sd if sd else 0.0, 2)
+        wr = sum(1 for x in wl_[k] if x == 1.0) / len(wl_[k])
+        entries.append(dict(cls=cls, mmr=round(cur[k]), games=gm[k],
+                            arch=arch_last[k], perf=round(st.mean(pf[k]), 2),
+                            win=round(wr * 100),
+                            old=(round(oldwl[k]) if k in oldwl else None),
+                            proj=settle(cur[k], st.mean(pf[k]), wr - st.mean(ex_[k])),
+                            z=z))
+    entries.sort(key=lambda e: -e["games"])
+    if entries:
+        players[nm] = entries
+json.dump(players, open("final_players.json", "w"))
+print("player profiles:")
+for nm, e in players.items():
+    print(f"  {nm:<10} " + "  ".join(
+        f"{x['cls'][:3]} {x['mmr']}({x['games']}g,{x['arch'][:4]})" for x in e))
+
+# ---- steamrolls, and what the balancer would have done --------------------
+CLASSES = ("Assault", "Recon", "Medic", "Robotic")
+GAPELO, LAM = TUN["elo_per_player_gap"], 0.5
+
+
+def winprob(P, asg, tfs):
+    a = [p for p in P if asg[p["uid"]] == tfs[0]]
+    b = [p for p in P if asg[p["uid"]] == tfs[1]]
+    if not a or not b:
+        return None
+    aa = sum(p["mmr"] for p in a) / len(a)
+    ab = sum(p["mmr"] for p in b) / len(b)
+    g = min(abs(len(a) - len(b)), 3)
+    e1, e2 = aa, ab
+    if len(a) > len(b):
+        e1 += g * GAPELO / 2; e2 -= g * GAPELO / 2
+    elif len(b) > len(a):
+        e2 += g * GAPELO / 2; e1 -= g * GAPELO / 2
+    cg = {}
+    for cl in CLASSES:
+        x = [p["mmr"] for p in a if p["cls"] == cl]
+        y = [p["mmr"] for p in b if p["cls"] == cl]
+        cg[cl] = ((sum(x) / len(x) if x else 0), (sum(y) / len(y) if y else 0), len(x), len(y))
+    return dict(a1=aa, a2=ab, n1=len(a), n2=len(b),
+                p=1.0 / (1.0 + 10.0 ** ((e2 - e1) / TUN["elo_divisor"])), cls=cg)
+
+
+scores = {}
+for iid, tf, k, d, o in conn.execute(
+        """SELECT instance_id,task_force,SUM(kills),SUM(deaths),SUM(obj_points)
+           FROM ga_match_player_stats GROUP BY 1,2"""):
+    scores.setdefault(iid, {})[tf] = (k or 0, d or 0, o or 0)
+
+cands = []
+for m in rated:
+    tfs = sorted({p["tf"] for p in m["players"]})
+    if len(tfs) != 2 or m["wtf"] == 0:
+        continue
+    P = [dict(uid=p["uid"], cls=p["cls"], mmr=cur.get((p["uid"], p["cls"]), 1000.0),
+              name=(NM.get(p["uid"]) or "?")[:16]) for p in m["players"]]
+    actual = {p["uid"]: pp["tf"] for p, pp in zip(P, m["players"])}
+    for p, pp in zip(P, m["players"]):
+        p["tf"] = pp["tf"]
+    w = winprob(P, actual, tfs)
+    if w is None:
+        continue
+    s = scores.get(m["id"], {})
+    kw = s.get(m["wtf"], (0, 0, 0))[0]
+    kl = s.get(tfs[1] if m["wtf"] == tfs[0] else tfs[0], (0, 0, 0))[0]
+    if kl >= 8 and kw / max(kl, 1) < 3.0:
+        continue                      # not a steamroll
+    fav = w["p"] if m["wtf"] == tfs[0] else 1 - w["p"]
+    cands.append((kw / max(kl, 1), m, P, actual, tfs, w, kw, kl, fav))
+
+cands.sort(key=lambda x: -x[0])
+out = []
+for ratio, m, P, actual, tfs, w, kw, kl, fav in cands[:6]:
+    byc = {cl: [p for p in P if p["cls"] == cl] for cl in CLASSES}
+    n1 = {cl: sum(1 for p in byc[cl] if actual[p["uid"]] == tfs[0]) for cl in CLASSES}
+    tot = {cl: len(byc[cl]) for cl in CLASSES}
+    sz1 = sum(1 for p in P if actual[p["uid"]] == tfs[0])
+    allowed = {cl: sorted({tot[cl] // 2, (tot[cl] + 1) // 2}) for cl in CLASSES}
+    combos = [c for c in itertools.product(*[allowed[cl] for cl in CLASSES]) if sum(c) == sz1]
+    if not combos:
+        combos = [tuple(n1[cl] for cl in CLASSES)]
+    best, base_off = None, abs(w["p"] - 0.5)
+    for counts in combos:
+        opts = [[set(x) for x in itertools.combinations([p["uid"] for p in byc[cl]], n)]
+                if byc[cl] else [set()] for cl, n in zip(CLASSES, counts)]
+        for combo in itertools.product(*opts):
+            sel = set().union(*combo) if combo else set()
+            asg = {p["uid"]: (tfs[0] if p["uid"] in sel else tfs[1]) for p in P}
+            r = winprob(P, asg, tfs)
+            if r is None or abs(r["p"] - 0.5) > base_off + 1e-9:
+                continue
+            val = abs(r["p"] - 0.5) * 400 + LAM * sum(
+                abs(x - y) for x, y, c1, c2 in r["cls"].values() if c1 and c2)
+            nmv = sum(1 for p in P if actual[p["uid"]] != asg[p["uid"]])
+            if best is None or (round(val, 6), nmv) < (round(best[0], 6), best[1]):
+                best = (val, nmv, asg, r)
+    if best is None:
+        continue
+    mp, = conn.execute("SELECT map_name FROM ga_instances WHERE id=?", (m["id"],)).fetchone()
+    out.append(dict(iid=m["id"], map=mp, kills=[kw, kl], won=m["wtf"],
+                    before=dict(p=round(fav * 100, 1), n1=w["n1"], n2=w["n2"],
+                                a1=round(w["a1"]), a2=round(w["a2"]),
+                                cls={k2: [round(v[0]), round(v[1]), v[2], v[3]]
+                                     for k2, v in w["cls"].items()}),
+                    after=dict(p=round((best[3]["p"] if m["wtf"] == tfs[0]
+                                        else 1 - best[3]["p"]) * 100, 1),
+                               n1=best[3]["n1"], n2=best[3]["n2"],
+                               a1=round(best[3]["a1"]), a2=round(best[3]["a2"]),
+                               cls={k2: [round(v[0]), round(v[1]), v[2], v[3]]
+                                    for k2, v in best[3]["cls"].items()}),
+                    moved=best[1]))
+json.dump(out, open("final_steamrolls.json", "w"))
+print("\nsteamrolls:")
+for o in out:
+    print(f"  inst {o['iid']:<6}{o['map'][:24]:<25}{o['kills'][0]}-{o['kills'][1]} kills   "
+          f"winner was {o['before']['p']}% -> {o['after']['p']}%   {o['moved']} moved")

--- a/tools/mmr/gen_data.py
+++ b/tools/mmr/gen_data.py
@@ -1,0 +1,129 @@
+"""Build standings.json + spotlight.json from a reseeded database.
+
+Archetype shown is the player's LATEST, not their most common: it is what they
+are now and what their next match will be scored as. Early games are labelled
+before the class baselines have settled, so a mode over all history can report
+someone as what they used to look like.
+"""
+import sqlite3, math, json, statistics as st, sys
+from collections import defaultdict
+import reseed
+from reseed import TUN, STATS
+
+DB = sys.argv[1] if len(sys.argv) > 1 else "E:/server-redacted.db"
+URI = "file:" + DB + "?mode=ro"
+c = sqlite3.connect(URI, uri=True)
+q = lambda s: c.execute(s).fetchall()
+col = next(x[1] for x in q("PRAGMA table_info(ga_users)")
+           if x[1] in ("username", "name", "display_name"))
+NM = {u: n for u, n in q(f"SELECT id,{col} FROM ga_users")}
+
+cur, gm, arch_last, pf, wl_, ex_ = {}, defaultdict(int), {}, \
+    defaultdict(list), defaultdict(list), defaultdict(list)
+for u, cl, a, p, e, act, after, g in q("""SELECT user_id,class_name,archetype,perf,expected,
+        actual,mmr_after,games_after FROM ga_mmr_history ORDER BY instance_id"""):
+    k = (u, cl)
+    cur[k] = after; gm[k] = g; arch_last[k] = a
+    pf[k].append(p); wl_[k].append(act); ex_[k].append(e)
+
+oldwl = {}
+try:
+    for u, cl, v in q("SELECT user_id,class_name,mmr_after FROM ga_wl_mmr_history_oldengine ORDER BY rowid"):
+        oldwl[(u, cl)] = v
+except sqlite3.OperationalError:
+    pass
+
+
+def settle(r0, perf, surprise):
+    """The team term does not depend on the player's rating, so the resting
+    point is r = 1000 + scale*(perf + surprise/beta). Simulated for exactness."""
+    r, n = r0, 0
+    while n < 5000:
+        d = TUN["k_base"] * (surprise + TUN["beta"] *
+                             (perf - (r - TUN["default_mmr"]) / TUN["perf_scale"]))
+        r += d; n += 1
+        if abs(d) < 0.25:
+            break
+    return round(r), n
+
+
+MIN = {"Assault": 20, "Recon": 20, "Medic": 20, "Robotic": 10}
+out = {}
+for cls in ("Assault", "Recon", "Medic", "Robotic"):
+    rows = []
+    for k, v in cur.items():
+        if k[1] != cls or gm[k] < 10:
+            continue
+        mp = st.mean(pf[k])
+        wr = sum(1 for x in wl_[k] if x == 1.0) / len(wl_[k])
+        proj, ng = settle(v, mp, wr - st.mean(ex_[k]))
+        rows.append(dict(name=(NM.get(k[0]) or f"u{k[0]}")[:18], mmr=round(v),
+                         games=gm[k], arch=arch_last[k], perf=round(mp, 2),
+                         win=round(wr * 100),
+                         old=(round(oldwl[k]) if k in oldwl else None),
+                         proj=proj, proj_games=gm[k] + ng))
+    rows.sort(key=lambda r: -r["mmr"])
+    out[cls] = rows
+json.dump(out, open("standings.json", "w"))
+
+# --- per-stat profiles for the spotlight tables -----------------------------
+matches = reseed.load(c)
+pop, per = defaultdict(list), defaultdict(list)
+for m in matches:
+    if len(m["players"]) < TUN["min_rated_players"]:
+        continue
+    for p in m["players"]:
+        pop[p["cls"]].append(p["rate"])
+        per[(p["uid"], p["cls"])].append(p["rate"])
+base = {}
+for cls, rows in pop.items():
+    b = []
+    for k in range(len(STATS)):
+        v = [r[k] for r in rows]
+        mu = sum(v) / len(v)
+        b.append((mu, math.sqrt(max(0.0, sum(x * x for x in v) / len(v) - mu * mu))))
+    base[cls] = b
+
+lookup = {(cls, r["name"]): r for cls, rows in out.items() for r in rows}
+rev = defaultdict(list)
+for u, n in NM.items():
+    if n:
+        rev[n.lower()].append(u)
+SHOW = ["kills", "assists", "deaths", "damage_dealt", "damage_taken",
+        "healing", "defense", "buff_value", "obj_points", "rel_deaths"]
+PICK = {"Assault": ["Zipe", "AngelDeLaGuarda", "Kelrior"],
+        "Recon":   ["Kelrior", "donk", "Marksy"],
+        "Medic":   ["Compelling", "Kloudnine", "amna", "Callizle", "RoundTwo"],
+        "Robotic": ["Jeronix", "Zaxik", "WaRadius"]}
+sp = {}
+for cls, names in PICK.items():
+    sp[cls] = []
+    for nm in names:
+        u = next((x for x in rev[nm.lower()] if (x, cls) in per), None)
+        row = lookup.get((cls, nm))
+        if u is None or row is None:
+            print("  missing:", nm, cls)
+            continue
+        rows = per[(u, cls)]
+        e = {}
+        for k, s in enumerate(STATS):
+            if s not in SHOW:
+                continue
+            mu, sd = base[cls][k]
+            m = sum(r[k] for r in rows) / len(rows)
+            e[s] = dict(val=round(m, 2), z=round((m - mu) / sd if sd else 0.0, 2))
+        sp[cls].append(dict(row, stats=e))
+json.dump(sp, open("spotlight.json", "w"))
+
+allrows = [dict(r, cls=cl) for cl, v in out.items() for r in v]
+for r in allrows:
+    r["d"] = r["proj"] - r["mmr"]
+d = [abs(r["d"]) for r in allrows]
+print(f"{len(allrows)} rated. median |proj-now| {st.median(d):.0f}, "
+      f"within 50: {sum(1 for x in d if x <= 50)}, over 100: {sum(1 for x in d if x > 100)}")
+counts = defaultdict(int)
+for r in allrows:
+    counts[r["arch"]] += 1
+print("archetypes (current label):", dict(counts))
+for cls in ("Assault", "Recon", "Medic", "Robotic"):
+    print(f"  {cls}: " + ", ".join(f"{r['name']} {r['mmr']}({r['arch']})" for r in out[cls][:4]))

--- a/tools/mmr/recent_form.py
+++ b/tools/mmr/recent_form.py
@@ -1,0 +1,144 @@
+"""Leaderboard from the last two Sundays only -- a form table, not a career one.
+
+Everyone restarts at 1000 and only those matches are folded, so the numbers say
+"how this fortnight went", not "how good you are". Class baselines are kept from
+the full dataset on purpose: what counts as an average medic is a property of
+the class, not of a 37-match window, and re-deriving it from so little would
+make every z-score meaningless.
+"""
+import sqlite3, math, json, datetime, statistics as st
+from collections import defaultdict
+import reseed
+from reseed import TUN, PROFILES, STATS, IX
+
+DB = "file:E:/server-redacted.db?mode=ro"
+conn = sqlite3.connect(DB, uri=True)
+col = next(x[1] for x in conn.execute("PRAGMA table_info(ga_users)")
+           if x[1] in ("username", "name", "display_name"))
+NM = {u: n for u, n in conn.execute(f"SELECT id,{col} FROM ga_users")}
+
+allm = reseed.load(conn)
+rated = [m for m in allm if len(m["players"]) >= TUN["min_rated_players"]]
+sundays = sorted({datetime.datetime.fromtimestamp(m["started"], datetime.timezone.utc).date()
+                  for m in rated
+                  if datetime.datetime.fromtimestamp(m["started"], datetime.timezone.utc)
+                  .weekday() == 6})[-2:]
+window = [m for m in rated
+          if datetime.datetime.fromtimestamp(m["started"], datetime.timezone.utc).date()
+          in sundays]
+print(f"window: {sundays[0]} and {sundays[1]}  ->  {len(window)} matches")
+
+# Class baselines from the FULL dataset (see module docstring).
+base = defaultdict(lambda: [[0.0, 0.0, 0] for _ in range(len(STATS))])
+for m in rated:
+    for p in m["players"]:
+        b = base[p["cls"]]
+        for k in range(len(STATS)):
+            b[k][0] += p["rate"][k]; b[k][1] += p["rate"][k] ** 2; b[k][2] += 1
+
+arch = defaultdict(lambda: [dict(), dict()])
+rating, games, wins, exl, pfl = {}, defaultdict(int), defaultdict(lambda: [0, 0]), \
+    defaultdict(list), defaultdict(list)
+arch_last = {}
+
+for m in window:
+    for p in m["players"]:
+        d = PROFILES[p["cls"]]; b = base[p["cls"]]
+        key = (p["uid"], p["cls"]); sig = arch[key]
+        zs = {}
+        for si, sname in enumerate(STATS):
+            z = reseed.zscore(b[si], p["rate"][si], TUN["z_clamp"], TUN["min_baseline_games"])
+            if z is None:
+                continue
+            zs[sname] = z
+            sig[0][sname] = sig[0].get(sname, 0.0) + z
+            sig[1][sname] = sig[1].get(sname, 0) + 1
+        mean_of = lambda n: (sig[0][n] / sig[1][n]) if sig[1].get(n) else None
+        def group_of(names):
+            v = [x for x in (mean_of(n) for n in names) if x is not None]
+            return (sum(v) / len(v)) if v else None
+        prof = d["profiles"][0]
+        for rule in d["rules"]:
+            cand = next((x for x in d["profiles"] if x[0] == rule["profile"]), None)
+            if cand is None: continue
+            pos = 0.0 if not rule["pos"] else group_of(rule["pos"])
+            neg = 0.0 if not rule["neg"] else group_of(rule["neg"])
+            if pos is None or neg is None: continue
+            if pos - neg <= rule["threshold"]: continue
+            ok = all((mean_of(rn) is not None and mean_of(rn) >= rv)
+                     for rn, rv in rule["require"].items())
+            if not ok: continue
+            prof = cand; break
+        nme, prem, w = prof
+        num = den = 0.0
+        for k2, wt in w.items():
+            if k2 not in zs: continue
+            num += wt * zs[k2]; den += abs(wt)
+        p["perf"] = prem * (num / den) if den else 0.0
+        p["arch"] = nme
+
+    tfs = sorted({p["tf"] for p in m["players"]})
+    if len(tfs) != 2:
+        continue
+    ta, tb = tfs
+    agg = defaultdict(lambda: [0.0, 0])
+    for p in m["players"]:
+        k = (p["uid"], p["cls"])
+        if k not in rating:
+            rating[k] = reseed.seed_rating(rating, games, p["uid"])
+        agg[p["tf"]][0] += rating[k]; agg[p["tf"]][1] += 1
+    avg = {t: s / c for t, (s, c) in agg.items()}
+    big, gap = reseed.team_size_gap(conn, m["id"]); gap = min(gap, TUN["gap_cap"])
+    adj = dict(avg)
+    if big in (ta, tb) and gap > 0:
+        sm = tb if big == ta else ta
+        half = gap * TUN["elo_per_player_gap"] / 2.0
+        adj[big] += half; adj[sm] -= half
+    new = {}
+    for p in m["players"]:
+        k = (p["uid"], p["cls"]); opp = tb if p["tf"] == ta else ta
+        b0 = rating[k]
+        e = 1.0 / (1.0 + 10.0 ** ((adj[opp] - adj[p["tf"]]) / TUN["elo_divisor"]))
+        a = 0.5 if m["wtf"] == 0 else (1.0 if p["tf"] == m["wtf"] else 0.0)
+        g = games[k]
+        K = TUN["k_provisional"] if g < TUN["provisional_games"] else TUN["k_base"]
+        new[k] = b0 + K * ((a - e) + TUN["beta"] *
+                           (p["perf"] - (b0 - TUN["default_mmr"]) / TUN["perf_scale"]))
+        games[k] = g + 1; wins[k][1] += 1; wins[k][0] += 1 if a == 1.0 else 0
+        exl[k].append(e); pfl[k].append(p["perf"]); arch_last[k] = p["arch"]
+    rating.update(new)
+
+# career ratings, for the comparison column
+career = {}
+for u, cl, v in conn.execute(
+        "SELECT user_id,class_name,mmr_after FROM ga_mmr_history ORDER BY instance_id"):
+    career[(u, cl)] = v
+
+MING = 5
+out = {}
+for cls in ("Assault", "Recon", "Medic", "Robotic"):
+    rows = []
+    for k, v in rating.items():
+        if k[1] != cls or games[k] < MING:
+            continue
+        rows.append(dict(name=(NM.get(k[0]) or f"u{k[0]}")[:18], mmr=round(v),
+                         games=games[k], arch=arch_last.get(k, ""),
+                         perf=round(st.mean(pfl[k]), 2),
+                         win=round(wins[k][0] / wins[k][1] * 100),
+                         career=(round(career[k]) if k in career else None)))
+    rows.sort(key=lambda r: -r["mmr"])
+    out[cls] = rows
+json.dump(dict(rows=out, days=[str(d) for d in sundays], matches=len(window)),
+          open("recent.json", "w"))
+
+tot = sum(len(v) for v in out.values())
+allv = [r["mmr"] for v in out.values() for r in v]
+print(f"{tot} rated at {MING}+ games in the window, spread {min(allv)}-{max(allv)}\n")
+for cls in ("Assault", "Recon", "Medic", "Robotic"):
+    print(f"--- {cls} ({len(out[cls])}) ---")
+    for i, r in enumerate(out[cls], 1):
+        d = (r["mmr"] - r["career"]) if r["career"] else 0
+        print(f"  {i:>2}. {r['name']:<18}{r['mmr']:>6}{r['games']:>4}g "
+              f"{r['win']:>4}% perf {r['perf']:+.2f}  {r['arch']:<7}"
+              f"  career {r['career'] or '-':>5} ({d:+d})")
+    print()

--- a/tools/mmr/reseed.py
+++ b/tools/mmr/reseed.py
@@ -1,0 +1,398 @@
+"""Reseed ga_mmr_history using the perf engine, mirroring MmrService.cpp.
+
+Deliberately a line-for-line port of the C++ rather than a tidier rewrite: the
+numbers this produces are the acceptance test for the build. If the compiled
+engine disagrees with this, one of the two is wrong.
+"""
+import sqlite3, math, argparse
+from collections import defaultdict
+
+# --- ClassProfiles defaults -------------------------------------------------
+STATS = ["kills", "assists", "deaths", "damage_dealt", "damage_taken",
+         "healing", "defense", "buff_value", "obj_points", "bot_kills",
+         "rel_deaths"]
+IX = {s: i for i, s in enumerate(STATS)}
+DB_COLS = STATS[:10]                       # rel_deaths is derived
+NSTAT = len(STATS)
+
+PROFILES = {
+    "Assault": dict(profile_id=680, profiles=[
+        ("roamer", 1.00, {"damage_dealt": 1.0, "kills": 1.0, "obj_points": 0.4,
+                          "assists": 0.3, "deaths": -0.4}),
+        ("tank", 1.10, {"damage_taken": 1.0, "obj_points": 1.0, "defense": 0.7,
+                        "damage_dealt": 0.4, "kills": 0.3, "deaths": -0.2})],
+        rules=[dict(profile="tank", pos=["damage_taken", "obj_points", "defense"],
+                    neg=["kills", "damage_dealt"], threshold=0.0, require={})]),
+    "Recon": dict(profile_id=681, profiles=[
+        ("recon", 1.00, {"kills": 1.0, "damage_dealt": 0.9, "obj_points": 0.4,
+                         "assists": 0.3, "deaths": -0.4})], rules=[]),
+    "Medic": dict(profile_id=567, profiles=[
+        ("healer", 1.00, {"healing": 1.0, "assists": 0.8, "buff_value": 0.4,
+                          "obj_points": 0.2, "deaths": -0.2,
+                          "damage_taken": -0.4, "rel_deaths": -0.3}),
+        ("poison", 0.45, {"kills": 0.8, "damage_dealt": 0.8, "assists": 0.5,
+                          "healing": 0.4, "buff_value": 0.2, "obj_points": 0.2,
+                          "deaths": -0.3}),
+        # Heals heavily AND buffs heavily -- not a trade of one for the other.
+        ("buff", 1.00, {"healing": 1.0, "buff_value": 0.8, "assists": 0.6,
+                        "obj_points": 0.2, "deaths": -0.2,
+                        "damage_taken": -0.4, "rel_deaths": -0.3})],
+        # Poison first: a damage medic must never be caught by the buff floors.
+        rules=[dict(profile="poison", pos=["kills", "damage_dealt"],
+                    neg=["healing"], threshold=0.5, require={}),
+               dict(profile="buff", pos=[], neg=[], threshold=-1e9,
+                    require={"healing": 0.35, "buff_value": 0.30})]),
+    "Robotic": dict(profile_id=679, profiles=[
+        ("robo", 1.00, {"damage_dealt": 0.8, "defense": 0.8, "kills": 0.7,
+                        "obj_points": 0.4, "healing": 0.4, "assists": 0.3,
+                        "deaths": -0.3})], rules=[]),
+}
+BY_PID = {v["profile_id"]: k for k, v in PROFILES.items()}
+
+TUN = dict(beta=1.0, perf_scale=600.0, elo_divisor=120.0,
+           k_base=24.0, k_provisional=48.0, provisional_games=5,
+           elo_per_player_gap=110.0, gap_cap=3.0, seed_weight=0.6,
+           default_mmr=1000.0, min_seconds=180, min_match_share=0.50,
+           min_rated_players=10, z_clamp=3.0, min_baseline_games=20)
+
+SCHEMA = """
+DROP TABLE IF EXISTS ga_mmr_history;
+CREATE TABLE ga_mmr_history (
+  user_id     INTEGER NOT NULL,
+  class_name  TEXT    NOT NULL,
+  archetype   TEXT    NOT NULL DEFAULT '',
+  instance_id INTEGER NOT NULL,
+  played_at   INTEGER NOT NULL,
+  minutes     REAL    NOT NULL DEFAULT 0,
+  match_share REAL    NOT NULL DEFAULT 0,
+  perf        REAL    NOT NULL DEFAULT 0,
+  expected    REAL    NOT NULL DEFAULT 0,
+  actual      REAL    NOT NULL DEFAULT 0,
+  mmr_before  REAL    NOT NULL,
+  mmr_after   REAL    NOT NULL,
+  games_after INTEGER NOT NULL,
+  PRIMARY KEY (user_id, class_name, instance_id));
+CREATE INDEX IF NOT EXISTS idx_mmr_history_instance ON ga_mmr_history(instance_id);
+DELETE FROM ga_mmr_processed;
+"""
+
+
+def zscore(acc, v, clamp, min_games):
+    s, ss, n = acc
+    if n < min_games:
+        return None
+    mean = s / n
+    var = ss / n - mean * mean
+    if var < 0:
+        var = 0.0
+    sd = math.sqrt(var)
+    if sd == 0:
+        return None
+    return max(-clamp, min(clamp, (v - mean) / sd))
+
+
+def mean_z(base, names, rate):
+    vals = [z for z in (zscore(base[IX[k]], rate[IX[k]],
+                               TUN["z_clamp"], TUN["min_baseline_games"])
+                        for k in names) if z is not None]
+    return (sum(vals) / len(vals)) if vals else None
+
+
+def load(conn):
+    q = lambda s, *a: conn.execute(s, a).fetchall()
+    matches = []
+    for iid, started, wtf, _ct, mlen in q("""
+            SELECT i.id, i.started_at, COALESCE(i.winning_task_force,0),
+                   COALESCE(NULLIF(i.end_mission_at,0),NULLIF(i.sealed_at,0),i.started_at) ct,
+                   COALESCE((SELECT MAX(e.game_time) FROM ga_match_events e
+                             WHERE e.instance_id=i.id),0.0)
+            FROM ga_instances i
+            WHERE i.outcome IN ('ATTACKERS_WIN','DEFENDERS_WIN','STALEMATE')
+              AND EXISTS(SELECT 1 FROM map_game_info m
+                         WHERE m.map_name=i.map_name AND m.is_pvp=1)
+            ORDER BY ct ASC, i.id ASC"""):
+        matches.append(dict(id=iid, started=started, wtf=wtf, length=mlen, players=[]))
+    by_id = {m["id"]: m for m in matches}
+
+    team = {}
+    for iid, tf, d, t in q("""SELECT instance_id,task_force,SUM(deaths),
+                                     SUM(time_played_seconds)
+                              FROM ga_match_player_stats GROUP BY 1,2"""):
+        team[(iid, tf)] = (d or 0.0, t or 0.0)
+
+    cols = ",".join("s." + c for c in DB_COLS)
+    stints = defaultdict(list)
+    for row in q(f"""
+            SELECT s.instance_id, s.user_id, s.task_force, r.profile_id,
+                   s.time_played_seconds, {cols}
+            FROM ga_match_player_stats s
+            JOIN ga_instances i ON i.id=s.instance_id
+            JOIN (SELECT instance_id,character_id,MIN(profile_id) profile_id
+                  FROM ga_instance_players WHERE profile_id IN(680,567,681,679)
+                  GROUP BY instance_id,character_id) r
+              ON r.instance_id=s.instance_id AND r.character_id=s.character_id
+            WHERE i.outcome IN ('ATTACKERS_WIN','DEFENDERS_WIN','STALEMATE')
+              AND (s.kills+s.assists+s.deaths+s.damage_dealt+s.healing
+                   +s.obj_points+s.bot_kills) > 0
+              AND EXISTS(SELECT 1 FROM map_game_info m
+                         WHERE m.map_name=i.map_name AND m.is_pvp=1)"""):
+        iid, uid, tf, pid, t = row[0], row[1], row[2], row[3], row[4]
+        if iid not in by_id or pid not in BY_PID:
+            continue
+        raw = [0.0] * NSTAT
+        for k, c in enumerate(DB_COLS):
+            raw[IX[c]] = row[5 + k] or 0.0
+        stints[(iid, uid)].append(dict(cls=BY_PID[pid], pid=pid, tf=tf,
+                                       time=t or 0.0, raw=raw))
+
+    for (iid, uid), grp in stints.items():
+        grp.sort(key=lambda x: -x["time"])
+        fin = grp[0]
+        summed = [0.0] * NSTAT
+        ctime = 0.0
+        for s in grp:
+            if s["cls"] != fin["cls"]:
+                continue
+            ctime += s["time"]
+            for k in range(NSTAT):
+                summed[k] += s["raw"][k]
+        if ctime < TUN["min_seconds"]:
+            continue
+        m = by_id[iid]
+        share = min(1.0, ctime / m["length"]) if m["length"] > 0 else 1.0
+        if share < TUN["min_match_share"]:
+            continue
+        mins = ctime / 60.0
+        rate = [x / mins for x in summed]
+        rate[IX["rel_deaths"]] = 1.0
+        td, tt = team.get((iid, fin["tf"]), (0.0, 0.0))
+        others_min = (tt - ctime) / 60.0
+        others_deaths = td - summed[IX["deaths"]]
+        if others_min > 1.0 and others_deaths > 0.0:
+            rate[IX["rel_deaths"]] = rate[IX["deaths"]] / (others_deaths / others_min)
+        m["players"].append(dict(uid=uid, tf=fin["tf"], cls=fin["cls"],
+                                 pid=fin["pid"], ctime=ctime, share=share,
+                                 rate=rate, perf=0.0, arch=""))
+    return matches
+
+
+def team_size_gap(conn, iid):
+    evs = conn.execute("""SELECT event_type,game_time,COALESCE(actor_user_id,0),
+             COALESCE(actor_task_force,0),COALESCE(target_task_force,detail,0)
+             FROM ga_match_events WHERE instance_id=?
+               AND event_type IN('JOIN','LEAVE','TEAM_CHANGE')
+               AND game_time IS NOT NULL ORDER BY ts""", (iid,)).fetchall()
+    if len(evs) < 2:
+        return (0, 0.0)
+    i = 0
+    while i < len(evs) and evs[i][0] == "JOIN":
+        i += 1
+    settle = evs[i - 1 if i > 0 else 0][1]
+    j = len(evs) - 1
+    while j >= 0 and evs[j][0] == "LEAVE":
+        j -= 1
+    teardown = evs[j + 1][1] if j + 1 < len(evs) else evs[-1][1]
+    if teardown <= settle:
+        return (0, 0.0)
+    state, w1, w2, last = {}, 0.0, 0.0, settle
+
+    def ap(e):
+        t, _, a, atf, ttf = e
+        if t == "JOIN":
+            state[a] = atf
+        elif t == "LEAVE":
+            state.pop(a, None)
+        else:
+            state[a] = ttf
+
+    for e in evs:
+        if e[1] > settle:
+            break
+        ap(e)
+    for e in evs:
+        if e[1] <= settle:
+            continue
+        if e[1] > teardown:
+            break
+        dt = e[1] - last
+        for v in state.values():
+            if v == 1:
+                w1 += dt
+            elif v == 2:
+                w2 += dt
+        ap(e)
+        last = e[1]
+    dur = teardown - settle
+    if dur <= 0:
+        return (0, 0.0)
+    a1, a2 = w1 / dur, w2 / dur
+    return (1 if a1 > a2 else 2, abs(a1 - a2))
+
+
+def seed_rating(rating, games, uid):
+    vals = [v for k, v in rating.items()
+            if k[0] == uid and games.get(k, 0) >= TUN["provisional_games"]]
+    if not vals:
+        return TUN["default_mmr"]
+    return TUN["default_mmr"] + TUN["seed_weight"] * (
+        sum(vals) / len(vals) - TUN["default_mmr"])
+
+
+def run(path, apply_writes):
+    conn = sqlite3.connect(path)
+    matches = load(conn)
+    if apply_writes:
+        conn.executescript(SCHEMA)
+
+    baselines = defaultdict(lambda: [[0.0, 0.0, 0] for _ in range(NSTAT)])
+    arch = defaultdict(lambda: [dict(), dict()])   # per-stat z sum, count
+    rating, games = {}, defaultdict(int)
+    rows = []
+    rated = small = one_sided = gap_adj = 0
+
+    for m in matches:
+        if len(m["players"]) < TUN["min_rated_players"]:
+            small += 1
+            continue
+
+        for p in m["players"]:
+            d = PROFILES[p["cls"]]
+            base = baselines[p["cls"]]
+            key = (p["uid"], p["cls"])
+            sig = arch[key]
+
+            zs = {}
+            for si, sname in enumerate(STATS):
+                z = zscore(base[si], p["rate"][si],
+                           TUN["z_clamp"], TUN["min_baseline_games"])
+                if z is None:
+                    continue
+                zs[sname] = z
+                sig[0][sname] = sig[0].get(sname, 0.0) + z
+                sig[1][sname] = sig[1].get(sname, 0) + 1
+
+            def mean_of(name):
+                n = sig[1].get(name, 0)
+                return (sig[0][name] / n) if n else None
+
+            def group_of(names):
+                vals = [v for v in (mean_of(n) for n in names) if v is not None]
+                return (sum(vals) / len(vals)) if vals else None
+
+            prof = d["profiles"][0]
+            for rule in d["rules"]:
+                cand = next((x for x in d["profiles"] if x[0] == rule["profile"]), None)
+                if cand is None:
+                    continue
+                pos = 0.0 if not rule["pos"] else group_of(rule["pos"])
+                neg = 0.0 if not rule["neg"] else group_of(rule["neg"])
+                if pos is None or neg is None:
+                    continue
+                if pos - neg <= rule["threshold"]:
+                    continue
+                ok = True
+                for rname, rmin in rule["require"].items():
+                    m2 = mean_of(rname)
+                    if m2 is None or m2 < rmin:
+                        ok = False
+                        break
+                if not ok:
+                    continue
+                prof = cand
+                break
+
+            name, prem, w = prof
+            num = den = 0.0
+            for k, wt in w.items():
+                if k not in zs:
+                    continue
+                num += wt * zs[k]
+                den += abs(wt)
+            p["perf"] = prem * (num / den) if den else 0.0
+            p["arch"] = name
+
+        def advance():
+            for p in m["players"]:
+                b = baselines[p["cls"]]
+                for k in range(NSTAT):
+                    b[k][0] += p["rate"][k]
+                    b[k][1] += p["rate"][k] ** 2
+                    b[k][2] += 1
+
+        tfs = sorted({p["tf"] for p in m["players"]})
+        if len(tfs) != 2:
+            one_sided += 1
+            advance()
+            continue
+        ta, tb = tfs
+
+        big, gap = team_size_gap(conn, m["id"])
+        gap = min(gap, TUN["gap_cap"])
+        adjust = big in (ta, tb) and gap > 0.0
+        if adjust:
+            gap_adj += 1
+
+        agg = defaultdict(lambda: [0.0, 0])
+        for p in m["players"]:
+            k = (p["uid"], p["cls"])
+            if k not in rating:
+                rating[k] = seed_rating(rating, games, p["uid"])
+            agg[p["tf"]][0] += rating[k]
+            agg[p["tf"]][1] += 1
+        avg = {t: s / c for t, (s, c) in agg.items()}
+        adj = dict(avg)
+        if adjust:
+            small_tf = tb if big == ta else ta
+            half = gap * TUN["elo_per_player_gap"] / 2.0
+            adj[big] += half
+            adj[small_tf] -= half
+
+        new = {}
+        for p in m["players"]:
+            k = (p["uid"], p["cls"])
+            opp = tb if p["tf"] == ta else ta
+            before = rating[k]
+            # Who won is a TEAM fact: scored team vs team and shared by the
+            # side. Scoring an individual against the opposing team treats one
+            # player as deciding a 9-a-side match. Per-player feedback comes
+            # from the anchored perf term below.
+            expected = 1.0 / (1.0 + 10.0 ** ((adj[opp] - adj[p["tf"]]) / TUN["elo_divisor"]))
+            actual = 0.5 if m["wtf"] == 0 else (1.0 if p["tf"] == m["wtf"] else 0.0)
+            g = games[k]
+            K = TUN["k_provisional"] if g < TUN["provisional_games"] else TUN["k_base"]
+            # Both halves self-correcting: raw perf would be a constant push
+            # with nothing pulling back, and the rating would never settle.
+            expected_perf = (before - TUN["default_mmr"]) / TUN["perf_scale"]
+            after = before + K * ((actual - expected)
+                                  + TUN["beta"] * (p["perf"] - expected_perf))
+            new[k] = after
+            games[k] = g + 1
+            rows.append((p["uid"], p["cls"], p["arch"], m["id"], m["started"],
+                         p["ctime"] / 60.0, p["share"], p["perf"], expected,
+                         actual, before, after, g + 1))
+        rating.update(new)
+        rated += 1
+        advance()
+
+    if apply_writes:
+        conn.executemany(
+            "INSERT OR IGNORE INTO ga_mmr_history (user_id,class_name,archetype,"
+            "instance_id,played_at,minutes,match_share,perf,expected,actual,"
+            "mmr_before,mmr_after,games_after) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            rows)
+        conn.executemany(
+            "INSERT OR IGNORE INTO ga_mmr_processed (instance_id, played_at) VALUES (?,?)",
+            [(m["id"], m["started"]) for m in matches])
+        conn.commit()
+    conn.close()
+    print(f"folded {rated} match(es) ({small} too small, {one_sided} one-sided, "
+          f"{gap_adj} gap-adjusted); rows {len(rows)}")
+    return rating, games, rows
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("db")
+    ap.add_argument("--apply", action="store_true")
+    a = ap.parse_args()
+    run(a.db, a.apply)

--- a/tools/mmr/team_splits.py
+++ b/tools/mmr/team_splits.py
@@ -1,0 +1,119 @@
+"""How balanced were team sizes, for the majority of each match?
+
+Walks the JOIN / LEAVE / TEAM_CHANGE log and accumulates wall time against each
+(team1, team2) headcount configuration, so a match is classified by what was
+actually true for most of it rather than by who happened to be present at the
+start or the end.
+
+TEAM_CHANGE destination comes from `detail` -- target_task_force is NULL on
+every row, and reading it drops the mover from both counts for the rest of the
+match.
+"""
+import sqlite3, statistics as st
+from collections import defaultdict
+
+DB = "file:E:/server-redacted.db?mode=ro"
+MIN_TOTAL = 10
+
+
+def dominant_split(conn, iid):
+    """Returns (bigger, smaller, share_of_match, mean_total) or None."""
+    evs = conn.execute("""SELECT event_type,game_time,COALESCE(actor_user_id,0),
+            COALESCE(actor_task_force,0),COALESCE(target_task_force,detail,0)
+            FROM ga_match_events WHERE instance_id=?
+              AND event_type IN('JOIN','LEAVE','TEAM_CHANGE')
+              AND game_time IS NOT NULL ORDER BY ts""", (iid,)).fetchall()
+    if len(evs) < 2:
+        return None
+    # Settle past the join ramp and stop before the teardown, same window the
+    # rating engine uses for its headcount correction.
+    i = 0
+    while i < len(evs) and evs[i][0] == "JOIN":
+        i += 1
+    settle = evs[i - 1 if i > 0 else 0][1]
+    j = len(evs) - 1
+    while j >= 0 and evs[j][0] == "LEAVE":
+        j -= 1
+    teardown = evs[j + 1][1] if j + 1 < len(evs) else evs[-1][1]
+    if teardown <= settle:
+        return None
+
+    state, last = {}, settle
+    held = defaultdict(float)
+    weighted_total, total_time = 0.0, 0.0
+
+    def apply(e):
+        t, _, a, atf, ttf = e
+        if t == "JOIN":
+            state[a] = atf
+        elif t == "LEAVE":
+            state.pop(a, None)
+        else:
+            state[a] = ttf
+
+    for e in evs:
+        if e[1] > settle:
+            break
+        apply(e)
+    for e in evs:
+        if e[1] <= settle:
+            continue
+        if e[1] > teardown:
+            break
+        dt = e[1] - last
+        if dt > 0:
+            n1 = sum(1 for v in state.values() if v == 1)
+            n2 = sum(1 for v in state.values() if v == 2)
+            held[(max(n1, n2), min(n1, n2))] += dt
+            weighted_total += (n1 + n2) * dt
+            total_time += dt
+        apply(e)
+        last = e[1]
+    if total_time <= 0 or not held:
+        return None
+    (big, small), t = max(held.items(), key=lambda kv: kv[1])
+    return big, small, t / total_time, weighted_total / total_time
+
+
+if __name__ == "__main__":
+    conn = sqlite3.connect(DB, uri=True)
+    ids = [r[0] for r in conn.execute("""
+        SELECT i.id FROM ga_instances i
+        WHERE i.outcome IN ('ATTACKERS_WIN','DEFENDERS_WIN','STALEMATE')
+          AND EXISTS(SELECT 1 FROM map_game_info m
+                     WHERE m.map_name=i.map_name AND m.is_pvp=1)""")]
+    splits, shares, skipped = defaultdict(int), [], 0
+    for iid in ids:
+        d = dominant_split(conn, iid)
+        if d is None:
+            skipped += 1
+            continue
+        big, small, share, mean_total = d
+        if big + small < MIN_TOTAL:
+            continue
+        splits[(big, small)] += 1
+        shares.append(share)
+
+    total = sum(splits.values())
+    print(f"{total} matches with {MIN_TOTAL}+ players, classified by the split that held "
+          f"for the largest share of the match")
+    print(f"({skipped} of {len(ids)} had no usable event log)\n")
+
+    print(f"{'split':>8}{'matches':>9}{'share':>8}")
+    for (big, small), n in sorted(splits.items(), key=lambda kv: (-kv[1], kv[0])):
+        print(f"{f'{big}v{small}':>8}{n:>9}{n/total*100:>7.0f}%")
+
+    print(f"\n{'gap':>8}{'matches':>9}{'share':>8}")
+    bygap = defaultdict(int)
+    for (big, small), n in splits.items():
+        bygap[big - small] += n
+    cum = 0
+    for gap in sorted(bygap):
+        cum += bygap[gap]
+        label = "even" if gap == 0 else f"+{gap}"
+        print(f"{label:>8}{bygap[gap]:>9}{bygap[gap]/total*100:>7.0f}%"
+              f"   (cumulative {cum/total*100:.0f}%)")
+
+    print(f"\nthe dominant split held for a median {st.median(shares)*100:.0f}% of the match; "
+          f"{sum(1 for s in shares if s >= 0.5)/len(shares)*100:.0f}% of matches "
+          f"spent over half their time in one configuration")

--- a/tools/mmr/wl_divisor.py
+++ b/tools/mmr/wl_divisor.py
@@ -1,0 +1,159 @@
+"""Would changing the Elo divisor improve the CURRENT (live) wl engine?
+
+Faithful replay of the shipped win/loss engine -- K=32, its own participation
+rule (>=180s on the finishing class, no match-share or roster minimum), the
+220-per-player headcount correction with a 0.25 deadzone -- sweeping only the
+divisor. Prediction is scored out of sample: each match is predicted from
+ratings built solely from earlier matches.
+"""
+import sqlite3, math, statistics as st
+from collections import defaultdict
+
+DB = "file:E:/server-redacted.db?mode=ro"
+CLS = {680: "Assault", 567: "Medic", 681: "Recon", 679: "Robotic"}
+K, GAP_ELO, DEADZONE, GAP_CAP, DEFAULT = 32.0, 220.0, 0.25, 3.0, 1000.0
+
+
+def load(conn):
+    q = lambda s, *a: conn.execute(s, a).fetchall()
+    matches, by_id = [], {}
+    for iid, started, wtf in q("""
+            SELECT i.id, i.started_at, COALESCE(i.winning_task_force,0)
+            FROM ga_instances i
+            WHERE i.outcome IN ('ATTACKERS_WIN','DEFENDERS_WIN','STALEMATE')
+              AND EXISTS(SELECT 1 FROM map_game_info m
+                         WHERE m.map_name=i.map_name AND m.is_pvp=1)
+            ORDER BY COALESCE(NULLIF(i.end_mission_at,0),NULLIF(i.sealed_at,0),
+                              i.started_at) ASC, i.id ASC"""):
+        m = dict(id=iid, started=started, wtf=wtf, players=[])
+        matches.append(m); by_id[iid] = m
+    stints = defaultdict(list)
+    for iid, uid, tf, pid, t in q("""
+            SELECT s.instance_id,s.user_id,s.task_force,r.profile_id,
+                   s.time_played_seconds
+            FROM ga_match_player_stats s
+            JOIN ga_instances i ON i.id=s.instance_id
+            JOIN (SELECT instance_id,character_id,MIN(profile_id) profile_id
+                  FROM ga_instance_players WHERE profile_id IN(680,567,681,679)
+                  GROUP BY instance_id,character_id) r
+              ON r.instance_id=s.instance_id AND r.character_id=s.character_id
+            WHERE i.outcome IN ('ATTACKERS_WIN','DEFENDERS_WIN','STALEMATE')
+              AND (s.kills+s.assists+s.deaths+s.damage_dealt+s.healing
+                   +s.obj_points+s.bot_kills) > 0
+              AND EXISTS(SELECT 1 FROM map_game_info m
+                         WHERE m.map_name=i.map_name AND m.is_pvp=1)"""):
+        if iid not in by_id or pid not in CLS:
+            continue
+        stints[(iid, uid)].append((t or 0.0, CLS[pid], tf))
+    for (iid, uid), grp in stints.items():
+        grp.sort(key=lambda x: -x[0])
+        cls, tf = grp[0][1], grp[0][2]
+        total = sum(t for t, c, _ in grp if c == cls)
+        if total < 180:
+            continue
+        by_id[iid]["players"].append(dict(uid=uid, cls=cls, tf=tf))
+    return matches
+
+
+def team_gap(conn, iid):
+    evs = conn.execute("""SELECT event_type,game_time,COALESCE(actor_user_id,0),
+            COALESCE(actor_task_force,0),COALESCE(target_task_force,detail,0)
+            FROM ga_match_events WHERE instance_id=?
+              AND event_type IN('JOIN','LEAVE','TEAM_CHANGE')
+              AND game_time IS NOT NULL ORDER BY ts""", (iid,)).fetchall()
+    if len(evs) < 2:
+        return (0, 0.0)
+    i = 0
+    while i < len(evs) and evs[i][0] == "JOIN":
+        i += 1
+    settle = evs[i - 1 if i > 0 else 0][1]
+    j = len(evs) - 1
+    while j >= 0 and evs[j][0] == "LEAVE":
+        j -= 1
+    teardown = evs[j + 1][1] if j + 1 < len(evs) else evs[-1][1]
+    if teardown <= settle:
+        return (0, 0.0)
+    state, w1, w2, last = {}, 0.0, 0.0, settle
+
+    def ap(e):
+        t, _, a, atf, ttf = e
+        if t == "JOIN":   state[a] = atf
+        elif t == "LEAVE": state.pop(a, None)
+        else:              state[a] = ttf
+    for e in evs:
+        if e[1] > settle: break
+        ap(e)
+    for e in evs:
+        if e[1] <= settle: continue
+        if e[1] > teardown: break
+        dt = e[1] - last
+        for v in state.values():
+            if v == 1: w1 += dt
+            elif v == 2: w2 += dt
+        ap(e); last = e[1]
+    dur = teardown - settle
+    if dur <= 0:
+        return (0, 0.0)
+    a1, a2 = w1 / dur, w2 / dur
+    return (1 if a1 > a2 else 2, abs(a1 - a2))
+
+
+def run(matches, conn, divisor, warm=40, min_players=10):
+    rating, games = {}, defaultdict(int)
+    ll = n = acc = 0
+    preds = []
+    for i, m in enumerate(matches):
+        tfs = sorted({p["tf"] for p in m["players"]})
+        if len(tfs) != 2:
+            continue
+        ta, tb = tfs
+        agg = defaultdict(lambda: [0.0, 0])
+        for p in m["players"]:
+            k = (p["uid"], p["cls"])
+            rating.setdefault(k, DEFAULT)
+            agg[p["tf"]][0] += rating[k]; agg[p["tf"]][1] += 1
+        avg = {t: s / c for t, (s, c) in agg.items()}
+        big, gap = team_gap(conn, m["id"])
+        gap = min(gap, GAP_CAP)
+        adj = dict(avg)
+        if big in (ta, tb) and gap > DEADZONE:
+            sm = tb if big == ta else ta
+            half = gap * GAP_ELO / 2.0
+            adj[big] += half; adj[sm] -= half
+        # Scored only on matches the new engine would also count, so the two
+        # are compared on the same games.
+        if i >= warm and m["wtf"] != 0 and len(m["players"]) >= min_players:
+            pr = min(max(1.0 / (1.0 + 10.0 ** ((adj[tb] - adj[ta]) / divisor)), 1e-6), 1 - 1e-6)
+            y = 1.0 if m["wtf"] == ta else 0.0
+            ll += -(y * math.log(pr) + (1 - y) * math.log(1 - pr))
+            acc += (pr > .5) == (y == 1); n += 1
+            preds.append((pr, y))
+        new = {}
+        for p in m["players"]:
+            k = (p["uid"], p["cls"]); opp = tb if p["tf"] == ta else ta
+            b = rating[k]
+            e = 1.0 / (1.0 + 10.0 ** ((adj[opp] - b) / divisor))
+            a = 0.5 if m["wtf"] == 0 else (1.0 if p["tf"] == m["wtf"] else 0.0)
+            new[k] = b + K * (a - e); games[k] += 1
+        rating.update(new)
+    return rating, games, ll / n, acc / n, n, preds
+
+
+if __name__ == "__main__":
+    conn = sqlite3.connect(DB, uri=True)
+    matches = load(conn)
+    print(f"{sum(1 for m in matches if len(m['players'])>=10)} matches with >=10 rated players\n")
+    print(f"{'divisor':>8}{'logloss':>10}{'acc':>6}   spread(>=20g)      calibration by band")
+    for div in (400, 300, 250, 200, 150, 120, 100):
+        r, g, ll, acc, n, preds = run(matches, conn, div)
+        v = sorted(x for k, x in r.items() if g[k] >= 20)
+        pts = [(p, y) for p, y in preds] + [(1 - p, 1 - y) for p, y in preds]
+        bands = []
+        for lo, hi in ((.55, .65), (.65, .75), (.75, 1.01)):
+            sel = [(p, y) for p, y in pts if lo <= p < hi]
+            bands.append(f"{sum(p for p,_ in sel)/len(sel)*100:.0f}->{sum(y for _,y in sel)/len(sel)*100:.0f}"
+                         if len(sel) >= 8 else "--")
+        mark = "  <- live" if div == 400 else ""
+        print(f"{div:>8}{ll:>10.4f}{acc*100:>5.0f}%   {min(v):.0f}-{max(v):.0f} (sd {st.pstdev(v):.0f})"
+              f"   {'  '.join(bands)}{mark}")
+    print(f"\n(scored on {n} matches)")

--- a/tools/mmr/wl_project.py
+++ b/tools/mmr/wl_project.py
@@ -1,0 +1,119 @@
+"""Forward-project the win/loss engine 10 games, old divisor vs recalibrated.
+
+Pure win/loss -- no performance term. Each player is projected using their own
+empirical win rate and the average opposition they have actually faced, so the
+only thing changing between the two columns is the divisor.
+
+A pure Elo rating settles where its expectation matches its win rate, i.e. at
+  opponent + divisor * log10(wr / (1-wr))
+so a wider divisor spreads the same win rates over a wider band. That is the
+whole effect being measured here.
+"""
+import sqlite3, math, statistics as st, json
+from collections import defaultdict
+import wl_divisor as W
+
+conn = sqlite3.connect(W.DB, uri=True)
+matches = W.load(conn)
+col = next(x[1] for x in conn.execute("PRAGMA table_info(ga_users)")
+           if x[1] in ("username", "name", "display_name"))
+NM = {u: n for u, n in conn.execute(f"SELECT id,{col} FROM ga_users")}
+
+
+def fold(divisor):
+    """Replay the engine; also record each player's mean opposition."""
+    rating, games = {}, defaultdict(int)
+    wins = defaultdict(lambda: [0, 0])
+    opp = defaultdict(list)
+    for m in matches:
+        tfs = sorted({p["tf"] for p in m["players"]})
+        if len(tfs) != 2:
+            continue
+        ta, tb = tfs
+        agg = defaultdict(lambda: [0.0, 0])
+        for p in m["players"]:
+            k = (p["uid"], p["cls"])
+            rating.setdefault(k, W.DEFAULT)
+            agg[p["tf"]][0] += rating[k]
+            agg[p["tf"]][1] += 1
+        avg = {t: s / c for t, (s, c) in agg.items()}
+        big, gap = W.team_gap(conn, m["id"])
+        gap = min(gap, W.GAP_CAP)
+        adj = dict(avg)
+        if big in (ta, tb) and gap > W.DEADZONE:
+            sm = tb if big == ta else ta
+            half = gap * W.GAP_ELO / 2.0
+            adj[big] += half
+            adj[sm] -= half
+        new = {}
+        for p in m["players"]:
+            k = (p["uid"], p["cls"])
+            o = tb if p["tf"] == ta else ta
+            b = rating[k]
+            e = 1.0 / (1.0 + 10.0 ** ((adj[o] - b) / divisor))
+            a = 0.5 if m["wtf"] == 0 else (1.0 if p["tf"] == m["wtf"] else 0.0)
+            new[k] = b + W.K * (a - e)
+            games[k] += 1
+            wins[k][1] += 1
+            wins[k][0] += 1 if a == 1.0 else 0
+            opp[k].append(adj[o])
+        rating.update(new)
+    return rating, games, wins, opp
+
+
+def project(r, wr, oppr, divisor, n):
+    """n more matches at the same win rate against the same standard."""
+    for _ in range(n):
+        e = 1.0 / (1.0 + 10.0 ** ((oppr - r) / divisor))
+        r += W.K * (wr - e)
+    return r
+
+
+def equilibrium(wr, oppr, divisor):
+    """Where a pure Elo rating comes to rest."""
+    wr = min(max(wr, 0.001), 0.999)
+    return oppr + divisor * math.log10(wr / (1.0 - wr))
+
+
+if __name__ == "__main__":
+    OLD, NEW, AHEAD = 400.0, 900.0, 10
+    r_old, g, wins, opp_old = fold(OLD)
+    r_new, _, _, opp_new = fold(NEW)
+
+    MIN = {"Assault": 20, "Recon": 20, "Medic": 20, "Robotic": 10}
+    out = {}
+    for cls in ("Assault", "Recon", "Medic", "Robotic"):
+        rows = []
+        for k in r_old:
+            if k[1] != cls or g[k] < MIN[cls]:
+                continue
+            wr = wins[k][0] / wins[k][1]
+            oo, on = st.mean(opp_old[k]), st.mean(opp_new[k])
+            rows.append(dict(
+                name=(NM.get(k[0]) or f"u{k[0]}")[:17], games=g[k], win=round(wr * 100),
+                old=round(r_old[k]), old10=round(project(r_old[k], wr, oo, OLD, AHEAD)),
+                old_eq=round(equilibrium(wr, oo, OLD)),
+                new=round(r_new[k]), new10=round(project(r_new[k], wr, on, NEW, AHEAD)),
+                new_eq=round(equilibrium(wr, on, NEW))))
+        rows.sort(key=lambda x: -x["new"])
+        out[cls] = rows
+    json.dump(out, open("wl_project.json", "w"))
+
+    allr = [r for v in out.values() for r in v]
+    for lab, a, b in (("now", "old", "new"), ("+10 games", "old10", "new10"),
+                      ("at rest", "old_eq", "new_eq")):
+        va = [r[a] for r in allr]
+        vb = [r[b] for r in allr]
+        print(f"{lab:<12} divisor 400: {min(va):>5}-{max(va):<5} sd {st.pstdev(va):>3.0f}"
+              f"    divisor 900: {min(vb):>5}-{max(vb):<5} sd {st.pstdev(vb):>3.0f}")
+    print()
+    for cls in ("Assault", "Recon", "Medic", "Robotic"):
+        print(f"--- {cls} ---")
+        print(f"{'player':<18}{'g':>4}{'win':>5}   "
+              f"{'DIV 400: now':>13}{'+10':>7}{'rest':>7}   "
+              f"{'DIV 900: now':>13}{'+10':>7}{'rest':>7}")
+        for r in out[cls]:
+            print(f"{r['name']:<18}{r['games']:>4}{r['win']:>4}%   "
+                  f"{r['old']:>13}{r['old10']:>7}{r['old_eq']:>7}   "
+                  f"{r['new']:>13}{r['new10']:>7}{r['new_eq']:>7}")
+        print()


### PR DESCRIPTION
## What this is

A performance-based per-class MMR engine, to replace the win/loss one for team
balancing. Plus the offline analysis the constants came from, and a plan for
folding in the device-usage metrics landing separately.

## Nothing in here changes live behaviour yet

This is the most important thing to know before reading it.

The server has always folded **two** rating engines on every concluded match —
`wl` (win/loss) and `perf` — and `cs_settings.active_mmr_engine` decides which
one anything actually reads. It is set to `wl` and this PR does not change it.
The perf engine has been writing `ga_mmr_history` silently all along; this PR
rewrites what it writes.

So: merge this and the server behaves identically. Flipping the switch is a
separate, reversible, one-row decision.

## Why replace win/loss rather than retune it

Win/loss ratings are compressed to the point of being useless for balancing:

```
class      wl spread          perf spread
Assault    867–1165  (298)    740–1349  (609)
Medic      885–1145  (260)    866–1467  (601)
Recon      912–1107  (195)    637–1347  (710)
Robotic    923–1105  (182)    752–1244  (492)
```

The cause is not the Elo divisor. One player is a ninth of a team, so win/loss
has ~0.64 split-half reliability. `tools/mmr/closed_pool.py` shuffles which side
won while keeping every real roster and result, and finds an observed win-rate
spread of 8.7pp against 6.5pp from chance — **only ~45% of the variance is
skill**. A divisor cannot create information, which is why retuning was
abandoned. `tools/mmr/wl_divisor.py` has that sweep if you want to see it fail.

## What changed in the engine

1. **Per-class z-scored performance index.** A medic is measured against medics.
   Baselines accumulate in match-conclusion order and never read ahead.

2. **Archetypes.** Assault roamer/tank, Medic healer/poison/buff, each with a
   premium. Assignment is per player, not per match — scoring someone on
   whichever profile flattered a given game inflates the whole population.

3. **An anchored performance term.** The old perf math had no resting point:
   `beta*perf` was a constant upward push, so anyone above ~44% win rate drifted
   without limit (a +0.56 performance player passed 5000 by their thousandth
   game). You now only gain by beating your own rating.

4. **Team-vs-team expected score.** The old code compared an individual against
   a team, which is how a 60%-win-rate player could still lose rating.

Also: divisor 400 → 120 (calibrated on 128 out-of-sample matches — teams the old
value called 62% favourites won 86% of the time), a 110-Elo headcount
correction, and a `min_rated_players = 10` gate so near-empty midweek lobbies
neither move ratings nor pollute the class baselines.

Every tunable is in `ClassProfiles.hpp` and overridable from
`control-server.json`, so weights can be adjusted between play sessions without
a rebuild.

## Known gaps — please don't assume these were missed

- **This has never been compiled.** Static review only. That's the main risk in
  the PR and the first thing to fix.
- **`ga_mmr_history` is rebuilt** behind migration marker
  `perf_mmr_rebuild_2026_08_03` — the table gains `archetype`, `perf`,
  `expected`, `actual`, `games_after`. Existing rows are discarded and replayed.
- **The balancer still has no MMR objective.** `RoleWeightedSplit::ComputeRebalanceDelta`
  only moves players when a class *count* is off target; MMR just picks which of
  an already-forced set of movers goes. A skill-lopsided 9v9 with matching class
  counts produces zero moves regardless of which engine feeds it. Out of scope
  here, but it is what decides whether any of this shows up in game.
- Everything rests on **158 rated matches**. The direction of each finding held
  across every cut; the exact constants did not.
- The rating measures what is in `ga_match_player_stats`. Shot-calling,
  positioning, keeping the right player alive — none of it appears, and no
  reweighting of the existing columns will find it. That is what the device-stats
  plan is for.

## How to review

`tools/mmr/reseed.py` is a deliberate line-for-line port of `MmrService.cpp`,
not a tidier rewrite. It is the **acceptance test**: reseed with the compiled
engine and with this, and the two should agree row for row. If they disagree,
one of them has a bug and the Python tells you what the answer should have been.

`tools/mmr/README.md` maps each script to the question it answers and which
constant came out of it.

Two of the three most consequential bugs fixed here were found by someone asking
a plain question about a specific player, not by any test in the harness — so
that kind of review is genuinely the most valuable thing you can do with it.

## Commits

- `f5031f52` performance-based per-class rating engine
- `d24c8173` make ratings settle, and stop treating one player as a team
- `5367191a` the offline analysis behind the engine's constants
- `30f0a5ab` how device usage folds into the perf engine (plan only, no code)
