### PR TITLE
Add per-connection black-screen lifecycle diagnostics

### DIFF
--- a/src/GameServer/Core/UObject/ProcessEvent/UObject__ProcessEvent.cpp
+++ b/src/GameServer/Core/UObject/ProcessEvent/UObject__ProcessEvent.cpp
@@ -15,10 +15,12 @@
 #include "src/GameServer/Storage/ClientConnectionsData/ClientConnectionsData.hpp"
 #include "src/GameServer/Storage/ActiveSpectatorCount/ActiveSpectatorCount.hpp"
 #include "src/GameServer/Storage/TeamsData/TeamsData.hpp"
+#include "src/GameServer/Diagnostics/BlackScreenDiagnostics.hpp"
 #include "src/GameServer/GameModes/SuperAgent/SuperAgent.hpp"
 #include "src/Config/Config.hpp"
 #include "src/GameServer/Globals.hpp"
 #include "src/Utils/Logger/Logger.hpp"
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <cstdlib>  // wcstombs (kismet LinkDesc → char buffer)
@@ -706,6 +708,35 @@ static DispatchTag GetDispatchTag(UFunction* fn) {
 	return tag;
 }
 
+// A separate cached classifier keeps lifecycle observation independent from
+// the existing dispatch tag and therefore preserves the original call path.
+static std::unordered_map<UFunction*, bool> s_BlackScreenLifecycleCache;
+
+static bool IsBlackScreenLifecycleFunction(UFunction* fn) {
+	auto it = s_BlackScreenLifecycleCache.find(fn);
+	if (it != s_BlackScreenLifecycleCache.end()) return it->second;
+
+	const char* raw = fn->GetFullName();
+	const std::string name = raw ? raw : "";
+	const bool match =
+		name == "Function TgGame.TgGame.RestartPlayer" ||
+		name == "Function Engine.PlayerController.ClientRestart" ||
+		name == "Function TgGame.TgPlayerController.IsReadyForStart" ||
+		name == "Function TgGame.TgPlayerController.ServerSetReadyToPlay" ||
+		name == "Function TgGame.TgPlayerController.SetReadyToPlay" ||
+		name == "Function TgGame.TgPlayerController.ClientSetReadyState" ||
+		name == "Function TgGame.TgPlayerController.ClientEnterStartState" ||
+		name == "Function TgGame.TgPlayerController.EnterStartState";
+	s_BlackScreenLifecycleCache.emplace(fn, match);
+	return match;
+}
+
+struct BlackScreenLifecycleContext {
+	std::string functionName;
+	ATgPlayerController* player = nullptr;
+	BlackScreenDiagnostics::EventDetails details;
+};
+
 // "scope" channel investigation — smooth scope-zoom transition broke into an
 // instant snap somewhere around 2026-05-29/30. The smooth-zoom path is
 // entirely client-side (Pawn.Tick → ManageZoomingClientSide → ClientZoomIn →
