### PR TITLE
Stats: heals on enemy targets are not healing — gate scoreboard + dev…

### DIFF
--- a/src/GameServer/TgGame/TgEffect/TrackStats/TgEffect__TrackStats.cpp
+++ b/src/GameServer/TgGame/TgEffect/TrackStats/TgEffect__TrackStats.cpp
@@ -692,7 +692,17 @@ void __fastcall TgEffect__TrackStats::Call(UTgEffect* /*Effect*/, void* /*edx*/,
 		// the top) and own pets/deployables (per user spec: repairing your
 		// own gear doesn't count). TrackHealing for player heal targets,
 		// TrackBotHealing for everything else.
-		if (!targetIsOwnedByInstigator) {
+		//
+		// Enemy targets skipped entirely — scoreboard AND device columns.
+		// Backstab heal riders (flat 50–80 HP skill effects, situational
+		// 509) apply WITH THE ENEMY AS TARGET, so without this gate every
+		// backstab against a full-HP victim booked the rider as healing/
+		// overheal (live: 24k "overheal" on a recon's Dual Daggers, plus
+		// STYPE_HEALING credit via TrackBotHealing on enemy bots). Healing
+		// an enemy is never healing performance. m_LastHealer above is
+		// deliberately left as shipped — changing who earns heal assists
+		// is a gameplay decision, not a stats fix.
+		if (!targetIsOwnedByInstigator && !bIsEnemy) {
 			if (targetIsPawn) {
 				const bool victimIsBot = !IsRealPlayer(targetPawn->Controller);
 				if (victimIsBot) {


### PR DESCRIPTION
## The bug

The game ships a family of backstab heal riders — flat 50–80 HP skill
effects, situational type 509 — that apply **with the enemy as the effect
target**. The heal-credit path in `TrackStats` had no enemy check, so every
melee backstab against a healthy victim booked the rider as healing output
on three surfaces: the scoreboard (STYPE_HEALING via `TrackBotHealing` on
enemy bots), the client Device Stats tab, and the server-side
`ga_match_device_stats` healing/overheal columns from #68.

Live merc data made it obvious: a recon's **Dual Daggers showing 24,048
"overheal"** from two melee holds (≈300 backstab procs against full-HP
targets), plus smaller traces on lifedrain SMGs.

## The fix

One condition on the existing heal-credit block: the target must be
friendly (`!bIsEnemy`). All legitimate healing — waves, Triage, Savior
buffs, boosts, repair arms, medical stations — targets friendlies and is
unaffected; the existing self-heal and own-gear exclusions are unchanged.

Deliberately **not** changed: `m_LastHealer` is still set unconditionally,
meaning an enemy backstabber can currently become a victim's "last healer"
(and plausibly earn a heal assist on their death). That's a gameplay-facing
decision rather than a stats fix, so it's documented in the comment and
left as shipped.

## Notes

- Historical rows recorded before this fix keep their values; the
  `damage = 0` filter used in medic-facing queries already sidesteps them.
- Recording-only change — no gameplay behavior affected.