### PR TITLE
support for the -cheat command (dev tool, default disabled)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,7 @@ SOURCE_FILES= \
 			  $(SRC_DIR)/GameServer/TgGame/TgPlayerActions/SetSpawnTable/SetSpawnTable.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/TgPlayerActions/SetItemCount/SetItemCount.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/TgPlayerActions/ToggleBrokenSuits/ToggleBrokenSuits.cpp \
+			  $(SRC_DIR)/GameServer/TgGame/TgPlayerActions/ToggleCheatMode/ToggleCheatMode.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/TgPlayerActions/Markers/Markers.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/TgPlayerActions/FxBrowse/FxBrowse.cpp \
 			  $(SRC_DIR)/GameServer/TgGame/TgPawn/SwapAttachedDeviceMaterials/TgPawn__SwapAttachedDeviceMaterials.cpp \

--- a/src/ControlServer/ChatSession/ChatCommand.cpp
+++ b/src/ControlServer/ChatSession/ChatCommand.cpp
@@ -347,6 +347,30 @@ ParseResult TryParseChatCommand(const std::string& message_text) {
         return out;
     }
 
+#if 0
+    // skal add support for -cheat
+    if (cmd_name == "-cheat") {
+        // -cheat zeus
+        // -cheat icarus
+        // -cheat hades
+        // -cheat apollo
+        // -cheat athena
+        out.recognized = true;
+        out.suppress_broadcast = true;
+        CheatArgs args;
+        if (!rest.empty()) {
+            if (rest == "zeus")         args.cheat_mode = CheatMode::Zeus;
+            else if (rest == "icarus")  args.cheat_mode = CheatMode::Icarus;
+            else if (rest == "hades")   args.cheat_mode = CheatMode::Hades;
+            else if (rest == "apollo")  args.cheat_mode = CheatMode::Apollo;
+            else if (rest == "athena")  args.cheat_mode = CheatMode::Athena;
+            else return out;  // bad arg — silent reject
+        }
+        out.cheat = args;
+        return out;
+    }
+#endif
+
     if (cmd_name == "-enabledlc" || cmd_name == "-disabledlc") {
         // -enabledlc <identifier>  -> mark the pack installed for this account
         // -disabledlc <identifier> -> mark it not installed
@@ -886,6 +910,24 @@ void DispatchTopDown(const TopDownArgs& args, const std::string& session_guid) {
         Logger::Log("chat-command",
             "[ChatCmd] guid=%s command=-topdown lift_z=%.0f outcome=ignored details=dispatch_failed\n",
             session_guid.c_str(), args.lift_z);
+    }
+}
+
+void DispatchToggleCheatMode(const CheatArgs& args, const std::string& session_guid) {
+    if (session_guid.empty()) {
+        Logger::Log("chat-command", "[ChatCmd] DispatchToggleCheatMode dropped: empty session_guid\n");
+        return;
+    }
+    nlohmann::json payload;
+    payload["type"]         = IpcProtocol::MSG_PLAYER_ACTION;
+    payload["session_guid"] = session_guid;
+    payload["action"]       = "cheat";
+    payload["args"]         = { {"mode", args.cheat_mode} };
+    const bool sent = TcpSession::DeliverPlayerAction(session_guid, payload);
+    if (!sent) {
+        Logger::Log("chat-command",
+            "[ChatCmd] guid=%s command=-cheat mode=%d outcome=ignored details=dispatch_failed\n",
+            session_guid.c_str(), args.cheat_mode);
     }
 }
 

--- a/src/ControlServer/ChatSession/ChatCommand.hpp
+++ b/src/ControlServer/ChatSession/ChatCommand.hpp
@@ -148,6 +148,26 @@ struct SetSpawnTableArgs {
     int spawn_table_id = 0;
 };
 
+// -cheat <mode> DEV TOOL
+// toggle the matching HiRez cheat mode
+// Zeus = god
+// Icarus = fly/noclip
+// Hades = no CD
+// Apollo = no energy cost (no morale cost also ?)
+// Athena = invisible to mobs
+enum class CheatMode {
+    None,
+    Zeus,
+    Icarus,
+    Hades,
+    Apollo,
+    Athena
+};
+
+struct CheatArgs {
+    CheatMode cheat_mode;
+};
+
 // Master switch for -components (the inventory-desync test harness).
 //
 // FALSE in normal operation, and it must stay that way: `grant` mints component