@@ -806,6 +837,35 @@ void __fastcall UObject__ProcessEvent::Call(UObject* Object, void* edx, UFunctio
 	// branch. See the IsScopeRelated comment block for context.
 	const bool scopeLog = Logger::IsChannelEnabled("scope") && IsScopeRelated(Function);
 	if (scopeLog) LogScopeCall("BEFORE", Object, Function);
+
+	std::optional<BlackScreenLifecycleContext> blackScreenLifecycle;
+	if (BlackScreenDiagnostics::IsEnabled() && IsBlackScreenLifecycleFunction(Function)) {
+		blackScreenLifecycle.emplace();
+		BlackScreenLifecycleContext& context = *blackScreenLifecycle;
+		const char* functionName = Function->GetFullName();
+		context.functionName = functionName ? functionName : "";
+		if (context.functionName == "Function TgGame.TgGame.RestartPlayer") {
+			AController* controller = Params ? *(AController**)Params : nullptr;
+			if (controller && ObjectClassCache::ClassNameContains(controller, "TgPlayerController")) {
+				context.player = (ATgPlayerController*)controller;
+			}
+		} else if (ObjectClassCache::ClassNameContains(Object, "TgPlayerController")) {
+			context.player = (ATgPlayerController*)Object;
+		}
+
+		if (context.player) {
+			if (Params && context.functionName == "Function Engine.PlayerController.ClientRestart") {
+				context.details.relatedActor = *(APawn**)Params;
+			}
+			if (Params && context.functionName == "Function TgGame.TgPlayerController.ClientSetReadyState") {
+				context.details.eventValue = (int)(*(uint32_t*)Params & 1);
+			}
+			BlackScreenDiagnostics::Log("before", context.functionName.c_str(),
+				nullptr, context.player, context.details);
+		} else {
+			blackScreenLifecycle.reset();
+		}
+	}
 
 	// Per-fire-tick refresh for hold-to-sustain stealth. Independent of the
 	// main dispatch — fires alongside whatever the catch-all does for this
@@ -1062,6 +1122,19 @@ void __fastcall UObject__ProcessEvent::Call(UObject* Object, void* edx, UFunctio
 		//      what makes a spectator invisible, uncollidable, and
 		//      unshootable, with no separate hide/no-collide/invulnerability
 		//      hack needed.
+		const bool blackScreenEnabled = BlackScreenDiagnostics::IsEnabled();
+		ATgPlayerController* diagnosticPlayer = nullptr;
+		if (blackScreenEnabled && Params) {
+			APlayerController* newPlayer = *(APlayerController**)Params;
+			if (newPlayer && ObjectClassCache::ClassNameContains(newPlayer, "TgPlayerController")) {
+				diagnosticPlayer = (ATgPlayerController*)newPlayer;
+			}
+		}
+		if (blackScreenEnabled) {
+			BlackScreenDiagnostics::Log("before", "Function TgGame.TgGame.PostLogin",
+				nullptr, diagnosticPlayer);
+		}
+
 		if (Params) {
 			APlayerController* NewPlayer = *(APlayerController**)Params;
 			// Deliberately NOT requiring NewPlayer->Player here anymore (dropped
@@ -1141,53 +1214,63 @@ void __fastcall UObject__ProcessEvent::Call(UObject* Object, void* edx, UFunctio
 			}
 		}
 		CallOriginal(Object, edx, Function, Params, Result);
+		if (blackScreenEnabled) {
+			BlackScreenDiagnostics::Log("after", "Function TgGame.TgGame.PostLogin",
+				nullptr, diagnosticPlayer);
+		}
 		break;
 	}
 
 	case DispatchTag::SpectateVisualState: {
-		if (Logger::IsChannelEnabled("spawn")) {
-			std::string fnName = Function->GetFullName();
-			std::string objName = Object->GetFullName();
-			ATgPlayerController* pc = (ATgPlayerController*)Object;
-			APlayerReplicationInfo* pri = pc ? pc->PlayerReplicationInfo : nullptr;
-			AActor* paramActor = nullptr;
-			if (Params &&
-			    (fnName == "Function TgGame.TgPlayerController.ServerSetViewTarget" ||
-			     fnName == "Function Engine.PlayerController.ClientSetViewTarget")) {
-				paramActor = *(AActor**)Params;
-			}
+		const bool blackScreenEnabled = BlackScreenDiagnostics::IsEnabled();
+		const bool spawnEnabled = Logger::IsChannelEnabled("spawn");
+		if ((!blackScreenEnabled && !spawnEnabled) ||
+		    !ObjectClassCache::ClassNameContains(Object, "TgPlayerController")) {
+			CallOriginal(Object, edx, Function, Params, Result);
+			break;
+		}
 
-			int fadeEnable = -1;
-			float fadeAlphaX = 0.0f;
-			float fadeAlphaY = 0.0f;
-			float fadeTime = 0.0f;
-			if (Params && fnName == "Function TgGame.TgPlayerController.ClientSetCameraFade") {
-				fadeEnable = (int)(*(uint32_t*)((char*)Params + 0x00) & 1);
-				fadeAlphaX = *(float*)((char*)Params + 0x08);
-				fadeAlphaY = *(float*)((char*)Params + 0x0C);
-				fadeTime = *(float*)((char*)Params + 0x10);
-			}
+		const std::string fnName = Function->GetFullName();
+		ATgPlayerController* pc = (ATgPlayerController*)Object;
+		BlackScreenDiagnostics::EventDetails details;
+		if (Params &&
+		    (fnName == "Function TgGame.TgPlayerController.ServerSetViewTarget" ||
+		     fnName == "Function Engine.PlayerController.ClientSetViewTarget")) {
+			details.relatedActor = *(AActor**)Params;
+		}
+		if (Params && fnName == "Function TgGame.TgPlayerController.ClientSetCameraFade") {
+			details.fadeEnabled = (int)(*(uint32_t*)((char*)Params + 0x00) & 1);
+			details.fadeAlphaFrom = *(float*)((char*)Params + 0x08);
+			details.fadeAlphaTo = *(float*)((char*)Params + 0x0C);
+			details.fadeTime = *(float*)((char*)Params + 0x10);
+		}
+		if (Params && fnName == "Function TgGame.TgPlayerController.ClientSetCinematicMode") {
+			details.cinematic = (int)(*(uint32_t*)((char*)Params + 0x00) & 1);
+			details.affectsHud = (int)(*(uint32_t*)((char*)Params + 0x0C) & 1);
+		}
 
-			int cinematic = -1;
-			int affectsHud = -1;
-			if (Params && fnName == "Function TgGame.TgPlayerController.ClientSetCinematicMode") {
-				cinematic = (int)(*(uint32_t*)((char*)Params + 0x00) & 1);
-				affectsHud = (int)(*(uint32_t*)((char*)Params + 0x0C) & 1);
-			}
-
+		if (spawnEnabled) {
+			const std::string objName = Object->GetFullName();
+			APlayerReplicationInfo* pri = pc->PlayerReplicationInfo;
 			Logger::Log("spawn",
 				"SpectateVisualState: fn=%s obj=%s pawn=%p viewTarget=%p paramActor=%p "
 				"onlySpec=%d isSpec=%d outOfLives=%d fade=%d alpha=(%.2f,%.2f) fadeTime=%.2f "
 				"cinematic=%d affectsHud=%d\n",
-				fnName.c_str(), objName.c_str(),
-				pc ? pc->Pawn : nullptr, pc ? pc->ViewTarget : nullptr, paramActor,
+				fnName.c_str(), objName.c_str(), pc->Pawn, pc->ViewTarget, details.relatedActor,
 				pri ? (int)pri->bOnlySpectator : -1,
 				pri ? (int)pri->bIsSpectator : -1,
 				pri ? (int)pri->bOutOfLives : -1,
-				fadeEnable, fadeAlphaX, fadeAlphaY, fadeTime,
-				cinematic, affectsHud);
+				details.fadeEnabled, details.fadeAlphaFrom, details.fadeAlphaTo, details.fadeTime,
+				details.cinematic, details.affectsHud);
+		}
+
+		if (blackScreenEnabled) {
+			BlackScreenDiagnostics::Log("before", fnName.c_str(), nullptr, pc, details);
 		}
 		CallOriginal(Object, edx, Function, Params, Result);
+		if (blackScreenEnabled) {
+			BlackScreenDiagnostics::Log("after", fnName.c_str(), nullptr, pc, details);
+		}
 		break;
 	}
 
@@ -2453,6 +2536,15 @@ void __fastcall UObject__ProcessEvent::Call(UObject* Object, void* edx, UFunctio
 	default:
 		DoCatchAll();
 		break;
+	}
+
+	if (blackScreenLifecycle) {
+		BlackScreenLifecycleContext& context = *blackScreenLifecycle;
+		if (Params && context.functionName == "Function TgGame.TgPlayerController.IsReadyForStart") {
+			context.details.eventValue = (int)(*(uint32_t*)Params & 1);
+		}
+		BlackScreenDiagnostics::Log("after", context.functionName.c_str(),
+			nullptr, context.player, context.details);
 	}
 
 	if (scopeLog) LogScopeCall("AFTER ", Object, Function);

--- a/src/GameServer/Diagnostics/BlackScreenDiagnostics.hpp
+++ b/src/GameServer/Diagnostics/BlackScreenDiagnostics.hpp
@@ -1,0 +1,153 @@
+#pragma once
+
+#include "src/Config/Config.hpp"
+#include "src/GameServer/Storage/ClientConnectionsData/ClientConnectionsData.hpp"
+#include "src/Utils/Logger/Logger.hpp"
+#include "src/pch.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace BlackScreenDiagnostics {
+
+// InstanceSpawner already scopes Logger::LogDir by instance ID. A dedicated
+// subfolder plus one fixed-schema file per connection keeps each mission and
+// each player's join lifecycle directly comparable without cross-instance mix.
+
+struct EventDetails {
+	AActor* relatedActor = nullptr;
+	int eventValue = -1;
+	int fadeEnabled = -1;
+	float fadeAlphaFrom = 0.0f;
+	float fadeAlphaTo = 0.0f;
+	float fadeTime = 0.0f;
+	int cinematic = -1;
+	int affectsHud = -1;
+};
+
+inline bool IsEnabled() {
+	static const bool enabled = []() {
+		const std::vector<std::string> channels = Config::GetEnabledChannels();
+		return std::find(channels.begin(), channels.end(), "blackscreen") != channels.end();
+	}();
+	return enabled;
+}
+
+inline void Log(const char* phase,
+	            const char* event,
+	            UNetConnection* connection,
+	            ATgPlayerController* controller,
+	            const EventDetails& details = {}) {
+	if (!IsEnabled()) return;
+
+	if (!connection && controller && controller->Player) {
+		connection = (UNetConnection*)controller->Player;
+	}
+
+	static unsigned long long sequence = 0;
+	static std::mutex fileMutex;
+	std::lock_guard<std::mutex> lock(fileMutex);
+
+	const unsigned long long eventSequence = ++sequence;
+	const unsigned long long tickMs = (unsigned long long)GetTickCount64();
+
+	const int32_t connectionKey = (int32_t)connection;
+	const ClientConnectionData* connectionData = nullptr;
+	const PlayerInfo* playerInfo = nullptr;
+	auto connectionIt = GClientConnectionsData.find(connectionKey);
+	if (connectionIt != GClientConnectionsData.end()) {
+		connectionData = &connectionIt->second;
+		playerInfo = &connectionData->PlayerInfo;
+	}
+
+	const long long characterId = playerInfo ? (long long)playerInfo->selected_character_id : 0;
+	const unsigned long long registerGeneration =
+		(connectionData && connectionData->pPlayerInfo)
+			? (unsigned long long)connectionData->pPlayerInfo->register_generation
+			: (playerInfo ? (unsigned long long)playerInfo->register_generation : 0);
+	std::string playerName = playerInfo ? playerInfo->player_name : "";
+	for (char& ch : playerName) {
+		if (ch == '\t' || ch == '\r' || ch == '\n') ch = ' ';
+	}
+	if (!playerName.empty() &&
+	    (playerName[0] == '=' || playerName[0] == '+' ||
+	     playerName[0] == '-' || playerName[0] == '@')) {
+		playerName.insert(playerName.begin(), '\'');
+	}
+
+	std::string stateName;
+	if (controller) {
+		stateName = controller->GetStateName().GetName();
+	}
+
+	APlayerReplicationInfo* pri = controller ? controller->PlayerReplicationInfo : nullptr;
+
+	const std::string directory = Logger::LogDir + "\\blackscreen";
+	if (!CreateDirectoryA(directory.c_str(), nullptr) && GetLastError() != ERROR_ALREADY_EXISTS) {
+		return;
+	}
+
+	char filename[256];
+	if (connection) {
+		snprintf(filename, sizeof(filename), "connection-%08X-generation-%llu.tsv",
+			(unsigned int)(uintptr_t)connection, registerGeneration);
+	} else {
+		snprintf(filename, sizeof(filename), "unattributed.tsv");
+	}
+
+	char path[768];
+	snprintf(path, sizeof(path), "%s\\%s", directory.c_str(), filename);
+	FILE* fp = fopen(path, "a+");
+	if (!fp) return;
+
+	fseek(fp, 0, SEEK_END);
+	if (ftell(fp) == 0) {
+		fprintf(fp, "# schema=1\tinstance_id=%lld\tmap=%s\tmap_params=%s\n",
+			(long long)Config::GetInstanceId(), Config::GetMapNameChar().c_str(),
+			Config::GetMapParamsChar().c_str());
+		fprintf(fp,
+			"sequence\ttick_ms\tphase\tevent\tcharacter_id\tregister_generation\tplayer_name\t"
+			"connection\tcontroller\tstate\tpawn\tacknowledged_pawn\tview_target\trelated_actor\t"
+			"controller_ready\tpri_ready\twaiting_player\tonly_spectator\tis_spectator\tout_of_lives\t"
+			"event_value\tfade_enabled\tfade_alpha_from\tfade_alpha_to\tfade_time\tcinematic\taffects_hud\n");
+	}
+
+	fprintf(fp,
+		"%llu\t%llu\t%s\t%s\t%lld\t%llu\t%s\t%p\t%p\t%s\t%p\t%p\t%p\t%p\t"
+		"%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%.3f\t%.3f\t%.3f\t%d\t%d\n",
+		eventSequence,
+		tickMs,
+		phase ? phase : "",
+		event ? event : "",
+		characterId,
+		registerGeneration,
+		playerName.c_str(),
+		(void*)connection,
+		(void*)controller,
+		stateName.c_str(),
+		controller ? (void*)controller->Pawn : nullptr,
+		controller ? (void*)controller->AcknowledgedPawn : nullptr,
+		controller ? (void*)controller->ViewTarget : nullptr,
+		(void*)details.relatedActor,
+		controller ? (int)controller->c_bReadyToPlay : -1,
+		pri ? (int)pri->bReadyToPlay : -1,
+		pri ? (int)pri->bWaitingPlayer : -1,
+		pri ? (int)pri->bOnlySpectator : -1,
+		pri ? (int)pri->bIsSpectator : -1,
+		pri ? (int)pri->bOutOfLives : -1,
+		details.eventValue,
+		details.fadeEnabled,
+		details.fadeAlphaFrom,
+		details.fadeAlphaTo,
+		details.fadeTime,
+		details.cinematic,
+		details.affectsHud);
+
+	fclose(fp);
+}
+
+} // namespace BlackScreenDiagnostics

--- a/src/GameServer/TgNetDrv/MarshalChannel/NotifyControlMessage/MarshalChannel__NotifyControlMessage.cpp
+++ b/src/GameServer/TgNetDrv/MarshalChannel/NotifyControlMessage/MarshalChannel__NotifyControlMessage.cpp
@@ -30,6 +30,7 @@
 #include "src/GameServer/Engine/World/GetGameInfo/World__GetGameInfo.hpp"
 #include "src/GameServer/Storage/TeamsData/TeamsData.hpp"
 #include "src/GameServer/Storage/ClientConnectionsData/ClientConnectionsData.hpp"
+#include "src/GameServer/Diagnostics/BlackScreenDiagnostics.hpp"
 #include "src/GameServer/Constants/GameTypes.h"
 #include "src/GameServer/Constants/TcpTypes.h"
 #include "src/GameServer/Constants/TcpFunctions.h"
@@ -266,8 +267,10 @@ void MarshalChannel__NotifyControlMessage::Call(UMarshalChannel* MarshalChannel,
 		FURL requesturl;
 		FURL__Constructor::CallOriginal(&requesturl, nullptr, nullptr, params2.data(), 0);
 
+		BlackScreenDiagnostics::Log("before", "SpawnPlayActor", Connection, nullptr);
 		ATgPlayerController* newcontrollerptr = World__SpawnPlayActor::CallOriginal((UWorld*)Globals::Get().GWorld, nullptr, connplayer, 2, &requesturl, &error, 0);
 		connplayer->Actor = newcontrollerptr;
+		BlackScreenDiagnostics::Log("after", "SpawnPlayActor", Connection, newcontrollerptr);
 
 		// Zero out FURL and error FStrings so their destructors don't delete[]
 		// memory that UE3 allocated with appMalloc.
@@ -392,7 +395,9 @@ void MarshalChannel__NotifyControlMessage::HandlePlayerConnected(UNetConnection*
 	// game->eventPostLogin(newcontroller);  // removed: now runs inside SpawnPlayActor naturally
 
 	Logger::Log("aim-trace", "RESETFORCEVIEWTARGET pawn = 0x%p\n", newcontroller->Pawn);
+	BlackScreenDiagnostics::Log("before", "ResetForceViewTarget", Connection, newcontroller);
 	newcontroller->ResetForceViewTarget();
+	BlackScreenDiagnostics::Log("after", "ResetForceViewTarget", Connection, newcontroller);
 	Logger::Log("aim-trace", "NEW VIEWTARGET = 0x%p\n", newcontroller->ViewTarget);
 
 	// Clear stale SpectatingMatch/cinematic visual state after real TgHUD_Game


### PR DESCRIPTION
## Summary

- add a gated `blackscreen` server diagnostic under each instance-specific log directory
- write one fixed-schema TSV per connection so normal and affected player join lifecycles can be compared directly
- observe SpawnPlayActor, PostLogin, RestartPlayer, readiness/start-state, ClientRestart, view-target, fade, cinematic, and spectate transitions
- make no join, readiness, spawn, camera, replication, or retry behavior changes

## Output

Add `blackscreen` to `enabled_channels`. Each mission instance writes:

`<log_dir>\<instance_id>\blackscreen\connection-<ptr>-generation-<n>.tsv`

Rows include sequence/tick, before/after phase, event, character/player identity, controller state, pawn/acknowledged pawn/view target, readiness, spectator/waiting flags, and event-specific ready/fade/cinematic values. Session GUIDs and control registration tokens are not recorded.

## Verification

- `git diff --cached --check`
- verified the observed lifecycle UFunction names against the live SDK wrappers
- reviewed the staged set as exactly three diagnostic files