@@ -184,6 +204,7 @@ struct ParseResult {
     std::optional<MarkersArgs>      markers;
     std::optional<FxBrowseArgs>     fx_browse;
     std::optional<SetSpawnTableArgs> set_spawn_table;
+    std::optional<CheatArgs>         cheat;
 
     // No-arg toggles. Flag is set when recognized + parsed cleanly.
     bool possess   = false;
@@ -329,5 +350,9 @@ void ExecuteToggleSoloMode(const ToggleSoloModeArgs& args,
 // catalog. DLC-gated queues appear/disappear on the next GET_TICKET_INFO
 // poll. Handled entirely on the control server; no PLAYER_ACTION IPC.
 void ExecuteSetDlc(const SetDlcArgs& args, const std::string& session_guid);
+
+// -cheat: toggle hirez cheat modes (zeus,icarus,hades,apollo,athena)
+void DispatchToggleCheatMode(const CheatArgs& args,
+                               const std::string& session_guid);
 
 } // namespace ChatCommand

--- a/src/ControlServer/ChatSession/ChatSession.cpp
+++ b/src/ControlServer/ChatSession/ChatSession.cpp
@@ -636,6 +636,12 @@ void ChatSession::handle_packet(const uint8_t* data, size_t length) {
                 player_name_.c_str(), session_guid_.c_str());
             MatchmakingService::ReloadQueues();
         }
+        if (parsed.recognized && parsed.cheat) {
+            Logger::Log("chat-command",
+                "[ChatCmd] -cheat player='%s' mode='%d'\n",
+                player_name_.c_str(), *parsed.cheat);
+            ChatCommand::DispatchToggleCheatMode (*parsed.cheat, session_guid_);
+        }
         if (parsed.suppress_broadcast) {
             // Recognized command (valid or invalid arg) — do not broadcast.
             return;

--- a/src/GameServer/GameModes/SuperAgent/SuperAgent.cpp
+++ b/src/GameServer/GameModes/SuperAgent/SuperAgent.cpp
@@ -24,6 +24,8 @@
 
 #include "src/GameServer/Engine/Actor/SetTimer/Actor__SetTimer.hpp"
 
+#include "src/GameServer/TgGame/TgAIController/RadioAlarm/TgAIController__RadioAlarm.hpp"
+
 #include <algorithm>
 #include <cmath>
 #include <cstdarg>
@@ -1869,6 +1871,9 @@ void Init(ATgGame* Game) {
 
 	UClass* cls = ClassPreloader::GetClass("Class TgGame.TgMissionObjective_Proximity");
 	if (!cls) { Log("Init: could not resolve TgMissionObjective_Proximity class\n"); return; }
+
+	//skal enable/set global alarm CD
+	TgAIController__RadioAlarm::fGlobalAlarmCD=40.0f;	// 40s
 
 	// Reset runtime state and (re-)author the mission for this match.
 	s_Game = Game;

--- a/src/GameServer/TgGame/TgAIController/RadioAlarm/TgAIController__RadioAlarm.cpp
+++ b/src/GameServer/TgGame/TgAIController/RadioAlarm/TgAIController__RadioAlarm.cpp
@@ -32,7 +32,9 @@
 
 // Server-side per-alarm-id cooldown: the data-driven test-629 gate is per
 // CONTROLLER, so multiple bots sharing an alarm id each fire it → add spam.
-static const float kAlarmCooldownSecs = 40.0f;
+// skal remove the previous 'constant' and make it a global variable accessible to the world
+//static const float kAlarmCooldownSecs = 40.0f;
+static float TgAIController__RadioAlarm::fGlobalAlarmCD=0.0f;
 static std::map<int, float> s_lastAlarmFireTime;  // alarmId -> WorldInfo.TimeSeconds
 
 // Known alarm_bot_spawn_table_id values on type-620 actions (validation set).
@@ -72,22 +74,35 @@ void __fastcall TgAIController__RadioAlarm::Call(ATgAIController* AIC, void* edx
 		}
 	}
 
-	const float now = AIC->WorldInfo ? AIC->WorldInfo->TimeSeconds : 0.0f;
-	auto it = s_lastAlarmFireTime.find(alarmId);
-	// `now >= it->second` defends against map travel resetting TimeSeconds.
-	if (it != s_lastAlarmFireTime.end() && now >= it->second
-			&& now - it->second < kAlarmCooldownSecs) {
-		Logger::Log("alarm",
-			"[%s] RadioAlarm SUPPRESSED (cooldown %.1fs/%.0fs): caller=%s alarmId=%d\n",
-			Logger::GetTime(), now - it->second, kAlarmCooldownSecs,
-			AIC->Pawn->GetName(), alarmId);
-		return;
+	const auto Origin=AIC->Pawn->GetName();
+	auto isScanner=[&]() -> bool {
+		return (std::strcmp (Origin,"TgPawn_Scanner")==0)
+				|| (std::strcmp (Origin,"TgPawn_ScannerRecursive")==0);
+	};
+
+	if ((fGlobalAlarmCD > 0.0f) && isScanner ()) {
+		if (!AIC->WorldInfo) {
+			Logger::Log("alarm","got an alarm but AIC->WorldInfo is null, investigate");
+		}
+		else {
+			const float now = AIC->WorldInfo->TimeSeconds;
+			const auto it = s_lastAlarmFireTime.find(alarmId);
+			// `now >= it->second` defends against map travel resetting TimeSeconds.
+			if ((it != s_lastAlarmFireTime.end()) && (now >= it->second)
+					&& ((now - it->second) < fGlobalAlarmCD)) {
+				Logger::Log("alarm",
+					"[%s] RadioAlarm SUPPRESSED (cooldown %.1fs/%.0fs): caller=%s alarmId=%d (globalAlarmId=%d)\n",
+					Logger::GetTime(), now - it->second, fGlobalAlarmCD,
+					Origin, alarmId, AIC->m_nGlobalAlarmId);
+				return;
+			}
+			s_lastAlarmFireTime[alarmId] = now;
+		}
 	}
-	s_lastAlarmFireTime[alarmId] = now;
 
 	Logger::Log("alarm",
 		"[%s] RadioAlarm: caller=%s alarmId=%d (globalAlarmId=%d)\n",
-		Logger::GetTime(), AIC->Pawn->GetName(), alarmId, AIC->m_nGlobalAlarmId);
+		Logger::GetTime(), Origin, alarmId, AIC->m_nGlobalAlarmId);
 
 	TgGame__ActivateAlarm::Call(Game, nullptr,
 		(AActor*)AIC->Pawn, alarmId,

--- a/src/GameServer/TgGame/TgAIController/RadioAlarm/TgAIController__RadioAlarm.hpp
+++ b/src/GameServer/TgGame/TgAIController/RadioAlarm/TgAIController__RadioAlarm.hpp
@@ -9,4 +9,7 @@ class TgAIController__RadioAlarm : public HookBase<
 	TgAIController__RadioAlarm> {
 public:
 	static void __fastcall Call(ATgAIController* AIC, void* edx);
+
+	//skal global alarm CD
+	static float fGlobalAlarmCD;
 };

--- a/src/GameServer/TgGame/TgGame/SpawnPlayerCharacter/TgGame__SpawnPlayerCharacter.cpp
+++ b/src/GameServer/TgGame/TgGame/SpawnPlayerCharacter/TgGame__SpawnPlayerCharacter.cpp
@@ -1018,10 +1018,7 @@ ATgPawn_Character* __fastcall TgGame__SpawnPlayerCharacter::Call(ATgGame* Game, 
 	LogAssemblySnapshot("[EXIT Orig]", newpawn, newpawn->s_OrigCustomCharacterAssembly);
 	{
 		ATgRepInfo_Player* pri = (ATgRepInfo_Player*)newpawn->PlayerReplicationInfo;
-		if (pri) {
-			pri->bAdmin=1;
-		 LogAssemblySnapshot("[EXIT PRI ]", pri, pri->r_CustomCharacterAssembly);
-		}
+		if (pri) LogAssemblySnapshot("[EXIT PRI ]", pri, pri->r_CustomCharacterAssembly);
 	}
 	LogCallEnd();
 

--- a/src/GameServer/TgGame/TgGame/SpawnPlayerCharacter/TgGame__SpawnPlayerCharacter.cpp
+++ b/src/GameServer/TgGame/TgGame/SpawnPlayerCharacter/TgGame__SpawnPlayerCharacter.cpp
@@ -1004,14 +1004,24 @@ ATgPawn_Character* __fastcall TgGame__SpawnPlayerCharacter::Call(ATgGame* Game, 
 	// before the engine's RestartPlayer fallback so we control the ordering.
 	PlayerController->eventPossess(PlayerController->Pawn, 0, 0);
 
-	// PlayerController->bGodMode = 1;
+	 // PlayerController->bGodMode = 1;
+
+	 // skal HiRez cheat modes
+	 //PlayerController->Zeus ();		//godmode
+	 //PlayerController->Icarus ();	//fly+noclip
+	 //PlayerController->Apollo (); //unlimited energy
+	 //PlayerController->Hades ();  //no cooldown
+	 //PlayerController->Athena (); //invisible to AI
 
 	Logger::Log("spawn-asm", "=== SpawnPlayerCharacter EXIT final snapshots ===\n");
 	LogAssemblySnapshot("[EXIT pawn]", newpawn, newpawn->r_CustomCharacterAssembly);
 	LogAssemblySnapshot("[EXIT Orig]", newpawn, newpawn->s_OrigCustomCharacterAssembly);
 	{
 		ATgRepInfo_Player* pri = (ATgRepInfo_Player*)newpawn->PlayerReplicationInfo;
-		if (pri) LogAssemblySnapshot("[EXIT PRI ]", pri, pri->r_CustomCharacterAssembly);
+		if (pri) {
+			pri->bAdmin=1;
+		 LogAssemblySnapshot("[EXIT PRI ]", pri, pri->r_CustomCharacterAssembly);
+		}
 	}
 	LogCallEnd();
 

--- a/src/GameServer/TgGame/TgPlayerActions/ToggleCheatMode/ToggleCheatMode.cpp
+++ b/src/GameServer/TgGame/TgPlayerActions/ToggleCheatMode/ToggleCheatMode.cpp
@@ -1,0 +1,71 @@
+#include "src/GameServer/TgGame/TgPlayerActions/ToggleCheatMode/ToggleCheatMode.hpp"
+
+#include "src/GameServer/Storage/ClientConnectionsData/ClientConnectionsData.hpp"
+#include "src/IpcClient/IpcClient.hpp"
+#include "src/Utils/Logger/Logger.hpp"
+
+namespace TgPlayerActions::ToggleCheatCmd {
+
+namespace {
+
+// Walk GClientConnectionsData looking for a matching SessionGuid.
+// Returns the connected pawn or nullptr.
+ATgPawn_Character* FindPawnBySessionGuid(const std::string& guid) {
+    for (auto& kv : GClientConnectionsData) {
+        if (kv.second.SessionGuid == guid) {
+            return kv.second.Pawn;
+        }
+    }
+    return nullptr;
+}
+
+bool IsPlayerController(AController* c) {
+    if (!c || !c->Class) return false;
+    const char* full = c->Class->GetFullName();
+    return full && std::strstr(full, "PlayerController");
+}
+
+void Audit(const std::string& guid,
+           const std::string& outcome, const std::string& details) {
+    IpcClient::SendChatCommandAudit(guid, "-changeteam", outcome, details);
+}
+
+}   // namespace
+
+void Execute(const std::string& session_guid, int cheat_mode) {
+    ATgPawn_Character* pawn = FindPawnBySessionGuid(session_guid);
+    if (!pawn) {
+        Logger::Log("chat-command",
+            "[ChatCmd][ToggleCheatMode] guid=%s: no pawn found\n", session_guid.c_str());
+        Audit(session_guid, "ignored", "no player pawn");
+        return;
+    }
+    if (!IsPlayerController(pawn->Controller)) {
+        Logger::Log("chat-command",
+            "[ChatCmd][ToggleCheatMode] guid=%s: session controller isn't a PlayerController\n",
+            session_guid.c_str());
+        Audit(session_guid, "ignored", "session controller is not PlayerController");
+        return;
+    }
+    ATgPlayerController* PlayerController=reinterpret_cast<ATgPlayerController*> (pawn->Controller);
+    switch (cheat_mode) {
+        case 1: PlayerController->Zeus ();   break;
+        case 2: PlayerController->Icarus (); break;
+        case 3: PlayerController->Hades ();  break;
+        case 4: PlayerController->Apollo (); break;
+        case 5: PlayerController->Athena (); break;
+        default:
+            Logger::Log("chat-command",
+                "[ChatCmd][ToggleCheatMode] guid=%s: invalid parameter '%d'\n",
+                session_guid.c_str(),cheat_mode);
+            Audit(session_guid, "ignored", "invalid parameter");
+            return;
+    }
+
+    Logger::Log("chat-command",
+        "[ChatCmd][ToggleCheatMode] guid=%s: applied (mode=%d)\n",
+        session_guid.c_str(), cheat_mode);
+    Audit(session_guid, "activated","cheat "+std::to_string (cheat_mode));
+}
+
+} // namespace TgPlayerActions::ToggleCheatCmd

--- a/src/GameServer/TgGame/TgPlayerActions/ToggleCheatMode/ToggleCheatMode.hpp
+++ b/src/GameServer/TgGame/TgPlayerActions/ToggleCheatMode/ToggleCheatMode.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <string>
+
+namespace TgPlayerActions::ToggleCheatCmd {
+
+// Toggle one of the cheat mode for the player owning session_guid.
+//
+void Execute(const std::string& session_guid, int cheat_mode);
+
+} // namespace TgPlayerActions::ToggleCheatCmd

--- a/src/IpcClient/IpcClient.cpp
+++ b/src/IpcClient/IpcClient.cpp
@@ -14,6 +14,7 @@
 #include "src/GameServer/TgGame/TgPlayerActions/Coords/Coords.hpp"
 #include "src/GameServer/TgGame/TgPlayerActions/FullHeal/FullHeal.hpp"
 #include "src/GameServer/TgGame/TgPlayerActions/ToggleBrokenSuits/ToggleBrokenSuits.hpp"
+#include "src/GameServer/TgGame/TgPlayerActions/ToggleCheatMode/ToggleCheatMode.hpp"
 #include "src/GameServer/TgGame/TgPlayerActions/Markers/Markers.hpp"
 #include "src/GameServer/TgGame/TgPlayerActions/FxBrowse/FxBrowse.hpp"
 #include "src/GameServer/TgGame/TgPlayerActions/SetSpawnTable/SetSpawnTable.hpp"
@@ -823,6 +824,12 @@ void IpcClient::DrainInbound() {
                     "[IPC] refresh_profile_ui guid=%s phase=%s itemProf=%d token=%llu refreshed=%d\n",
                     guid.c_str(), phase.c_str(), item_profile_id,
                     (unsigned long long)refresh_token, refreshed);
+            } else if (action == "cheat") {
+                int cheat_mode=0;
+                if (j.contains("args") && j["args"].is_object()) {
+                    cheat_mode = j["args"].value("mode", 0);
+                }
+                TgPlayerActions::ToggleCheatCmd::Execute(guid,cheat_mode);
             } else {
                 Logger::Log("chat-command",
                     "[ChatCmd][DLL] PLAYER_ACTION guid=%s: unknown action '%s'; dropping\n",


### PR DESCRIPTION
  allows one to use HiRez built-in cheat modes (Zeus, Icarus, Hades, Apollo, Athena)

tweak alarms (scanners & boss ads waves)
  the previous hard-coded 40s CD on alarms is now a global variable that can be altered per mission mode or any other situation
  default is no CD (==0) which is the normal behavior (triggering two scanners spawns 2 responders waves)
  super-agent specifically initializes this to 40s to go back to the way it was balanced upon creation (multiple scanner triggers within 40s only spawn one responder wave)
  the CD applies _only_ to scanner alarms, boss ads wave are exempt